### PR TITLE
integration name inline edit & other enhancements

### DIFF
--- a/src/components/Catalog.css
+++ b/src/components/Catalog.css
@@ -1,10 +1,19 @@
 
-.catalog--step {
+.catalog__hint {
+    padding: 0.5em !important;
+    border-radius: 10px;
+}
+
+.catalog__hint .pf-c-hint__body {
+    font-size: 0.9em;
+}
+
+.catalog__step {
     border-radius: 15px;
     cursor: grab;
 }
 
-.catalog--stepImage {
+.catalog__stepImage {
     height: 75px;
     width: 75px;
     align-items: center;
@@ -14,33 +23,33 @@
     position: relative;
 }
 
-.catalog--stepLabel {
+.catalog__stepLabel {
     margin-top: 5px !important;
 }
 
 /* MINI CATALOG */
 
 /* Mini Catalog Search */
-.miniCatalog--search.pf-c-toolbar__item {
+.miniCatalog__search.pf-c-toolbar__item {
     width: 100%;
 }
 
 /* Mini Catalog Step (from list) */
-button.miniCatalog--stepItem.pf-c-button.pf-m-tertiary {
+button.miniCatalog__stepItem.pf-c-button.pf-m-tertiary {
     --pf-c-button--after--BorderColor: transparent;
     width: 100%;
 }
 
-button.miniCatalog--stepItem:hover {
+button.miniCatalog__stepItem:hover {
     background: #F5F5F5;
 }
 
-.miniCatalog--stepItem__grid {
+.miniCatalog__stepItem__grid {
     line-height: 40px;
     padding: 2px;
 }
 
-.miniCatalog--stepImage {
+.miniCatalog__stepImage {
     height: 40px;
     width: 40px;
     padding: 0 5px;

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -10,8 +10,8 @@ import {
   Gallery,
   Grid,
   GridItem,
-  HelperText,
-  HelperTextItem,
+  Hint,
+  HintBody,
   InputGroup,
   Label,
   PageSection,
@@ -23,7 +23,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { InfoIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useEffect, useState } from 'react';
 
@@ -116,15 +116,14 @@ export const Catalog = (props: ICatalog) => {
   return (
     <PageSection data-testid={'stepCatalog'}>
       <TextContent>
-        <HelperText>
-          <HelperTextItem icon={<InfoIcon />}>Drag a step onto a circle</HelperTextItem>
-        </HelperText>
+        <Hint className={'catalog__hint'}>
+          <HintBody>
+            <InfoCircleIcon />
+            &nbsp;&nbsp;You can drag a step onto a circle in the visualization
+          </HintBody>
+        </Hint>
       </TextContent>
-      <Toolbar
-        id={'toolbar'}
-        style={{ background: 'transparent' }}
-        className={'stepCatalog-toolbar'}
-      >
+      <Toolbar id={'toolbar'} style={{ background: 'transparent' }} className={'catalog__toolbar'}>
         <ToolbarContent style={{ padding: 0 }}>
           {
             <>
@@ -176,9 +175,9 @@ export const Catalog = (props: ICatalog) => {
             return (
               <Card
                 key={idx}
-                className={'catalog--step'}
+                className={'catalog__step'}
                 isCompact={true}
-                isHoverable={true}
+                isSelectable={true}
                 draggable={'true'}
                 onDragStart={(e: any) => {
                   e.dataTransfer.setData('application/reactflow', 'step');
@@ -190,7 +189,7 @@ export const Catalog = (props: ICatalog) => {
                 <Grid md={6}>
                   <GridItem span={2}>
                     <Bullseye>
-                      <img src={step.icon} className={'catalog--stepImage'} alt={'Step Image'} />
+                      <img src={step.icon} className={'catalog__stepImage'} alt={'Step Image'} />
                     </Bullseye>
                   </GridItem>
                   <GridItem span={7}>
@@ -200,7 +199,7 @@ export const Catalog = (props: ICatalog) => {
                     <CardBody>{shorten(step.description, 60)}</CardBody>
                   </GridItem>
                   <GridItem span={3}>
-                    <Label color={'blue'} className={'catalog--stepLabel'}>
+                    <Label color={'blue'} className={'catalog__stepLabel'}>
                       SOURCE
                     </Label>
                   </GridItem>

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -8,9 +8,11 @@ import {
   DropdownPosition,
   DropdownSeparator,
   DropdownToggle,
+  InputGroup,
   KebabToggle,
   OverflowMenu,
   OverflowMenuControl,
+  TextInput,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -19,10 +21,13 @@ import {
 import {
   BellIcon,
   CatalogIcon,
+  CheckIcon,
   CubesIcon,
+  PencilAltIcon,
   PlayIcon,
   StopIcon,
   ThIcon,
+  TimesIcon,
 } from '@patternfly/react-icons';
 import { useState } from 'react';
 
@@ -32,19 +37,23 @@ export interface IKaotoToolbar {
   handleExpanded: (newState: IExpanded) => void;
   handleStartDeploy: () => void;
   handleStopDeploy: () => void;
+  handleUpdateName: (val: any) => void;
   settings: ISettings;
 }
 
 export const KaotoToolbar = ({
-  deployment,
+  // deployment,
   expanded,
   handleExpanded,
   handleStartDeploy,
   handleStopDeploy,
+  handleUpdateName,
   settings,
 }: IKaotoToolbar) => {
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
   const [appMenuIsOpen, setAppMenuIsOpen] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [localName, setLocalName] = useState<string>(settings.integrationName);
 
   const handleDeployStartClick = () => {
     handleStartDeploy();
@@ -139,9 +148,55 @@ export const KaotoToolbar = ({
 
         <ToolbarItem variant="separator" />
 
-        <ToolbarItem variant="label" id="stacked-example-resource-select">
-          {settings.integrationName ?? 'Integration'}
+        <ToolbarItem variant="label">
+          {isEditingName ? (
+            <InputGroup>
+              <TextInput
+                name="edit-integration-name"
+                id="edit-integration-name"
+                type="text"
+                onChange={(val) => {
+                  handleUpdateName(val);
+                  setLocalName(val);
+                }}
+                value={localName}
+                aria-label="edit integration name"
+              />
+              <Button
+                variant="control"
+                aria-label="save button for editing integration name"
+                onClick={() => {
+                  setIsEditingName(false);
+                }}
+              >
+                <CheckIcon />
+              </Button>
+              <Button
+                variant="control"
+                aria-label="close button for editing integration name"
+                onClick={() => {
+                  setIsEditingName(false);
+                }}
+              >
+                <TimesIcon />
+              </Button>
+            </InputGroup>
+          ) : (
+            <>
+              {settings.integrationName ?? 'Integration'}&nbsp;&nbsp;
+              <Button
+                variant={'link'}
+                onClick={() => {
+                  setIsEditingName(true);
+                }}
+              >
+                <PencilAltIcon />
+              </Button>
+            </>
+          )}
         </ToolbarItem>
+
+        <ToolbarItem variant="separator" />
 
         {/*<ToolbarItem variant="separator" />*/}
 
@@ -163,23 +218,31 @@ export const KaotoToolbar = ({
           </Tooltip>
         </ToolbarItem>
 
-        {deployment ? (
-          <ToolbarItem alignment={{ default: 'alignRight' }}>
-            <div className="status-container">
-              <div className={`dot-${deployment.status}`}></div>
-              <div className="text">{deployment.status}</div>
-            </div>
-          </ToolbarItem>
-        ) : (
-          <ToolbarItem alignment={{ default: 'alignRight' }}>
-            <div className="status-container" data-testid={'toolbar-deployment-status'}>
-              <div className="dot"></div>
-              <div className="text">Running</div>
-            </div>
-          </ToolbarItem>
-        )}
+        {/*{deployment ? (*/}
+        {/*  <ToolbarItem alignment={{ default: 'alignRight' }}>*/}
+        {/*    <div className="status-container">*/}
+        {/*      <div className={`dot-${deployment.status}`}></div>*/}
+        {/*      <div className="text">{deployment.status}</div>*/}
+        {/*    </div>*/}
+        {/*  </ToolbarItem>*/}
+        {/*) : (*/}
+        {/*  <ToolbarItem alignment={{ default: 'alignRight' }}>*/}
+        {/*    <div className="status-container" data-testid={'toolbar-deployment-status'}>*/}
+        {/*      <div className="dot"></div>*/}
+        {/*      <div className="text">Running</div>*/}
+        {/*    </div>*/}
+        {/*  </ToolbarItem>*/}
+        {/*)}*/}
 
-        {deployment && <ToolbarItem variant="separator" />}
+        {/*{deployment && <ToolbarItem variant="separator" />}*/}
+        <ToolbarItem alignment={{ default: 'alignRight' }}>
+          <div className="status-container" data-testid={'toolbar-deployment-status'}>
+            <div className="dot"></div>
+            <div className="text">Running</div>
+          </div>
+        </ToolbarItem>
+
+        <ToolbarItem variant="separator" />
 
         <ToolbarItem>
           <Button

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -42,7 +42,7 @@ export interface IKaotoToolbar {
 }
 
 export const KaotoToolbar = ({
-  // deployment,
+  deployment,
   expanded,
   handleExpanded,
   handleStartDeploy,
@@ -198,14 +198,6 @@ export const KaotoToolbar = ({
 
         <ToolbarItem variant="separator" />
 
-        {/*<ToolbarItem variant="separator" />*/}
-
-        {/*<ToolbarItem>*/}
-        {/*  <Button variant="plain" aria-label="edit">*/}
-        {/*    <CodeIcon />*/}
-        {/*  </Button>*/}
-        {/*</ToolbarItem>*/}
-
         <ToolbarItem>
           <Tooltip content={<div>Step Catalog</div>} position={'bottom'}>
             <Button
@@ -218,31 +210,23 @@ export const KaotoToolbar = ({
           </Tooltip>
         </ToolbarItem>
 
-        {/*{deployment ? (*/}
-        {/*  <ToolbarItem alignment={{ default: 'alignRight' }}>*/}
-        {/*    <div className="status-container">*/}
-        {/*      <div className={`dot-${deployment.status}`}></div>*/}
-        {/*      <div className="text">{deployment.status}</div>*/}
-        {/*    </div>*/}
-        {/*  </ToolbarItem>*/}
-        {/*) : (*/}
-        {/*  <ToolbarItem alignment={{ default: 'alignRight' }}>*/}
-        {/*    <div className="status-container" data-testid={'toolbar-deployment-status'}>*/}
-        {/*      <div className="dot"></div>*/}
-        {/*      <div className="text">Running</div>*/}
-        {/*    </div>*/}
-        {/*  </ToolbarItem>*/}
-        {/*)}*/}
+        {deployment ? (
+          <ToolbarItem alignment={{ default: 'alignRight' }}>
+            <div className="status-container">
+              <div className={`dot-${deployment.status}`}></div>
+              <div className="text">{deployment.status}</div>
+            </div>
+          </ToolbarItem>
+        ) : (
+          <ToolbarItem alignment={{ default: 'alignRight' }}>
+            <div className="status-container" data-testid={'toolbar-deployment-status'}>
+              <div className="dot"></div>
+              <div className="text">Running</div>
+            </div>
+          </ToolbarItem>
+        )}
 
-        {/*{deployment && <ToolbarItem variant="separator" />}*/}
-        <ToolbarItem alignment={{ default: 'alignRight' }}>
-          <div className="status-container" data-testid={'toolbar-deployment-status'}>
-            <div className="dot"></div>
-            <div className="text">Running</div>
-          </div>
-        </ToolbarItem>
-
-        <ToolbarItem variant="separator" />
+        {deployment && <ToolbarItem variant="separator" />}
 
         <ToolbarItem>
           <Button

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -212,7 +212,7 @@ export const KaotoToolbar = ({
 
         {deployment ? (
           <ToolbarItem alignment={{ default: 'alignRight' }}>
-            <div className="status-container">
+            <div className="status-container" data-testid={'toolbar-deployment-status'}>
               <div className={`dot-${deployment.status}`}></div>
               <div className="text">{deployment.status}</div>
             </div>

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -77,7 +77,7 @@ export const MiniCatalog = (props: IMiniCatalog) => {
       <Toolbar id={'toolbar'} style={{ background: 'transparent' }}>
         <ToolbarContent>
           {
-            <ToolbarItem className={'miniCatalog--search'}>
+            <ToolbarItem className={'miniCatalog__search'}>
               <InputGroup>
                 <TextInput
                   name={'stepSearch'}
@@ -104,14 +104,14 @@ export const MiniCatalog = (props: IMiniCatalog) => {
                 onClick={() => {
                   handleSelectStep(step);
                 }}
-                className={'miniCatalog--stepItem'}
+                className={'miniCatalog__stepItem'}
               >
-                <Grid md={6} className={'miniCatalog--stepItem__grid'}>
+                <Grid md={6} className={'miniCatalog__stepItem__grid'}>
                   <GridItem span={3}>
                     <Bullseye>
                       <img
                         src={step.icon}
-                        className={'miniCatalog--stepImage'}
+                        className={'miniCatalog__stepImage'}
                         alt={'Step Image'}
                       />
                     </Bullseye>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -60,8 +60,8 @@ export const SettingsModal = ({
   const [, setYAMLData] = useYAMLContext();
 
   useEffect(() => {
-    // console.log('currentSettings changed.. ', currentSettings);
-  }, [currentSettings]);
+    setLocalSettings({ ...localSettings, integrationName: currentSettings.integrationName });
+  }, [currentSettings.integrationName]);
 
   useEffect(() => {
     const fetchContext = () => {
@@ -130,7 +130,6 @@ export const SettingsModal = ({
       (i: ICompatibleDSLsAndCRDs) => i.dsl === localSettings.dsl
     );
     // update YAML with new compatible DSL/YAML
-    // should I be doing this here though?
     if (newDSL) setYAMLData(newDSL.crd);
 
     handleSaveSettings(localSettings);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -121,6 +121,9 @@ const Dashboard = () => {
               handleExpanded={handleExpanded}
               handleStartDeploy={handleStartDeployment}
               handleStopDeploy={handleStopDeployment}
+              handleUpdateName={(val) => {
+                setSettings({ ...settings, integrationName: val });
+              }}
               settings={settings}
             />
             <Grid>


### PR DESCRIPTION
- minor fix to the helper text for dragging and dropping a step, making it more visible
- inline editing for integration name
- add a `data-testid` to the toolbar

![Screen Shot 2022-06-28 at 3 42 08 pm](https://user-images.githubusercontent.com/3844502/176212766-03953cbd-3efe-4935-b457-bafff53beab1.png)

