### PR TITLE
add ability to replace existing step from catalog

### DIFF
--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -8,6 +8,7 @@ import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core
 import './Visualization.css';
 import Konva from 'konva';
 import { v4 as uuidv4 } from 'uuid';
+import { VisualizationSlot } from './VisualizationSlot';
 import { VisualizationStep } from './VisualizationStep';
 
 interface IVisualization {
@@ -251,6 +252,10 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
                             text={truncateString(item.model.name, 14)}
                             {...textProps}
                           />
+                          {/** Validation goes here **/}
+                          <Group name={'slot-group-for-' + index}>
+                            <VisualizationSlot idx={index} step={item} />
+                          </Group>
                         </Group>
                       );
                     })}

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -131,28 +131,27 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
                 // Register event position
                 stageRef.current?.setPointersPositions(e);
                 const parsed: IStepProps = JSON.parse(dataJSON);
-
                 const currentPosition = stageRef.current?.getPointerPosition(); // e.g. {"x":158,"y":142}
-                console.log('currentPosition: ' + JSON.stringify(currentPosition));
-                const shapeIntersects = stageRef.current?.getIntersection(currentPosition!);
+                const intersectingShape = stageRef.current?.getIntersection(currentPosition!);
 
-                if (shapeIntersects) {
-                  console.log('intersects');
+                // Only create as a temporary step if it does not intersect with an existing step
+                if (intersectingShape) {
+                  console.log('Intersects');
                 } else {
-                  console.log('does not intersect');
-                }
+                  console.log('Does not intersect, creating temporary step..');
 
-                setTempSteps(
-                  tempSteps.concat({
-                    model: parsed,
-                    viz: {
-                      id: uuidv4(),
-                      label: parsed.name,
-                      position: { ...stageRef.current?.getPointerPosition()! },
-                      temporary: true,
-                    },
-                  })
-                );
+                  setTempSteps(
+                    tempSteps.concat({
+                      model: parsed,
+                      viz: {
+                        id: uuidv4(),
+                        label: parsed.name,
+                        position: { ...stageRef.current?.getPointerPosition()! },
+                        temporary: true,
+                      },
+                    })
+                  );
+                }
               }}
               onDragOver={(e) => {
                 e.preventDefault();
@@ -193,7 +192,7 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
 
                   <Group
                     name={'integration-and-slots'}
-                    x={window.innerWidth / 4}
+                    x={window.innerWidth / 5}
                     y={window.innerHeight / 2}
                   >
                     {/** Create the visualization slots **/}

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Circle, Group, Image, Layer, Line, Stage, Text } from 'react-konva';
+import { Circle, Group, Image, Layer, Stage, Text } from 'react-konva';
 import { IStepProps, IViewProps, IVizStepProps } from '../types';
 import createImage from '../utils/createImage';
 import truncateString from '../utils/truncateName';
@@ -43,7 +43,6 @@ const placeholderStep = {
 };
 
 const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) => {
-  const incrementAmt = 100;
   const stageRef = useRef<Konva.Stage>(null);
   const [isPanelExpanded, setIsPanelExpanded] = useState(false);
   const [selectedStep, setSelectedStep] =
@@ -65,10 +64,6 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
     selectedStep.viz.temporary
       ? setTempSteps(tempSteps.filter((tempStep) => tempStep.viz.id !== selectedStepVizId))
       : deleteIntegrationStep(stepsIndex);
-  };
-
-  const onDragEndIntegration = () => {
-    //
   };
 
   const onDragEndTempStep = (e: any) => {
@@ -151,6 +146,7 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
             >
               <Stage width={window.innerWidth} height={window.innerHeight} ref={stageRef}>
                 <Layer>
+                  {/** Create the temporary steps **/}
                   {tempSteps.map((step, idx) => {
                     const groupProps = {
                       x: step.viz.position.x,
@@ -180,86 +176,73 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
                       />
                     );
                   })}
-                  <Group
-                    x={250}
-                    y={300}
-                    id={'Integration'}
-                    onDragEnd={onDragEndIntegration}
-                    draggable
-                  >
-                    <Line
-                      points={[100, 0, steps.length * incrementAmt, 0]}
-                      stroke={'black'}
-                      strokeWidth={3}
-                      lineCap={'round'}
-                      lineJoin={'round'}
-                    />
-                    {steps.map((item, index) => {
-                      const imageProps = {
-                        id: item.viz.id,
-                        image: createImage(item.model.icon, null),
-                        x: item.viz.position.x! - imageDimensions.width / 2,
-                        y: 0 - imageDimensions.height / 2,
-                        height: imageDimensions.height,
-                        width: imageDimensions.width,
-                      };
 
-                      const circleProps = {
-                        x: item.viz.position.x,
-                        y: 0,
-                      };
+                  {/** Create the visualization slots **/}
+                  <VisualizationSlot steps={steps} />
 
-                      const textProps = {
-                        x: item.viz.position.x! - CIRCLE_LENGTH,
-                        y: CIRCLE_LENGTH / 2 + 10,
-                      };
+                  {/** Create the visualization steps **/}
+                  {steps.map((item, index) => {
+                    const imageProps = {
+                      id: item.viz.id,
+                      image: createImage(item.model.icon, null),
+                      x: item.viz.position.x! - imageDimensions.width / 2,
+                      y: 0 - imageDimensions.height / 2,
+                      height: imageDimensions.height,
+                      width: imageDimensions.width,
+                    };
 
-                      return (
-                        <Group
-                          key={index}
-                          onClick={handleClickStep}
-                          onMouseEnter={(e: any) => {
-                            // style stage container:
-                            const container = e.target.getStage().container();
-                            container.style.cursor = 'pointer';
-                          }}
-                          onMouseLeave={(e: any) => {
-                            const container = e.target.getStage().container();
-                            container.style.cursor = 'default';
-                          }}
-                        >
-                          <Circle
-                            {...circleProps}
-                            name={`${index}`}
-                            stroke={
-                              item.model.type === 'START'
-                                ? 'rgb(0, 136, 206)'
-                                : item.model.type === 'END'
-                                ? 'rgb(149, 213, 245)'
-                                : 'rgb(204, 204, 204)'
-                            }
-                            fill={'white'}
-                            strokeWidth={3}
-                            width={CIRCLE_LENGTH}
-                            height={CIRCLE_LENGTH}
-                          />
-                          <Image {...imageProps} />
-                          <Text
-                            align={'center'}
-                            width={150}
-                            fontFamily={'Ubuntu'}
-                            fontSize={11}
-                            text={truncateString(item.model.name, 14)}
-                            {...textProps}
-                          />
-                          {/** Validation goes here **/}
-                          <Group name={'slot-group-for-' + index}>
-                            <VisualizationSlot idx={index} step={item} />
-                          </Group>
-                        </Group>
-                      );
-                    })}
-                  </Group>
+                    const circleProps = {
+                      x: item.viz.position.x,
+                      y: 0,
+                    };
+
+                    const textProps = {
+                      x: item.viz.position.x! - CIRCLE_LENGTH,
+                      y: CIRCLE_LENGTH / 2 + 10,
+                    };
+
+                    return (
+                      <Group
+                        key={index}
+                        onClick={handleClickStep}
+                        onMouseEnter={(e: any) => {
+                          // style stage container:
+                          const container = e.target.getStage().container();
+                          container.style.cursor = 'pointer';
+                        }}
+                        onMouseLeave={(e: any) => {
+                          const container = e.target.getStage().container();
+                          container.style.cursor = 'default';
+                        }}
+                        id={'visualization-step-' + index}
+                      >
+                        <Circle
+                          {...circleProps}
+                          name={`${index}`}
+                          stroke={
+                            item.model.type === 'START'
+                              ? 'rgb(0, 136, 206)'
+                              : item.model.type === 'END'
+                              ? 'rgb(149, 213, 245)'
+                              : 'rgb(204, 204, 204)'
+                          }
+                          fill={'white'}
+                          strokeWidth={3}
+                          width={CIRCLE_LENGTH}
+                          height={CIRCLE_LENGTH}
+                        />
+                        <Image {...imageProps} />
+                        <Text
+                          align={'center'}
+                          width={150}
+                          fontFamily={'Ubuntu'}
+                          fontSize={11}
+                          text={truncateString(item.model.name, 14)}
+                          {...textProps}
+                        />
+                      </Group>
+                    );
+                  })}
                 </Layer>
               </Stage>
             </div>

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -15,6 +15,7 @@ interface IVisualization {
   deleteIntegrationStep: (e: any) => void;
   isError?: boolean;
   isLoading?: boolean;
+  replaceIntegrationStep: (newStep: any, oldStepIndex: any) => void;
   steps: { viz: IVizStepProps; model: IStepProps }[];
   views: IViewProps[];
 }
@@ -42,7 +43,12 @@ const placeholderStep = {
   views: [{}],
 };
 
-const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) => {
+const Visualization = ({
+  deleteIntegrationStep,
+  replaceIntegrationStep,
+  steps,
+  views,
+}: IVisualization) => {
   const layerRef = useRef<Konva.Layer>(null);
   const stageRef = useRef<Konva.Stage>(null);
   const [isPanelExpanded, setIsPanelExpanded] = useState(false);
@@ -134,12 +140,12 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
                 const currentPosition = stageRef.current?.getPointerPosition(); // e.g. {"x":158,"y":142}
                 const intersectingShape = stageRef.current?.getIntersection(currentPosition!);
 
-                // Only create as a temporary step if it does not intersect with an existing step
+                // Only create a temporary step if it does not intersect with an existing step
                 if (intersectingShape) {
-                  console.log('Intersects');
+                  const parentVizId = intersectingShape.getParent().attrs.id;
+                  const parentIdx = steps.map((step) => step.viz.id).indexOf(parentVizId);
+                  replaceIntegrationStep(parsed, parentIdx);
                 } else {
-                  console.log('Does not intersect, creating temporary step..');
-
                   setTempSteps(
                     tempSteps.concat({
                       model: parsed,
@@ -231,7 +237,7 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
                             const container = e.target.getStage().container();
                             container.style.cursor = 'default';
                           }}
-                          id={'visualization-step-' + index}
+                          id={item.viz.id}
                         >
                           <Circle
                             {...circleProps}

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -191,7 +191,11 @@ const Visualization = ({ deleteIntegrationStep, steps, views }: IVisualization) 
                     );
                   })}
 
-                  <Group name={'integration-and-slots'} x={100} y={window.innerHeight / 2}>
+                  <Group
+                    name={'integration-and-slots'}
+                    x={window.innerWidth / 4}
+                    y={window.innerHeight / 2}
+                  >
                     {/** Create the visualization slots **/}
                     <VisualizationSlot steps={steps} />
 

--- a/src/components/VisualizationSlot.test.tsx
+++ b/src/components/VisualizationSlot.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import { screen } from '@testing-library/dom';
+import { VisualizationSlot } from './VisualizationSlot';
+import { IStepProps, IVizStepProps } from '../types';
+
+describe.skip('VisualizationSlot.tsx', () => {
+  test('component renders correctly', () => {
+    const fakeStep: { viz: IVizStepProps; model: IStepProps } = {
+      model: {
+        apiVersion: '',
+        id: '',
+        icon: '',
+        name: '',
+        type: 'START',
+      },
+      viz: {
+        id: '',
+        label: '',
+        position: {
+          x: 0,
+          y: 0,
+        },
+        temporary: false,
+      },
+    };
+
+    render(<VisualizationSlot idx={0} step={fakeStep} />);
+    const element = screen.getByTestId('visualization-slot');
+    expect(element).toBeInTheDocument();
+  });
+});

--- a/src/components/VisualizationSlot.test.tsx
+++ b/src/components/VisualizationSlot.test.tsx
@@ -5,7 +5,8 @@ import { IStepProps, IVizStepProps } from '../types';
 
 describe.skip('VisualizationSlot.tsx', () => {
   test('component renders correctly', () => {
-    const fakeStep: { viz: IVizStepProps; model: IStepProps } = {
+    const fakeSteps: { viz: IVizStepProps; model: IStepProps }[] = [];
+    const fakeStep = {
       model: {
         apiVersion: '',
         id: '',
@@ -24,7 +25,9 @@ describe.skip('VisualizationSlot.tsx', () => {
       },
     };
 
-    render(<VisualizationSlot idx={0} step={fakeStep} />);
+    fakeSteps.push(fakeStep);
+
+    render(<VisualizationSlot steps={fakeSteps} />);
     const element = screen.getByTestId('visualization-slot');
     expect(element).toBeInTheDocument();
   });

--- a/src/components/VisualizationSlot.tsx
+++ b/src/components/VisualizationSlot.tsx
@@ -2,59 +2,62 @@ import { Circle, Group, Line } from 'react-konva';
 import { IStepProps, IVizStepProps } from '../types';
 
 export interface IVisualizationSlot {
-  circleProps?: any;
-  groupProps?: any;
-  idx: number;
-  onDragEndTempStep?: (e: any) => void;
-  step: { viz: IVizStepProps; model: IStepProps };
+  children?: any;
+  steps: { viz: IVizStepProps; model: IStepProps }[];
 }
 
 const CIRCLE_LENGTH = 75;
 
-const VisualizationSlot = ({
-  circleProps,
-  groupProps,
-  idx,
-  onDragEndTempStep,
-  step,
-}: IVisualizationSlot) => {
+const VisualizationSlot = ({ children, steps }: IVisualizationSlot) => {
+  const incrementAmt = 100;
+
   return (
-    <Group
-      onDragEnd={onDragEndTempStep}
-      data-testid={'visualization-slot-' + idx}
-      id={step.viz.id}
-      index={idx}
-      key={idx}
-      onMouseEnter={() => {
-        console.log('incoming hover!');
-      }}
-      onMouseLeave={() => {
-        console.log('outgoing hover!');
-      }}
-      {...groupProps}
-    >
+    <Group x={250} y={300} id={'slots'}>
       <Line
-        //points={[100, 0, steps.length * incrementAmt, 0]}
+        points={[100, 0, steps.length * incrementAmt, 0]}
         stroke={'black'}
         strokeWidth={3}
         lineCap={'round'}
         lineJoin={'round'}
       />
-      <Circle
-        name={`${idx}`}
-        stroke={
-          step.model.type === 'START'
-            ? 'rgb(0, 136, 206)'
-            : step.model.type === 'END'
-            ? 'rgb(149, 213, 245)'
-            : 'rgb(204, 204, 204)'
-        }
-        fill={'white'}
-        strokeWidth={3}
-        width={CIRCLE_LENGTH}
-        height={CIRCLE_LENGTH}
-        {...circleProps}
-      />
+      {steps.map((step, index) => {
+        const circleProps = {
+          x: step.viz.position.x,
+          y: 0,
+        };
+
+        return (
+          <Group
+            data-testid={'visualization-slot-' + index}
+            id={'visualization-slot-' + step.viz.id}
+            index={index}
+            key={index}
+            onMouseEnter={() => {
+              console.log('incoming hover!');
+            }}
+            onMouseLeave={() => {
+              console.log('outgoing hover!');
+            }}
+          >
+            <Circle
+              name={`${index}`}
+              stroke={
+                step.model.type === 'START'
+                  ? 'rgb(0, 136, 206)'
+                  : step.model.type === 'END'
+                  ? 'rgb(149, 213, 245)'
+                  : 'rgb(204, 204, 204)'
+              }
+              fill={'white'}
+              strokeWidth={3}
+              width={CIRCLE_LENGTH}
+              height={CIRCLE_LENGTH}
+              {...circleProps}
+            />
+          </Group>
+        );
+      })}
+      {children}
     </Group>
   );
 };

--- a/src/components/VisualizationSlot.tsx
+++ b/src/components/VisualizationSlot.tsx
@@ -1,4 +1,4 @@
-import { Circle, Group } from 'react-konva';
+import { Circle, Group, Line } from 'react-konva';
 import { IStepProps, IVizStepProps } from '../types';
 
 export interface IVisualizationSlot {
@@ -33,6 +33,13 @@ const VisualizationSlot = ({
       }}
       {...groupProps}
     >
+      <Line
+        //points={[100, 0, steps.length * incrementAmt, 0]}
+        stroke={'black'}
+        strokeWidth={3}
+        lineCap={'round'}
+        lineJoin={'round'}
+      />
       <Circle
         name={`${idx}`}
         stroke={

--- a/src/components/VisualizationSlot.tsx
+++ b/src/components/VisualizationSlot.tsx
@@ -12,9 +12,14 @@ const VisualizationSlot = ({ children, steps }: IVisualizationSlot) => {
   const incrementAmt = 100;
 
   return (
-    <Group x={250} y={300} id={'slots'}>
+    <Group name={'slots'} id={'slots'}>
       <Line
-        points={[100, 0, steps.length * incrementAmt, 0]}
+        points={[
+          0, // x1
+          0, // y1
+          steps.length * incrementAmt - 100, // x2 (subtract 100 for first step)
+          0, // y2
+        ]}
         stroke={'black'}
         strokeWidth={3}
         lineCap={'round'}
@@ -32,11 +37,8 @@ const VisualizationSlot = ({ children, steps }: IVisualizationSlot) => {
             id={'visualization-slot-' + step.viz.id}
             index={index}
             key={index}
-            onMouseEnter={() => {
-              console.log('incoming hover!');
-            }}
-            onMouseLeave={() => {
-              console.log('outgoing hover!');
+            onDragOver={() => {
+              console.log('drag over slot');
             }}
           >
             <Circle

--- a/src/components/VisualizationSlot.tsx
+++ b/src/components/VisualizationSlot.tsx
@@ -1,0 +1,55 @@
+import { Circle, Group } from 'react-konva';
+import { IStepProps, IVizStepProps } from '../types';
+
+export interface IVisualizationSlot {
+  circleProps?: any;
+  groupProps?: any;
+  idx: number;
+  onDragEndTempStep?: (e: any) => void;
+  step: { viz: IVizStepProps; model: IStepProps };
+}
+
+const CIRCLE_LENGTH = 75;
+
+const VisualizationSlot = ({
+  circleProps,
+  groupProps,
+  idx,
+  onDragEndTempStep,
+  step,
+}: IVisualizationSlot) => {
+  return (
+    <Group
+      onDragEnd={onDragEndTempStep}
+      data-testid={'visualization-slot-' + idx}
+      id={step.viz.id}
+      index={idx}
+      key={idx}
+      onMouseEnter={() => {
+        console.log('incoming hover!');
+      }}
+      onMouseLeave={() => {
+        console.log('outgoing hover!');
+      }}
+      {...groupProps}
+    >
+      <Circle
+        name={`${idx}`}
+        stroke={
+          step.model.type === 'START'
+            ? 'rgb(0, 136, 206)'
+            : step.model.type === 'END'
+            ? 'rgb(149, 213, 245)'
+            : 'rgb(204, 204, 204)'
+        }
+        fill={'white'}
+        strokeWidth={3}
+        width={CIRCLE_LENGTH}
+        height={CIRCLE_LENGTH}
+        {...circleProps}
+      />
+    </Group>
+  );
+};
+
+export { VisualizationSlot };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -107,35 +107,44 @@ const Dashboard = () => {
     });
   }, [previousYaml, yamlData]);
 
+  const updateIntegration = async (newSteps: any) => {
+    setIsError(false);
+    setIsLoading(true);
+
+    try {
+      const resp = await request.post({
+        endpoint: '/deployment/yaml',
+        contentType: 'application/json',
+        body: { name: 'Updated integration', steps: newSteps },
+      });
+
+      const data = await resp.text();
+      console.log(JSON.stringify(data));
+      setYamlData(data);
+      console.log('Data set');
+    } catch (err) {
+      console.error(err);
+      setIsError(true);
+    }
+
+    setIsLoading(false);
+  };
+
   const deleteIntegrationStep = (stepsIndex: any) => {
     // Remove Step from viewData.steps
     // @ts-ignore
     const newSteps = viewData.steps.filter((step, idx) => idx !== stepsIndex);
 
-    const getVizData = async () => {
-      setIsError(false);
-      setIsLoading(true);
+    updateIntegration(newSteps).catch((e) => {
+      console.error(e);
+    });
+  };
 
-      try {
-        const resp = await request.post({
-          endpoint: '/deployment/yaml',
-          contentType: 'application/json',
-          body: { name: 'Updated integration', steps: newSteps },
-        });
+  const replaceIntegrationStep = (newStep: any, oldStepIndex: number) => {
+    const newSteps = viewData.steps;
+    newSteps[oldStepIndex] = newStep;
 
-        const data = await resp.text();
-        console.log(JSON.stringify(data));
-        setYamlData(data);
-        console.log('Data set');
-      } catch (err) {
-        console.error(err);
-        setIsError(true);
-      }
-
-      setIsLoading(false);
-    };
-
-    getVizData().catch((e) => {
+    updateIntegration(newSteps).catch((e) => {
       console.error(e);
     });
   };
@@ -256,6 +265,7 @@ const Dashboard = () => {
                 deleteIntegrationStep={deleteIntegrationStep}
                 isError={isError}
                 isLoading={isLoading}
+                replaceIntegrationStep={replaceIntegrationStep}
                 steps={vizData}
                 views={viewData.views}
               />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -173,7 +173,7 @@ const Dashboard = () => {
         viz: {
           data: { label: step.name },
           id: uuidv4(),
-          position: { x: 300, y: window.innerHeight / 2 },
+          position: { x: 0, y: 0 },
           temporary: false,
         },
       };
@@ -188,7 +188,7 @@ const Dashboard = () => {
       switch (index) {
         case 0:
           // First item in `steps` array
-          inputStep.viz.position.x = 100;
+          inputStep.viz.position.x = 0; // control this in the `integration` Konva Group instead
           break;
         case steps.length - 1:
         default:

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -119,9 +119,7 @@ const Dashboard = () => {
       });
 
       const data = await resp.text();
-      console.log(JSON.stringify(data));
       setYamlData(data);
-      console.log('Data set');
     } catch (err) {
       console.error(err);
       setIsError(true);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,8 +54,8 @@ export interface IVizStepProps {
   id: string;
   label: string;
   position: {
-    x?: number;
-    y?: number;
+    x: number;
+    y: number;
   };
   temporary: boolean;
 }

--- a/src/utils/useDocumentTitle.ts
+++ b/src/utils/useDocumentTitle.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { useEffect } from 'react';
 
 // a custom hook for setting the page title
 export function useDocumentTitle(title: string) {
-  React.useEffect(() => {
+  useEffect(() => {
     const originalTitle = document.title;
     document.title = title;
 

--- a/src/utils/useImage.ts
+++ b/src/utils/useImage.ts
@@ -1,30 +1,33 @@
-import * as React from 'react';
+import { useEffect, useState } from 'react';
 
 let defaultState: { image: undefined; status: string };
 defaultState = { image: undefined, status: 'loading' };
 
-export default function useImage(url: string, crossOrigin?: string): [
+export default function useImage(
+  url: string,
+  crossOrigin?: string
+): [
   (
     | HTMLImageElement
     | SVGImageElement
     | HTMLVideoElement
     | HTMLCanvasElement
     | ImageBitmap
-    | OffscreenCanvas
+    //| OffscreenCanvas
     | undefined
-    ),
-    string
+  ),
+  string
 ] {
-  const res = React.useState(defaultState);
+  const res = useState(defaultState);
   const image = res[0].image;
   const status = res[0].status;
 
   const setState = res[1];
 
-  React.useEffect(
+  useEffect(
     function () {
       if (!url) return;
-      const img:HTMLImageElement = document.createElement('img');
+      const img: HTMLImageElement = document.createElement('img');
 
       function onload() {
         // @ts-ignore
@@ -53,4 +56,4 @@ export default function useImage(url: string, crossOrigin?: string): [
   // const [background, backgroundStatus] = useImage(url1);
   // const [patter] = useImage(url2);
   return [image, status];
-};
+}


### PR DESCRIPTION
adds ability to replace an existing step in the integration from the catalog, subsequently updating the YAML.

- add slots for future validation
- create temporary step if the dragged step does not intersect with an existing step
- improve positioning of integration group
- update/improve a few typings

![Kapture 2021-11-08 at 16 49 05](https://user-images.githubusercontent.com/3844502/140929911-68e1d6cf-ab16-420b-bb4a-cfc45d66499d.gif)

implements part of #144 
