### PR TITLE
Allow using all hosts for the webpack in production.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "webpack serve --mode development --hot --progress --config webpack.dev.js ",
-    "prod": "webpack serve --mode production --port 8080 --host 0.0.0.0 --progress --config webpack.prod.js ",
+    "prod": "webpack serve --mode production --port 8080 --allowed-hosts all --progress --config webpack.prod.js ",
     "build": "webpack --mode production --config webpack.prod.js",
     "build-storybook": "build-storybook -s public",
     "chromatic": "npx chromatic",


### PR DESCRIPTION
Using this is considered as security risk but in current stage of the project I believe we can live with that :) 

I'd say this is only temporary fix to have working  image within the kubernetes/openshift cluster. In the future probably usage of nginx would be more sufficient. 

