### PR TITLE
fetch new view definitions with updated integration

### DIFF
--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -280,6 +280,11 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
 
   const onSelectNewStep = (selectedStep: IStepProps) => {
     dispatch({ type: 'ADD_STEP', payload: { newStep: selectedStep } });
+
+    // fetch the updated view definitions again with new views
+    fetchViewDefinitions(viewData.steps).then((data: any) => {
+      dispatch({ type: 'UPDATE_INTEGRATION', payload: data });
+    });
   };
 
   const onElementsRemove = (elementsToRemove: Elements<IVizStepProps[]>) =>


### PR DESCRIPTION
Makes a separate call to fetch updated view definitions on selecting a new step. fixes #232 