### PR TITLE
trigger update manually to fix jolty editor

### DIFF
--- a/src/api/StepsAndViewsProvider.tsx
+++ b/src/api/StepsAndViewsProvider.tsx
@@ -14,7 +14,7 @@ type StepsAndViewsAction =
 
 export type IUseStepsAndViews = [
   viewData: IViewData,
-  dispatch: (action: StepsAndViewsAction) => void
+  dispatch: (action: StepsAndViewsAction) => void | IViewData
 ];
 
 function stepsAndViewsReducer(state: IViewData, action: StepsAndViewsAction) {
@@ -68,10 +68,7 @@ function StepsAndViewsProvider({ initialState, children }: IStepsAndViewsProvide
   );
 }
 
-const StepsAndViewsContext = createContext<IUseStepsAndViews>([
-  { steps: [], views: [] },
-  () => null,
-]);
+const StepsAndViewsContext = createContext<IUseStepsAndViews>([{ steps: [], views: [] }, () => {}]);
 
 function useStepsAndViewsContext() {
   const context = useContext(StepsAndViewsContext);

--- a/src/api/YAMLProvider.tsx
+++ b/src/api/YAMLProvider.tsx
@@ -1,6 +1,3 @@
-// import { usePrevious } from '../utils';
-// import { useStepsAndViewsContext } from './StepsAndViewsProvider';
-// import { fetchViewDefinitions } from './apiService';
 import {
   createContext,
   Dispatch,
@@ -20,28 +17,10 @@ export type IUseYAMLData = [string, Dispatch<SetStateAction<string>>];
 
 export const useYAMLData = (newYAMLData: string): IUseYAMLData => {
   const [YAMLData, setYAMLData] = useState<string>(newYAMLData);
-  // const previousYaml = usePrevious(YAMLData);
-  // const [, dispatch] = useStepsAndViewsContext();
 
   useEffect(() => {
     setYAMLData(newYAMLData);
   }, [newYAMLData]);
-
-  // useEffect(() => {
-  //   if (previousYaml === YAMLData) {
-  //     return;
-  //   }
-  //
-  //   fetchViewDefinitions(YAMLData)
-  //     .then((res) => {
-  //       dispatch({ type: 'UPDATE_INTEGRATION', payload: res });
-  //     })
-  //     .catch((e) => {
-  //       console.error(e);
-  //     });
-  //
-  //   setYAMLData(newYAMLData);
-  // }, [newYAMLData]);
 
   return [YAMLData, setYAMLData];
 };

--- a/src/api/YAMLProvider.tsx
+++ b/src/api/YAMLProvider.tsx
@@ -1,6 +1,6 @@
-import { usePrevious } from '../utils';
-import { useStepsAndViewsContext } from './StepsAndViewsProvider';
-import { fetchViewDefinitions } from './apiService';
+// import { usePrevious } from '../utils';
+// import { useStepsAndViewsContext } from './StepsAndViewsProvider';
+// import { fetchViewDefinitions } from './apiService';
 import {
   createContext,
   Dispatch,
@@ -16,41 +16,45 @@ interface IYAMLDataProvider {
   children: ReactNode;
 }
 
-export type IUseYAMLData = [string | undefined, Dispatch<SetStateAction<string | undefined>>];
+export type IUseYAMLData = [string, Dispatch<SetStateAction<string>>];
 
-export const useYAMLData = (newYAMLData?: string): IUseYAMLData => {
-  const [YAMLData, setYAMLData] = useState<string | undefined>(newYAMLData ?? undefined);
-  const previousYaml = usePrevious(YAMLData);
-  const [, dispatch] = useStepsAndViewsContext();
+export const useYAMLData = (newYAMLData: string): IUseYAMLData => {
+  const [YAMLData, setYAMLData] = useState<string>(newYAMLData);
+  // const previousYaml = usePrevious(YAMLData);
+  // const [, dispatch] = useStepsAndViewsContext();
 
   useEffect(() => {
-    if (previousYaml === YAMLData) {
-      return;
-    }
-
-    fetchViewDefinitions(YAMLData)
-      .then((res) => {
-        dispatch({ type: 'UPDATE_INTEGRATION', payload: res });
-      })
-      .catch((e) => {
-        console.error(e);
-      });
-
     setYAMLData(newYAMLData);
   }, [newYAMLData]);
+
+  // useEffect(() => {
+  //   if (previousYaml === YAMLData) {
+  //     return;
+  //   }
+  //
+  //   fetchViewDefinitions(YAMLData)
+  //     .then((res) => {
+  //       dispatch({ type: 'UPDATE_INTEGRATION', payload: res });
+  //     })
+  //     .catch((e) => {
+  //       console.error(e);
+  //     });
+  //
+  //   setYAMLData(newYAMLData);
+  // }, [newYAMLData]);
 
   return [YAMLData, setYAMLData];
 };
 
 function YAMLProvider({ initialState, children }: IYAMLDataProvider) {
-  const [YAMLData, setYAMLData] = useYAMLData(initialState ?? undefined);
+  const [YAMLData, setYAMLData] = useYAMLData(initialState ?? '');
 
   return (
     <YAMLDataContext.Provider value={[YAMLData, setYAMLData]}>{children}</YAMLDataContext.Provider>
   );
 }
 
-const YAMLDataContext = createContext<IUseYAMLData>([undefined, () => null]);
+const YAMLDataContext = createContext<IUseYAMLData>(['', () => null]);
 
 function useYAMLContext() {
   const context = useContext(YAMLDataContext);

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -42,7 +42,7 @@ interface IVisualization {
   toggleCatalog?: () => void;
 }
 
-const Visualization = ({}: IVisualization) => {
+const Visualization = ({ toggleCatalog }: IVisualization) => {
   // `elements` is an array of UI-specific objects that represent the Step model visually
   const [elements, setElements] = useState<Elements<IStepProps>>([]);
   const [isPanelExpanded, setIsPanelExpanded] = useState(false);
@@ -263,8 +263,7 @@ const Visualization = ({}: IVisualization) => {
     if (element.type === 'slot') {
       // prevent slots from being selected,
       // passive-aggressively open the steps catalog
-      // if (toggleCatalog) toggleCatalog();
-
+      if (toggleCatalog) toggleCatalog();
       return;
     }
 
@@ -273,9 +272,10 @@ const Visualization = ({}: IVisualization) => {
       const findStep: IStepProps =
         viewData.steps.find((step) => step.UUID === element.data.UUID) ?? selectedStep;
       setSelectedStep(findStep);
-
-      setIsPanelExpanded(!isPanelExpanded);
     }
+
+    // show/hide the panel regardless
+    setIsPanelExpanded(!isPanelExpanded);
   };
 
   /**

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -318,11 +318,11 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
       });
 
       const oldStepIdx = findStepIdxWithUUID(selectedStep.UUID!, viewData.steps);
+      // we'll need to update the code editor
+      shouldUpdateCodeEditor.current = true;
+
       // Replace step with new step
       dispatch({ type: 'REPLACE_STEP', payload: { newStep, oldStepIndex: oldStepIdx } });
-
-      // check that this isn't returning old data
-      updateCodeEditor(viewData.steps);
     } else {
       return;
     }

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -62,7 +62,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     }
 
     if (shouldUpdateCodeEditor.current) {
-      console.log('requested to updated the code editor');
+      // console.log('requested to updated the code editor');
       updateCodeEditor(viewData.steps);
       shouldUpdateCodeEditor.current = false;
     }

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -60,8 +60,15 @@ const Visualization = ({}: IVisualization) => {
       return;
     }
 
+    prepareAndSetVizDataSteps(viewData.steps);
+  }, [viewData]);
+
+  const updateCodeEditor = (viewDataSteps: any[]) => {
+    console.log('updating the code editor...');
+    console.table(viewDataSteps);
+
     // Remove all "Add Step" placeholders before updating the API
-    fetchCustomResource(viewData.steps.filter((step) => step.type))
+    fetchCustomResource(viewDataSteps.filter((step) => step.type))
       .then((value) => {
         if (typeof value === 'string') {
           setYAMLData(value);
@@ -78,9 +85,7 @@ const Visualization = ({}: IVisualization) => {
             description: 'There was a problem updating the integration. Please try again later.',
           });
       });
-
-    prepareAndSetVizDataSteps(viewData.steps);
-  }, [viewData]);
+  };
 
   const nodeTypes = {
     slot: VisualizationSlot,
@@ -112,6 +117,7 @@ const Visualization = ({}: IVisualization) => {
       // fetch the updated view definitions again with new views
       fetchViewDefinitions(viewData.steps).then((data: any) => {
         dispatch({ type: 'UPDATE_INTEGRATION', payload: data });
+        updateCodeEditor(viewData.steps);
       });
     } else {
       // the step CANNOT be replaced, the proposed step is invalid
@@ -223,6 +229,7 @@ const Visualization = ({}: IVisualization) => {
 
     const stepsIndex = findStepIdxWithUUID(selectedStep.UUID, viewData.steps);
     dispatch({ type: 'DELETE_STEP', payload: { index: stepsIndex } });
+    updateCodeEditor(viewData.steps);
   };
 
   // Close Step View panel
@@ -276,6 +283,7 @@ const Visualization = ({}: IVisualization) => {
     // fetch the updated view definitions again with new views
     fetchViewDefinitions(viewData.steps).then((data: any) => {
       dispatch({ type: 'UPDATE_INTEGRATION', payload: data });
+      updateCodeEditor(viewData.steps);
     });
   };
 
@@ -307,6 +315,9 @@ const Visualization = ({}: IVisualization) => {
       const oldStepIdx = findStepIdxWithUUID(selectedStep.UUID!, viewData.steps);
       // Replace step with new step
       dispatch({ type: 'REPLACE_STEP', payload: { newStep, oldStepIndex: oldStepIdx } });
+
+      // check that this isn't returning old data
+      updateCodeEditor(viewData.steps);
     } else {
       return;
     }

--- a/src/components/YAMLEditor.tsx
+++ b/src/components/YAMLEditor.tsx
@@ -1,7 +1,6 @@
 import { fetchViewDefinitions, useStepsAndViewsContext, useYAMLContext } from '../api';
 import { usePrevious } from '../utils';
 import { StepErrorBoundary } from './StepErrorBoundary';
-// import Editor from '@monaco-editor/react';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { useRef } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
@@ -24,24 +23,21 @@ const YAMLEditor = (props: IYAMLEditor) => {
    * Returns JSON to be displayed in the visualizer
    */
   const handleChanges = (incomingData?: string) => {
-    // Wait a bit before setting data
-    setTimeout(() => {
-      // Check that the data has changed, otherwise return
-      if (previousYaml === incomingData) {
-        return;
-      }
+    // Check that the data has changed, otherwise return
+    if (previousYaml === incomingData) {
+      return;
+    }
 
-      setYAMLData(incomingData);
+    setYAMLData(incomingData);
 
-      fetchViewDefinitions(incomingData)
-        .then((res) => {
-          // update Visualization with new data
-          dispatch({ type: 'UPDATE_INTEGRATION', payload: res });
-        })
-        .catch((e) => {
-          console.error(e);
-        });
-    }, 750);
+    fetchViewDefinitions(incomingData)
+      .then((res) => {
+        // update Visualization with new data
+        dispatch({ type: 'UPDATE_INTEGRATION', payload: res });
+      })
+      .catch((e) => {
+        console.error(e);
+      });
   };
 
   function handleEditorChange(value?: string) {
@@ -54,12 +50,12 @@ const YAMLEditor = (props: IYAMLEditor) => {
 
   const debounced = useDebouncedCallback((value?: string) => {
     handleChanges(value);
-  }, 800);
+  }, 1000);
 
   return (
     <StepErrorBoundary>
       <CodeEditor
-        code={props.initialData ?? YAMLData}
+        code={props.initialData ?? YAMLData ?? ''}
         height="650px"
         isCopyEnabled={true}
         isDarkTheme={true}


### PR DESCRIPTION
- fixed a bug where sometimes you couldn't select a step
- toggle the catalog when clicking on a placeholder step (e.g. "ADD A STEP")
- fix #158 by updating the code editor and visualization manually, and increase the debounce rate back to the default value