### PR TITLE
fix(job): Dependabot is not updating yarn.lock 

### DIFF
--- a/.github/workflows/dependabot-yarn-fix.yml
+++ b/.github/workflows/dependabot-yarn-fix.yml
@@ -1,0 +1,66 @@
+# Automatically save updated `yarn.lock` file for dependabot PRs.
+# This is necessary because dependabot doesn't support Yarn v2 yet:
+# https://github.com/dependabot/dependabot-core/issues/1297
+#
+# Note: We use the `pull_request_target` event due to GitHub security measures.
+#       It is important to ensure we don't execute any untrusted PR code in this context.
+# See: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+#      https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+
+name: Dependabot Yarn Fix
+
+on:
+  - pull_request_target
+
+jobs:
+  build:
+    name: fix
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/')
+
+    # IMPORTANT: setting YARN_ENABLE_SCRIPTS=false is critical to ensure that untrusted
+    # PRs can't add an npm package and then use that to execute untrusted code in
+    # a trusted context. See links at the top of this workflow for further details.
+    # See also: https://github.com/yarnpkg/berry/issues/1679#issuecomment-669937860
+    env:
+      YARN_ENABLE_SCRIPTS: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Using a Personal Access Token here is required to trigger workflows on our new commit.
+          # The default GitHub token doesn't trigger any workflows.
+          # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
+          token: ${{ secrets.DEPENDABOT_FIX_GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - run: git lfs pull --include .yarn/
+
+      - name: Configure Node.js
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 15.x
+
+      - name: Restore cache
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            .yarn/cache
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+
+      - run: yarn install --skip-builds
+
+      - run: yarn dedupe
+
+      - name: Commit yarn.lock
+        run: |
+          git config user.name "dependabot-fix"
+          git config user.email "hellokaoto@gmail.com"
+          git add yarn.lock
+          git commit -m '[dependabot skip] Fix yarn.lock'
+          git push
+


### PR DESCRIPTION
so tests are not run on its PR

This job updates the yarn.lock on each and every dependabot PR.