### PR TITLE
include dsl in requests to custom resource

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -28,11 +28,16 @@ export async function fetchCatalogSteps(queryParams?: {
  * Requires a list of all new steps.
  * @param newSteps
  * @param integrationName
+ * @param dsl
  */
-export async function fetchCustomResource(newSteps: IStepProps[], integrationName: string) {
+export async function fetchCustomResource(
+  newSteps: IStepProps[],
+  integrationName: string,
+  dsl: string
+) {
   try {
     const resp = await request.post({
-      endpoint: '/integrations/customResource',
+      endpoint: '/integrations/customResource?dsl=' + dsl,
       contentType: 'application/json',
       body: { name: integrationName.toLowerCase(), steps: newSteps },
     });

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -137,7 +137,7 @@ export async function startDeployment(
 ) {
   try {
     const resp = await request.post({
-      endpoint: '/integrations?type=' + dsl + '&namespace=' + namespace,
+      endpoint: '/integrations?dsl=' + dsl + '&namespace=' + namespace,
       contentType: 'application/json',
       body: { name: integrationName.toLowerCase(), steps: integration },
     });

--- a/src/api/stepExtensionApi.ts
+++ b/src/api/stepExtensionApi.ts
@@ -21,7 +21,7 @@ import { IStepProps } from '../types';
  */
 export interface IStepExtensionApi {
   fetchCatalogSteps: () => void;
-  fetchCRDs: (newSteps: IStepProps[], integrationName: string) => void;
+  fetchCRDs: (newSteps: IStepProps[], integrationName: string, dsl: string) => void;
   fetchDeployments: () => void;
   fetchDSLs: () => void;
   fetchViewDefinitions: (data: string | IStepProps[]) => void;

--- a/src/components/StepViews.tsx
+++ b/src/components/StepViews.tsx
@@ -191,8 +191,12 @@ const StepViews = ({
                 });
               };
 
-              const seFetchCRDs = (newSteps: IStepProps[], integrationName: string) => {
-                return fetchCustomResource(newSteps, integrationName).then((res) => {
+              const seFetchCRDs = (
+                newSteps: IStepProps[],
+                integrationName: string,
+                dsl: string
+              ) => {
+                return fetchCustomResource(newSteps, integrationName, dsl).then((res) => {
                   return res;
                 });
               };

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -78,7 +78,8 @@ const Visualization = ({ settings, toggleCatalog }: IVisualization) => {
     // Remove all "Add Step" placeholders before updating the API
     fetchCustomResource(
       viewDataSteps.filter((step) => step.type),
-      settings.integrationName
+      settings.integrationName,
+      settings.dsl
     )
       .then((value) => {
         if (typeof value === 'string') {
@@ -167,6 +168,7 @@ const Visualization = ({ settings, toggleCatalog }: IVisualization) => {
         icon: step.icon,
         kind: step.kind,
         label: truncateString(step.name, 14),
+        dsl: settings.dsl,
         UUID: step.UUID,
         index,
         onDropChange,

--- a/src/components/VisualizationSlot.tsx
+++ b/src/components/VisualizationSlot.tsx
@@ -40,7 +40,8 @@ const VisualizationSlot = ({ data }: IVisualizationSlot) => {
 
         fetchCustomResource(
           newViewDefs.steps.filter((step: IStepProps) => step.type),
-          data.settings.integrationName
+          data.settings.integrationName,
+          data.settings.dsl
         )
           .then((value) => {
             if (typeof value === 'string') {

--- a/src/components/YAMLEditor.test.tsx
+++ b/src/components/YAMLEditor.test.tsx
@@ -1,11 +1,11 @@
 import { YAMLEditor } from './YAMLEditor';
-import { render } from '@testing-library/react';
 import { Language } from '@patternfly/react-code-editor';
 import { screen } from '@testing-library/dom';
+import { render } from '@testing-library/react';
 
 describe('YAMLEditor.tsx', () => {
   test('component renders correctly', () => {
-    render(<YAMLEditor language={Language.yaml} />);
+    render(<YAMLEditor language={Language.yaml} dsl={'KameletBinding'} />);
     const emptyStateBrowseBtn = screen.getByRole('textbox');
     expect(emptyStateBrowseBtn).toBeInTheDocument();
   });

--- a/src/components/YAMLEditor.tsx
+++ b/src/components/YAMLEditor.tsx
@@ -5,13 +5,14 @@ import {
   fetchCustomResource,
 } from '../api';
 import { StepErrorBoundary } from './StepErrorBoundary';
-import {CodeEditor, CodeEditorControl, Language} from '@patternfly/react-code-editor';
+import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
+import { RedoIcon, UndoIcon } from '@patternfly/react-icons';
 import { useRef } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
 import EditorDidMount from 'react-monaco-editor';
-import {RedoIcon, UndoIcon} from "@patternfly/react-icons";
+import { useDebouncedCallback } from 'use-debounce';
 
 interface IYAMLEditor {
+  dsl: string;
   // Used to mock data for stories
   initialData?: string;
   language?: Language;
@@ -38,7 +39,7 @@ const YAMLEditor = (props: IYAMLEditor) => {
            * resource (YAML). Used to fill any relevant YAML data missed while
            * manually typing.
            */
-          fetchCustomResource(res.steps, 'integration').then((yamlResponse) => {
+          fetchCustomResource(res.steps, 'integration', props.dsl).then((yamlResponse) => {
             if (typeof yamlResponse === 'string') {
               setYAMLData(yamlResponse);
             }
@@ -65,33 +66,33 @@ const YAMLEditor = (props: IYAMLEditor) => {
   }, 1000);
 
   const undoAction = () => {
-      (editorRef.current?.getModel() as any)?.undo();
-  }
+    (editorRef.current?.getModel() as any)?.undo();
+  };
   const redoAction = () => {
-      (editorRef.current?.getModel()as any)?.redo();
-    }
+    (editorRef.current?.getModel() as any)?.redo();
+  };
 
   const UndoButton = (
-      <CodeEditorControl
-          key='undoButton'
-          icon={<UndoIcon/>}
-          aria-label="Undo change"
-          toolTipText="Undo change"
-          onClick={undoAction}
-          isVisible={YAMLData !== ''}
-        />
-    );
+    <CodeEditorControl
+      key="undoButton"
+      icon={<UndoIcon />}
+      aria-label="Undo change"
+      toolTipText="Undo change"
+      onClick={undoAction}
+      isVisible={YAMLData !== ''}
+    />
+  );
 
   const RedoButton = (
-      <CodeEditorControl
-          key='redoButton'
-          icon={<RedoIcon/>}
-          aria-label="Redo change"
-          toolTipText="Redo change"
-          onClick={redoAction}
-          isVisible={YAMLData !== ''}
-      />
-    );
+    <CodeEditorControl
+      key="redoButton"
+      icon={<RedoIcon />}
+      aria-label="Redo change"
+      toolTipText="Redo change"
+      onClick={redoAction}
+      isVisible={YAMLData !== ''}
+    />
+  );
 
   return (
     <StepErrorBoundary>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { StepsAndViewsProvider, YAMLProvider } from '../api';
 import { Catalog, KaotoToolbar, SettingsModal, Visualization, YAMLEditor } from '../components';
+import { ISettings } from '../types';
 import {
   AlertVariant,
   Drawer,
@@ -8,9 +9,8 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { useState } from 'react';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { ISettings } from '../types';
+import { useState } from 'react';
 
 export interface IExpanded {
   catalog?: boolean;
@@ -78,7 +78,7 @@ const Dashboard = () => {
               <Grid>
                 {expanded.codeEditor && (
                   <GridItem span={4}>
-                    <YAMLEditor />
+                    <YAMLEditor dsl={settings.dsl} />
                   </GridItem>
                 )}
                 <GridItem span={expanded.codeEditor ? 8 : 12} className={'visualization'}>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -70,6 +70,7 @@ export interface IViewData {
 
 export interface IVizStepNodeData {
   connectorType: string;
+  dsl: string;
   icon?: string;
   kind?: string;
   label: string;


### PR DESCRIPTION
Changes:
- Include `dsl` in all requests to `/customResource`
- Update deployment requests to `/integrations` to use `dsl` instead of `type`

cc @Delawen 