### PR TITLE
fix field properties not updating immediately

### DIFF
--- a/src/components/JsonSchemaConfigurator.test.tsx
+++ b/src/components/JsonSchemaConfigurator.test.tsx
@@ -38,7 +38,7 @@ describe('JsonSchemaConfigurator.tsx', () => {
       <JsonSchemaConfigurator
         schema={bridge}
         configuration={stepPropertyModel}
-        onSubmit={jest.fn()}
+        onChangeModel={jest.fn()}
       />
     );
     const element = screen.getByTestId('json-schema-configurator');

--- a/src/components/JsonSchemaConfigurator.tsx
+++ b/src/components/JsonSchemaConfigurator.tsx
@@ -23,13 +23,13 @@ export function createValidator(schema: object) {
 type JsonSchemaConfiguratorProps = {
   schema: any;
   configuration: any;
-  onSubmit: (configuration: unknown, isValid: boolean) => void;
+  onChangeModel: (configuration: unknown, isValid: boolean) => void;
 };
 
 export const JsonSchemaConfigurator = ({
   schema,
   configuration,
-  onSubmit,
+  onChangeModel,
 }: JsonSchemaConfiguratorProps) => {
   schema.type = schema.type || 'object';
   const schemaValidator = createValidator(schema);
@@ -38,7 +38,7 @@ export const JsonSchemaConfigurator = ({
     <AutoForm
       schema={bridge}
       model={configuration}
-      onSubmit={(model: any) => onSubmit(model, true)}
+      onChangeModel={(model: any) => onChangeModel(model, true)}
       data-testid={'json-schema-configurator'}
     >
       <AutoFields />

--- a/src/components/JsonSchemaConfigurator.tsx
+++ b/src/components/JsonSchemaConfigurator.tsx
@@ -1,4 +1,3 @@
-import { ActionGroup, Button } from '@patternfly/react-core';
 import Ajv from 'ajv';
 import { AutoForm } from 'uniforms';
 import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
@@ -44,11 +43,6 @@ export const JsonSchemaConfigurator = ({
       <AutoFields />
       <ErrorsField />
       <br />
-      <ActionGroup>
-        <Button variant={'primary'} type={'submit'}>
-          Verify Configuration
-        </Button>
-      </ActionGroup>
     </AutoForm>
   );
 };

--- a/src/components/StepViews.tsx
+++ b/src/components/StepViews.tsx
@@ -180,7 +180,7 @@ const StepViews = ({
                   <JsonSchemaConfigurator
                     schema={{ type: 'object', properties: stepPropertySchema.current }}
                     configuration={stepPropertyModel.current}
-                    onSubmit={(configuration, isValid) => {
+                    onChangeModel={(configuration, isValid) => {
                       if (isValid) {
                         saveConfig(configuration);
                       }


### PR DESCRIPTION
In `Step Detail View` -> `Configuration` the fields were not updating immediately, and required the user to press the 'Validate' buton.

- update YAML as soon as user makes the changes
- remove validate button

![Kapture 2022-04-06 at 15 59 10](https://user-images.githubusercontent.com/3844502/162005620-b3b63cbb-499d-45ba-8638-263ea62907ae.gif)

We might need to add debounce in the near future, depending on the expected behavior.