### PR TITLE
reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
This reduces the image size from over 2.5GB to 174MB. I verified that the UI loads in my browser using the following commands, and opening http://localhost:8080. 

```
podman build . -t kaoto
podman run --rm -p 8080:80 kaoto:latest
```