### PR TITLE
Use assets modules instead of deprecated loaders

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,20 +47,11 @@ module.exports = () => {
         },
         {
           test: /\.(ttf|eot|woff|woff2)$/,
-          use: {
-            loader: 'file-loader',
-          },
+          type: 'asset/resource',
         },
         {
           test: /\.(svg|jpg|jpeg|png|gif)$/i,
-          use: [
-            {
-              loader: 'url-loader',
-              options: {
-                limit: 5000,
-              },
-            },
-          ],
+          type: 'asset/inline'
         },
         {
           test: /\.yaml$/,


### PR DESCRIPTION
#274 

Current loaders where deprecated since webpack 5, changed it to [assets modules](https://webpack.js.org/guides/asset-modules/#resource-assets)