### PR TITLE
fix: api-provided definition should replace user-defined definition

### DIFF
--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -70,7 +70,6 @@ const Visualization = ({ settings, toggleCatalog }: IVisualization) => {
     }
 
     if (shouldUpdateCodeEditor.current) {
-      // console.log('requested to updated the code editor');
       updateCodeEditor(viewData.steps);
       shouldUpdateCodeEditor.current = false;
     }

--- a/src/components/YAMLEditor.tsx
+++ b/src/components/YAMLEditor.tsx
@@ -1,4 +1,9 @@
-import { useYAMLContext, useStepsAndViewsContext, fetchViewDefinitions } from '../api';
+import {
+  useYAMLContext,
+  useStepsAndViewsContext,
+  fetchViewDefinitions,
+  fetchCustomResource,
+} from '../api';
 import { StepErrorBoundary } from './StepErrorBoundary';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { useRef } from 'react';
@@ -27,6 +32,16 @@ const YAMLEditor = (props: IYAMLEditor) => {
       fetchViewDefinitions(incomingData)
         .then((res) => {
           dispatch({ type: 'UPDATE_INTEGRATION', payload: res });
+          /**
+           * Use new API-provided view definition to re-fetch the "proper" custom
+           * resource (YAML). Used to fill any relevant YAML data missed while
+           * manually typing.
+           */
+          fetchCustomResource(res.steps, 'integration').then((yamlResponse) => {
+            if (typeof yamlResponse === 'string') {
+              setYAMLData(yamlResponse);
+            }
+          });
         })
         .catch((e) => {
           console.error(e);


### PR DESCRIPTION
This fixes an issue where, if the user types in YAML that is valid but doesn't contain all of the valid properties, then the code editor should re-fetch the correct YAML provided by the API. This allows for users to quickly see what properties are available for the kamelet that they have defined.

### Screenshot

![Kapture 2022-05-25 at 15 36 15](https://user-images.githubusercontent.com/3844502/170289010-dea64a6a-6a19-4c2b-8514-e56d2ecfb5e8.gif)


cc @MohammadiIram @Delawen 