### PR TITLE
update endpoint for contextual mini catalog

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -7,7 +7,7 @@ export async function fetchCatalogSteps(queryParams?: {
   // e.g. 'Kamelet'
   kind?: string;
   // e.g. 'START', 'END', 'MIDDLE'
-  type?: 'START' | 'END' | 'MIDDLE';
+  type?: string;
 }) {
   try {
     const resp = await request.get({

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -1,6 +1,26 @@
 import { IStepProps } from '../types';
 import request from './request';
 
+export async function fetchCatalogSteps(queryParams?: {
+  // e.g. 'KameletBinding'
+  integrationType?: string;
+  // e.g. 'Kamelet'
+  kind?: string;
+  // e.g. 'START', 'END', 'MIDDLE'
+  type?: 'START' | 'END' | 'MIDDLE';
+}) {
+  try {
+    const resp = await request.get({
+      endpoint: '/step',
+      queryParams,
+    });
+
+    return await resp.json();
+  } catch (err) {
+    return console.error(err);
+  }
+}
+
 /**
  * Returns the custom resource (YAML).
  * Usually to update the YAML after a change in the integration from the Visualization.

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -55,7 +55,7 @@ const api = ({
 
   let options: RequestInit = {
     method,
-    body: undefined,
+    body: contentType?.includes('application/json') && stringifyBody ? JSON.stringify(body) : body,
     // cache: 'no-cache',
     /**
      * TODO: Omit for now, reassess for prod
@@ -73,14 +73,8 @@ const api = ({
 
   // if params exists and method is GET, add query string to url
   // otherwise, add query params as a "body" property to the options object
-  if (queryParams) {
-    if (method === 'GET') {
-      endpoint += '?' + objectToQueryString(queryParams);
-    } else {
-      // stringify body for JSON, leave plain for YAML text and everything else
-      options.body =
-        contentType?.includes('application/json') && stringifyBody ? JSON.stringify(body) : body; // body should match Content-Type in headers option
-    }
+  if (queryParams && method === 'GET') {
+    endpoint += '?' + objectToQueryString(queryParams);
   }
 
   return fetch(`${apiURL}${endpoint}`, options);

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -20,6 +20,11 @@ export interface IFetch {
    */
   contentType?: string;
 
+  // Object of key/value string for passing query parameters
+  queryParams?: {
+    [name: string]: string;
+  };
+
   /**
    * Whether or not to stringify the data to JSON, overrides the content type
    */
@@ -28,42 +33,63 @@ export interface IFetch {
 
 const apiURL = process.env.KAOTO_API;
 
-const api = ({
-               endpoint,
-               method,
-               headers = {},
-               body,
-               contentType,
-               accept,
-               stringifyBody = true,
-             }: IFetch) => {
-  const data = contentType?.includes('application/json') && stringifyBody ? JSON.stringify(body) : body;
+// converts an object into a query string
+// ex: {authorId : 'abc123'} -> &type=Kamelet
+function objectToQueryString(obj: { [x: string]: string }) {
+  return Object.keys(obj)
+    .map((key) => key + '=' + obj[key])
+    .join('&');
+}
 
+const api = ({
+  endpoint,
+  method,
+  headers = {},
+  body,
+  contentType,
+  accept,
+  queryParams,
+  stringifyBody = true,
+}: IFetch) => {
   headers = { ...headers };
 
-  return fetch(`${apiURL}${endpoint}`, {
+  let options: RequestInit = {
     method,
-    body: data,
-    cache: 'no-cache',
+    body: undefined,
+    // cache: 'no-cache',
     /**
      * TODO: Omit for now, reassess for prod
      */
     credentials: 'omit',
     headers: {
-      'Accept': accept ?? 'application/json,text/plain,text/yaml,*/*',
+      Accept: accept ?? 'application/json,text/plain,text/yaml,*/*',
       'Content-Type': contentType ?? 'application/json',
       ...headers,
     },
     mode: 'cors',
     redirect: 'follow',
-    referrerPolicy: 'no-referrer'
-  });
+    referrerPolicy: 'no-referrer',
+  };
+
+  // if params exists and method is GET, add query string to url
+  // otherwise, add query params as a "body" property to the options object
+  if (queryParams) {
+    if (method === 'GET') {
+      endpoint += '?' + objectToQueryString(queryParams);
+    } else {
+      // stringify body for JSON, leave plain for YAML text and everything else
+      options.body =
+        contentType?.includes('application/json') && stringifyBody ? JSON.stringify(body) : body; // body should match Content-Type in headers option
+    }
+  }
+
+  return fetch(`${apiURL}${endpoint}`, options);
 };
 
 export default {
-  get: (options: IFetch) => api({method: 'GET', ...options}),
-  post: (options: IFetch) => api({method: 'POST', ...options}),
-  put: (options: IFetch) => api({method: 'PUT', ...options}),
-  patch: (options: IFetch) => api({method: 'PATCH', ...options}),
-  delete: (options: IFetch) => api({method: 'DELETE', ...options}),
+  get: (options: IFetch) => api({ method: 'GET', ...options }),
+  post: (options: IFetch) => api({ method: 'POST', ...options }),
+  put: (options: IFetch) => api({ method: 'PUT', ...options }),
+  patch: (options: IFetch) => api({ method: 'PATCH', ...options }),
+  delete: (options: IFetch) => api({ method: 'DELETE', ...options }),
 };

--- a/src/components/Catalog.stories.tsx
+++ b/src/components/Catalog.stories.tsx
@@ -1,6 +1,7 @@
 // For now the only view data we care about are steps
 import catalog from '../data/catalog';
 import { Catalog, ICatalog } from './Catalog';
+import { AlertProvider } from './MASAlerts';
 import { Drawer, DrawerContent } from '@patternfly/react-core';
 import { action } from '@storybook/addon-actions';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
@@ -12,15 +13,17 @@ export default {
 
 const Template: ComponentStory<typeof Catalog> = (props: ICatalog) => {
   return (
-    <Drawer
-      isExpanded={props.isCatalogExpanded}
-      onExpand={() => {
-        action('Catalog expanded');
-      }}
-      position={'left'}
-    >
-      <DrawerContent panelContent={<Catalog {...props} />} className={'panelCustom'} />
-    </Drawer>
+    <AlertProvider>
+      <Drawer
+        isExpanded={props.isCatalogExpanded}
+        onExpand={() => {
+          action('Catalog expanded');
+        }}
+        position={'left'}
+      >
+        <DrawerContent panelContent={<Catalog {...props} />} className={'panelCustom'} />
+      </Drawer>
+    </AlertProvider>
   );
 };
 

--- a/src/components/Catalog.test.tsx
+++ b/src/components/Catalog.test.tsx
@@ -1,10 +1,15 @@
 import { Catalog } from './Catalog';
+import { AlertProvider } from './MASAlerts';
 import { screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 
 describe('Catalog.tsx', () => {
   test('component renders correctly', () => {
-    render(<Catalog isCatalogExpanded={true} onClosePanelClick={jest.fn()} />);
+    render(
+      <AlertProvider>
+        <Catalog isCatalogExpanded={true} onClosePanelClick={jest.fn()} />
+      </AlertProvider>
+    );
 
     const element = screen.getByTestId('stepCatalog');
     expect(element).toBeInTheDocument();

--- a/src/components/MiniCatalog.stories.tsx
+++ b/src/components/MiniCatalog.stories.tsx
@@ -1,4 +1,5 @@
 import catalog from '../data/catalog';
+import { AlertProvider } from './MASAlerts';
 import { MiniCatalog, IMiniCatalog } from './MiniCatalog';
 import { action } from '@storybook/addon-actions';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
@@ -10,9 +11,11 @@ export default {
 
 const Template: ComponentStory<typeof MiniCatalog> = (props: IMiniCatalog) => {
   return (
-    <div style={{ maxWidth: '20%' }}>
-      <MiniCatalog {...props} />
-    </div>
+    <AlertProvider>
+      <div style={{ maxWidth: '20%' }}>
+        <MiniCatalog {...props} />
+      </div>
+    </AlertProvider>
   );
 };
 

--- a/src/components/MiniCatalog.test.tsx
+++ b/src/components/MiniCatalog.test.tsx
@@ -1,10 +1,15 @@
+import { AlertProvider } from './MASAlerts';
 import { MiniCatalog } from './MiniCatalog';
 import { screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 
 describe('MiniCatalog.tsx', () => {
   test('component renders correctly', () => {
-    render(<MiniCatalog />);
+    render(
+      <AlertProvider>
+        <MiniCatalog />
+      </AlertProvider>
+    );
 
     const element = screen.getByTestId('miniCatalog');
     expect(element).toBeInTheDocument();

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -1,6 +1,7 @@
-import request from '../api/request';
+import { fetchCatalogSteps } from '../api';
 import { IStepProps } from '../types';
 import {
+  AlertVariant,
   Bullseye,
   Button,
   Grid,
@@ -11,10 +12,19 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
+import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useEffect, useState } from 'react';
 
 export interface IMiniCatalog {
   handleSelectStep?: (selectedStep: any) => void;
+  queryParams?: {
+    // e.g. 'KameletBinding'
+    integrationType?: string;
+    // e.g. 'Kamelet'
+    kind?: string;
+    // e.g. 'START', 'END', 'MIDDLE'
+    type?: 'START' | 'END' | 'MIDDLE';
+  };
   steps?: IStepProps[];
 }
 
@@ -22,28 +32,29 @@ export const MiniCatalog = (props: IMiniCatalog) => {
   const [catalogData, setCatalogData] = useState<IStepProps[]>(props.steps ?? []);
   const [query, setQuery] = useState(``);
 
+  const { addAlert } = useAlert() || {};
+
   /**
    * Sort & fetch all Steps for the Catalog
    */
   useEffect(() => {
     if (!props.steps) {
-      const getCatalogData = async () => {
-        try {
-          const resp = await request.get({
-            endpoint: '/step',
-          });
-
-          const data = await resp.json();
-          data.sort((a: IStepProps, b: IStepProps) => a.name.localeCompare(b.name));
-          setCatalogData(data);
-        } catch (err) {
-          console.error(err);
-        }
-      };
-
-      getCatalogData().catch((e) => {
-        console.error(e);
-      });
+      fetchCatalogSteps(props.queryParams)
+        .then((value) => {
+          if (value) {
+            value.sort((a: IStepProps, b: IStepProps) => a.name.localeCompare(b.name));
+            setCatalogData(value);
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+          addAlert &&
+            addAlert({
+              title: 'Something went wrong',
+              variant: AlertVariant.danger,
+              description: 'There was a problem updating the integration. Please try again later.',
+            });
+        });
     }
   }, []);
 

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -23,7 +23,7 @@ export interface IMiniCatalog {
     // e.g. 'Kamelet'
     kind?: string;
     // e.g. 'START', 'END', 'MIDDLE'
-    type?: 'START' | 'END' | 'MIDDLE';
+    type?: string;
   };
   steps?: IStepProps[];
 }

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -163,6 +163,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
         data: {
           connectorType: step.type,
           icon: step.icon,
+          kind: step.kind,
           label: truncateString(step.name, 14),
           UUID: step.UUID,
           onDropChange,

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,3 +1,4 @@
+import { appendableStepTypes } from '../utils/validationService';
 import { MiniCatalog } from './MiniCatalog';
 import './Visualization.css';
 import { Button, Popover } from '@patternfly/react-core';
@@ -20,8 +21,6 @@ const VisualizationStep = ({ data }: any) => {
   const onElementClick = (event: any) => data.onElementClick(event, data);
   const onElementClickAdd = (selectedStep: any) => data.onElementClickAdd(selectedStep);
 
-  console.table(data);
-
   return (
     <>
       <div
@@ -42,7 +41,7 @@ const VisualizationStep = ({ data }: any) => {
                 queryParams={{
                   kind: data.kind,
                   integrationType: 'KameletBinding',
-                  type: data.connectorType,
+                  type: appendableStepTypes(data.connectorType),
                 }}
               />
             }

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -20,6 +20,8 @@ const VisualizationStep = ({ data }: any) => {
   const onElementClick = (event: any) => data.onElementClick(event, data);
   const onElementClickAdd = (selectedStep: any) => data.onElementClickAdd(selectedStep);
 
+  console.table(data);
+
   return (
     <>
       <div
@@ -34,7 +36,16 @@ const VisualizationStep = ({ data }: any) => {
           <Popover
             appendTo={() => document.body}
             aria-label="Search for a step"
-            bodyContent={<MiniCatalog handleSelectStep={onElementClickAdd} />}
+            bodyContent={
+              <MiniCatalog
+                handleSelectStep={onElementClickAdd}
+                queryParams={{
+                  kind: data.kind,
+                  integrationType: 'KameletBinding',
+                  type: data.connectorType,
+                }}
+              />
+            }
             hideOnOutsideClick={true}
             position={'auto'}
           >

--- a/src/utils/validationService.ts
+++ b/src/utils/validationService.ts
@@ -1,30 +1,21 @@
 import { IStepProps } from '../types';
 
 /**
- * Checks whether a step can be appended onto an existing step.
- * @param existingStep
- * @param appendedStep
+ * Checks kind of steps can be appended onto an existing step.
+ * @param existingStepType
  */
-export function canStepBeAppended(
-  existingStep: any,
-  appendedStep: any
-): { isValid: boolean; message?: string } {
-  let isValid = false;
-  let message = undefined;
+export function appendableStepTypes(existingStepType: string): string {
+  let possibleSteps: string = '';
 
-  switch (existingStep.connectorType) {
+  switch (existingStepType) {
     case 'START':
     case 'MIDDLE':
       // cannot append a START step to a START or MIDDLE step
-      isValid = appendedStep.connectorType !== 'START';
-      break;
-    case 'END':
-      // you can't add anything onto an end step
-      isValid = false;
+      possibleSteps = 'MIDDLE,END';
       break;
   }
 
-  return { isValid, message };
+  return possibleSteps;
 }
 
 /**


### PR DESCRIPTION
- Update endpoint for contextual mini catalog. This allows us to return only the steps that are possible for appending, and will make it easier once we support multiple DSLs.
- Add alert on failing to fetch steps.
- Add validation to pass only valid step `kinds` for appending.
- Removes direct reference to `request` (`fetch` API), and uses the `apiService` instead to make any call for the catalog.

fix #216 