### PR TITLE
clear canvas button & confirmation modal

### DIFF
--- a/src/api/IntegrationJsonProvider.tsx
+++ b/src/api/IntegrationJsonProvider.tsx
@@ -8,6 +8,7 @@ interface IIntegrationJsonProvider {
 
 type IntegrationJsonAction =
   | { type: 'ADD_STEP'; payload: { newStep: IStepProps } }
+  | { type: 'DELETE_INTEGRATION'; payload: null }
   | { type: 'DELETE_STEP'; payload: { index: number } }
   | { type: 'REPLACE_STEP'; payload: { newStep: IStepProps; oldStepIndex: number } }
   | { type: 'UPDATE_INTEGRATION'; payload: any };
@@ -16,6 +17,12 @@ export type IUseIntegrationJson = [
   integrationJson: IIntegration,
   dispatch: (action: IntegrationJsonAction) => void | IIntegration
 ];
+
+const initialIntegration: IIntegration = {
+  metadata: { name: 'integration', dsl: 'KameletBinding', namespace: 'default' },
+  steps: [],
+  params: [],
+};
 
 /**
  * Regenerate a UUID for a list of Steps
@@ -46,6 +53,9 @@ function integrationJsonReducer(state: IIntegration, action: IntegrationJsonActi
       payload.newStep.UUID = payload.newStep.name + state.steps.length;
       newSteps.push(payload.newStep);
       return { ...state, steps: newSteps };
+    }
+    case 'DELETE_INTEGRATION': {
+      return { ...initialIntegration };
     }
     case 'DELETE_STEP': {
       let stepsCopy = state.steps.slice();
@@ -93,14 +103,7 @@ function IntegrationJsonProvider({ initialState, children }: IIntegrationJsonPro
 /**
  * Create context
  */
-const IntegrationJsonContext = createContext<IUseIntegrationJson>([
-  {
-    metadata: { name: 'Integration', dsl: 'KameletBinding', namespace: 'default' },
-    steps: [],
-    params: [],
-  },
-  () => {},
-]);
+const IntegrationJsonContext = createContext<IUseIntegrationJson>([initialIntegration, () => {}]);
 
 /**
  * Convenience hook

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,0 +1,63 @@
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+export interface IConfirmationModal {
+  handleCancel: () => void;
+  handleConfirm: () => void;
+  isModalOpen: boolean;
+  modalTitle?: string;
+  modalBody?: string;
+}
+
+/**
+ * Contains the contents for the Confirmation modal.
+ * @param handleCancel
+ * @param handleConfirm
+ * @param isModalOpen
+ * @param modalBody
+ * @param modalTitle
+ * @constructor
+ */
+export const ConfirmationModal = ({
+  handleCancel,
+  handleConfirm,
+  isModalOpen,
+  modalBody,
+  modalTitle,
+}: IConfirmationModal) => {
+  const onCancel = () => {
+    handleCancel();
+  };
+
+  const onConfirm = () => {
+    handleConfirm();
+  };
+
+  return (
+    <div className={'confirmation-modal'} data-testid={'confirmation-modal'}>
+      <Modal
+        actions={[
+          <Button key="confirm" variant="primary" onClick={onConfirm}>
+            Confirm
+          </Button>,
+          <Button key="cancel" variant="link" onClick={onCancel}>
+            Cancel
+          </Button>,
+        ]}
+        aria-describedby="modal-description"
+        isOpen={isModalOpen}
+        onClose={handleCancel}
+        className={'customClass'}
+        // titleIconVariant={'warning'}
+        titleIconVariant={ExclamationTriangleIcon}
+        title={modalTitle ?? 'Confirmation'}
+        variant={ModalVariant.small}
+      >
+        <span id="modal-description">
+          {modalBody ??
+            'WARNING! This action is not reversible. Are you sure you would like to proceed?'}
+        </span>
+      </Modal>
+    </div>
+  );
+};

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,11 +1,13 @@
 import {
   startDeployment,
   stopDeployment,
+  useIntegrationJsonContext,
   useIntegrationSourceContext,
   useSettingsContext,
 } from '../api';
 import { IExpanded } from '../pages/Dashboard';
 import { canBeDeployed, isNameValidCheck } from '../utils/validationService';
+import { ConfirmationModal } from './ConfirmationModal';
 import {
   AlertVariant,
   Button,
@@ -34,6 +36,7 @@ import {
   StopIcon,
   ThIcon,
   TimesIcon,
+  TrashIcon,
 } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useState } from 'react';
@@ -53,9 +56,11 @@ export const KaotoToolbar = ({
 }: IKaotoToolbar) => {
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
   const [appMenuIsOpen, setAppMenuIsOpen] = useState(false);
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [settings, setSettings] = useSettingsContext();
   const [localName, setLocalName] = useState(settings.name);
+  const [, dispatch] = useIntegrationJsonContext();
   const [sourceCode] = useIntegrationSourceContext();
   const [nameValidation, setNameValidation] = useState<
     'default' | 'warning' | 'success' | 'error' | undefined
@@ -175,6 +180,7 @@ export const KaotoToolbar = ({
   return (
     <Toolbar className={'viz-toolbar'} data-testid={'viz-toolbar'}>
       <ToolbarContent>
+        {/* App Menu */}
         <ToolbarItem>
           <Dropdown
             onSelect={onSelectAppMenu}
@@ -196,6 +202,38 @@ export const KaotoToolbar = ({
 
         <ToolbarItem variant="separator" />
 
+        {/* Delete/Clear Button */}
+        <ToolbarItem>
+          <Tooltip content={<div>Clear</div>} position={'bottom'}>
+            <Button
+              tabIndex={0}
+              variant="link"
+              data-testid={'toolbar-delete-btn'}
+              icon={<TrashIcon />}
+              onClick={() => {
+                // verify with user first
+                setIsConfirmationModalOpen(true);
+              }}
+            />
+          </Tooltip>
+        </ToolbarItem>
+
+        {/* Step Catalog Button */}
+        <ToolbarItem>
+          <Tooltip content={<div>Step Catalog</div>} position={'bottom'}>
+            <Button
+              tabIndex={0}
+              variant="link"
+              data-testid={'toolbar-step-catalog-btn'}
+              icon={<CatalogIcon />}
+              onClick={() => handleExpanded({ catalog: !expanded.catalog, codeEditor: false })}
+            />
+          </Tooltip>
+        </ToolbarItem>
+
+        <ToolbarItem variant="separator" />
+
+        {/* Name */}
         <ToolbarItem variant="label">
           {isEditingName ? (
             <InputGroup>
@@ -255,20 +293,6 @@ export const KaotoToolbar = ({
               </Button>
             </>
           )}
-        </ToolbarItem>
-
-        <ToolbarItem variant="separator" />
-
-        <ToolbarItem>
-          <Tooltip content={<div>Step Catalog</div>} position={'bottom'}>
-            <Button
-              tabIndex={0}
-              variant="link"
-              data-testid={'toolbar-step-catalog-btn'}
-              icon={<CatalogIcon />}
-              onClick={() => handleExpanded({ catalog: !expanded.catalog, codeEditor: false })}
-            />
-          </Tooltip>
         </ToolbarItem>
 
         {deployment ? (
@@ -349,6 +373,20 @@ export const KaotoToolbar = ({
           </OverflowMenu>
         </ToolbarItem>
       </ToolbarContent>
+      <ConfirmationModal
+        handleCancel={() => {
+          setIsConfirmationModalOpen(false);
+        }}
+        handleConfirm={() => {
+          dispatch({ type: 'DELETE_INTEGRATION', payload: null });
+          setIsConfirmationModalOpen(false);
+        }}
+        isModalOpen={isConfirmationModalOpen}
+        modalBody={
+          'This will clear the whole canvas, and you will lose your current work. Are you sure you will' +
+          ' like to proceed?'
+        }
+      />
     </Toolbar>
   );
 };

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -172,221 +172,223 @@ export const KaotoToolbar = ({
       Feedback
     </DropdownItem>,
     <DropdownSeparator key="separator" />,
-    <DropdownItem key="delete" component="button" isDisabled>
+    <DropdownItem key="delete" component="button" onClick={() => setIsConfirmationModalOpen(true)}>
       Delete
     </DropdownItem>,
   ];
 
   return (
-    <Toolbar className={'viz-toolbar'} data-testid={'viz-toolbar'}>
-      <ToolbarContent>
-        {/* App Menu */}
-        <ToolbarItem>
-          <Dropdown
-            onSelect={onSelectAppMenu}
-            toggle={
-              <DropdownToggle
-                toggleIndicator={null}
-                onToggle={(e) => setAppMenuIsOpen(e)}
-                aria-label="Applications"
-                id="toggle-icon-only"
-              >
-                <ThIcon />
-              </DropdownToggle>
-            }
-            isOpen={appMenuIsOpen}
-            isPlain
-            dropdownItems={appMenuItems}
-          />
-        </ToolbarItem>
-
-        <ToolbarItem variant="separator" />
-
-        {/* Delete/Clear Button */}
-        <ToolbarItem>
-          <Tooltip content={<div>Clear</div>} position={'bottom'}>
-            <Button
-              tabIndex={0}
-              variant="link"
-              data-testid={'toolbar-delete-btn'}
-              icon={<TrashIcon />}
-              onClick={() => {
-                // verify with user first
-                setIsConfirmationModalOpen(true);
-              }}
+    <>
+      <Toolbar className={'viz-toolbar'} data-testid={'viz-toolbar'}>
+        <ToolbarContent>
+          {/* App Menu */}
+          <ToolbarItem>
+            <Dropdown
+              onSelect={onSelectAppMenu}
+              toggle={
+                <DropdownToggle
+                  toggleIndicator={null}
+                  onToggle={(e) => setAppMenuIsOpen(e)}
+                  aria-label="Applications"
+                  id="toggle-icon-only"
+                >
+                  <ThIcon />
+                </DropdownToggle>
+              }
+              isOpen={appMenuIsOpen}
+              isPlain
+              dropdownItems={appMenuItems}
             />
-          </Tooltip>
-          <ConfirmationModal
-            handleCancel={() => {
-              setIsConfirmationModalOpen(false);
-            }}
-            handleConfirm={() => {
-              dispatch({ type: 'DELETE_INTEGRATION', payload: null });
-              setIsConfirmationModalOpen(false);
-            }}
-            isModalOpen={isConfirmationModalOpen}
-            modalBody={
-              'This will clear the whole canvas, and you will lose your current work. Are you sure you will' +
-              ' like to proceed?'
-            }
-          />
-        </ToolbarItem>
+          </ToolbarItem>
 
-        {/* Step Catalog Button */}
-        <ToolbarItem>
-          <Tooltip content={<div>Step Catalog</div>} position={'bottom'}>
-            <Button
-              tabIndex={0}
-              variant="link"
-              data-testid={'toolbar-step-catalog-btn'}
-              icon={<CatalogIcon />}
-              onClick={() => handleExpanded({ catalog: !expanded.catalog, codeEditor: false })}
-            />
-          </Tooltip>
-        </ToolbarItem>
+          <ToolbarItem variant="separator" />
 
-        <ToolbarItem variant="separator" />
-
-        {/* Name */}
-        <ToolbarItem variant="label">
-          {isEditingName ? (
-            <InputGroup>
-              <TextInput
-                name="edit-integration-name"
-                id="edit-integration-name"
-                type="text"
-                onChange={(val) => {
-                  setLocalName(val);
-                  if (isNameValidCheck(val)) {
-                    setNameValidation('success');
-                  } else {
-                    setNameValidation('error');
-                  }
-                }}
-                value={localName}
-                aria-label="edit integration name"
-                validated={nameValidation}
-                aria-invalid={nameValidation === 'error'}
-              />
+          {/* Delete/Clear Button */}
+          <ToolbarItem>
+            <Tooltip content={<div>Clear</div>} position={'bottom'}>
               <Button
-                variant="plain"
-                aria-label="save button for editing integration name"
+                tabIndex={0}
+                variant="link"
+                data-testid={'toolbar-delete-btn'}
+                icon={<TrashIcon />}
                 onClick={() => {
-                  if (isNameValidCheck(localName)) {
+                  // verify with user first
+                  setIsConfirmationModalOpen(true);
+                }}
+              />
+            </Tooltip>
+          </ToolbarItem>
+
+          {/* Step Catalog Button */}
+          <ToolbarItem>
+            <Tooltip content={<div>Step Catalog</div>} position={'bottom'}>
+              <Button
+                tabIndex={0}
+                variant="link"
+                data-testid={'toolbar-step-catalog-btn'}
+                icon={<CatalogIcon />}
+                onClick={() => handleExpanded({ catalog: !expanded.catalog, codeEditor: false })}
+              />
+            </Tooltip>
+          </ToolbarItem>
+
+          <ToolbarItem variant="separator" />
+
+          {/* Name */}
+          <ToolbarItem variant="label">
+            {isEditingName ? (
+              <InputGroup>
+                <TextInput
+                  name="edit-integration-name"
+                  id="edit-integration-name"
+                  type="text"
+                  onChange={(val) => {
+                    setLocalName(val);
+                    if (isNameValidCheck(val)) {
+                      setNameValidation('success');
+                    } else {
+                      setNameValidation('error');
+                    }
+                  }}
+                  value={localName}
+                  aria-label="edit integration name"
+                  validated={nameValidation}
+                  aria-invalid={nameValidation === 'error'}
+                />
+                <Button
+                  variant="plain"
+                  aria-label="save button for editing integration name"
+                  onClick={() => {
+                    if (isNameValidCheck(localName)) {
+                      setIsEditingName(false);
+                      setSettings({ ...settings, name: localName });
+                    }
+                  }}
+                  aria-disabled={nameValidation === 'error'}
+                  isDisabled={nameValidation === 'error'}
+                >
+                  <CheckIcon />
+                </Button>
+                <Button
+                  variant="plain"
+                  aria-label="close button for editing integration name"
+                  onClick={() => {
+                    setLocalName(settings.name);
+                    setNameValidation('default');
                     setIsEditingName(false);
-                    setSettings({ ...settings, name: localName });
-                  }
-                }}
-                aria-disabled={nameValidation === 'error'}
-                isDisabled={nameValidation === 'error'}
-              >
-                <CheckIcon />
-              </Button>
-              <Button
-                variant="plain"
-                aria-label="close button for editing integration name"
-                onClick={() => {
-                  setLocalName(settings.name);
-                  setNameValidation('default');
-                  setIsEditingName(false);
-                }}
-              >
-                <TimesIcon />
-              </Button>
-            </InputGroup>
+                  }}
+                >
+                  <TimesIcon />
+                </Button>
+              </InputGroup>
+            ) : (
+              <>
+                {settings.name}&nbsp;&nbsp;
+                <Button
+                  variant={'link'}
+                  onClick={() => {
+                    setIsEditingName(true);
+                  }}
+                >
+                  <PencilAltIcon />
+                </Button>
+              </>
+            )}
+          </ToolbarItem>
+
+          {deployment ? (
+            <ToolbarItem alignment={{ default: 'alignRight' }}>
+              <div className="status-container" data-testid={'toolbar-deployment-status'}>
+                <div className={`dot`}></div>
+                <div className="text">Running</div>
+              </div>
+            </ToolbarItem>
           ) : (
-            <>
-              {settings.name}&nbsp;&nbsp;
-              <Button
-                variant={'link'}
-                onClick={() => {
-                  setIsEditingName(true);
-                }}
-              >
-                <PencilAltIcon />
-              </Button>
-            </>
+            <ToolbarItem alignment={{ default: 'alignRight' }}></ToolbarItem>
           )}
-        </ToolbarItem>
 
-        {deployment ? (
-          <ToolbarItem alignment={{ default: 'alignRight' }}>
-            <div className="status-container" data-testid={'toolbar-deployment-status'}>
-              <div className={`dot`}></div>
-              <div className="text">Running</div>
-            </div>
-          </ToolbarItem>
-        ) : (
-          <ToolbarItem alignment={{ default: 'alignRight' }}></ToolbarItem>
-        )}
+          {deployment && <ToolbarItem variant="separator" />}
 
-        {deployment && <ToolbarItem variant="separator" />}
-
-        <ToolbarItem>
-          <Tooltip content={<div>Source Code</div>} position={'bottom'}>
-            <Button
-              variant={expanded.codeEditor ? 'primary' : 'secondary'}
-              data-testid={'toolbar-show-code-btn'}
-              onClick={() => handleExpanded({ codeEditor: !expanded.codeEditor, catalog: false })}
-            >
-              Code
-            </Button>
-          </Tooltip>
-        </ToolbarItem>
-
-        {/*<ToolbarItem>*/}
-        {/*  <Button*/}
-        {/*    variant="primary"*/}
-        {/*    data-testid={'toolbar-save-btn'}*/}
-        {/*    onClick={() => alert('YAY')}*/}
-        {/*    isDisabled*/}
-        {/*  >*/}
-        {/*    Save*/}
-        {/*  </Button>*/}
-        {/*</ToolbarItem>*/}
-
-        {canBeDeployed() ? (
           <ToolbarItem>
-            <Tooltip content={<div>Deploy</div>} position={'bottom'}>
+            <Tooltip content={<div>Source Code</div>} position={'bottom'}>
               <Button
-                tabIndex={0}
-                variant="link"
-                data-testid={'toolbar-deploy-start-btn'}
-                icon={<PlayIcon />}
-                onClick={handleDeployStartClick}
-              />
+                variant={expanded.codeEditor ? 'primary' : 'secondary'}
+                data-testid={'toolbar-show-code-btn'}
+                onClick={() => handleExpanded({ codeEditor: !expanded.codeEditor, catalog: false })}
+              >
+                Code
+              </Button>
             </Tooltip>
           </ToolbarItem>
-        ) : (
-          <ToolbarItem>
-            <Tooltip content={<div>Stop</div>} position={'bottom'}>
-              <Button
-                tabIndex={0}
-                variant="link"
-                icon={<StopIcon />}
-                data-testid={'toolbar-deploy-stop-btn'}
-                onClick={handleDeployStopClick}
-                isDisabled={true}
-              />
-            </Tooltip>
-          </ToolbarItem>
-        )}
 
-        <ToolbarItem variant="overflow-menu">
-          <OverflowMenu breakpoint="2xl">
-            <OverflowMenuControl hasAdditionalOptions>
-              <Dropdown
-                position={DropdownPosition.right}
-                toggle={<KebabToggle onToggle={(val) => setKebabIsOpen(val)} />}
-                isOpen={kebabIsOpen}
-                isPlain
-                data-testid={'toolbar-kebab-dropdown-btn'}
-                dropdownItems={kebabItems}
-              />
-            </OverflowMenuControl>
-          </OverflowMenu>
-        </ToolbarItem>
-      </ToolbarContent>
-    </Toolbar>
+          {/*<ToolbarItem>*/}
+          {/*  <Button*/}
+          {/*    variant="primary"*/}
+          {/*    data-testid={'toolbar-save-btn'}*/}
+          {/*    onClick={() => alert('YAY')}*/}
+          {/*    isDisabled*/}
+          {/*  >*/}
+          {/*    Save*/}
+          {/*  </Button>*/}
+          {/*</ToolbarItem>*/}
+
+          {canBeDeployed() ? (
+            <ToolbarItem>
+              <Tooltip content={<div>Deploy</div>} position={'bottom'}>
+                <Button
+                  tabIndex={0}
+                  variant="link"
+                  data-testid={'toolbar-deploy-start-btn'}
+                  icon={<PlayIcon />}
+                  onClick={handleDeployStartClick}
+                />
+              </Tooltip>
+            </ToolbarItem>
+          ) : (
+            <ToolbarItem>
+              <Tooltip content={<div>Stop</div>} position={'bottom'}>
+                <Button
+                  tabIndex={0}
+                  variant="link"
+                  icon={<StopIcon />}
+                  data-testid={'toolbar-deploy-stop-btn'}
+                  onClick={handleDeployStopClick}
+                  isDisabled={true}
+                />
+              </Tooltip>
+            </ToolbarItem>
+          )}
+
+          <ToolbarItem variant="overflow-menu">
+            <OverflowMenu breakpoint="2xl">
+              <OverflowMenuControl hasAdditionalOptions>
+                <Dropdown
+                  position={DropdownPosition.right}
+                  toggle={<KebabToggle onToggle={(val) => setKebabIsOpen(val)} />}
+                  isOpen={kebabIsOpen}
+                  isPlain
+                  data-testid={'toolbar-kebab-dropdown-btn'}
+                  dropdownItems={kebabItems}
+                />
+              </OverflowMenuControl>
+            </OverflowMenu>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+      <ConfirmationModal
+        handleCancel={() => {
+          setIsConfirmationModalOpen(false);
+        }}
+        handleConfirm={() => {
+          dispatch({ type: 'DELETE_INTEGRATION', payload: null });
+          setIsConfirmationModalOpen(false);
+        }}
+        isModalOpen={isConfirmationModalOpen}
+        modalBody={
+          'This will clear the whole canvas, and you will lose your current work. Are you sure you will' +
+          ' like to proceed?'
+        }
+      />
+    </>
   );
 };

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -216,6 +216,20 @@ export const KaotoToolbar = ({
               }}
             />
           </Tooltip>
+          <ConfirmationModal
+            handleCancel={() => {
+              setIsConfirmationModalOpen(false);
+            }}
+            handleConfirm={() => {
+              dispatch({ type: 'DELETE_INTEGRATION', payload: null });
+              setIsConfirmationModalOpen(false);
+            }}
+            isModalOpen={isConfirmationModalOpen}
+            modalBody={
+              'This will clear the whole canvas, and you will lose your current work. Are you sure you will' +
+              ' like to proceed?'
+            }
+          />
         </ToolbarItem>
 
         {/* Step Catalog Button */}
@@ -373,20 +387,6 @@ export const KaotoToolbar = ({
           </OverflowMenu>
         </ToolbarItem>
       </ToolbarContent>
-      <ConfirmationModal
-        handleCancel={() => {
-          setIsConfirmationModalOpen(false);
-        }}
-        handleConfirm={() => {
-          dispatch({ type: 'DELETE_INTEGRATION', payload: null });
-          setIsConfirmationModalOpen(false);
-        }}
-        isModalOpen={isConfirmationModalOpen}
-        modalBody={
-          'This will clear the whole canvas, and you will lose your current work. Are you sure you will' +
-          ' like to proceed?'
-        }
-      />
     </Toolbar>
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Catalog';
+export * from './ConfirmationModal';
 export * from './DeploymentsModal';
 export * from './ErrorBoundary';
 export * from './Extension';
@@ -7,10 +8,10 @@ export * from './MASAlerts';
 export * from './MASLoading';
 export * from './MiniCatalog';
 export * from './SettingsModal';
+export * from './SourceCodeEditor';
 export * from './StepErrorBoundary';
 export * from './StepExtensionApi';
 export * from './StepViews';
 export * from './Visualization';
 export * from './VisualizationSlot';
 export * from './VisualizationStep';
-export * from './SourceCodeEditor';

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 export interface IExpanded {
   catalog?: boolean;
   codeEditor?: boolean;
+  confirmationModal?: boolean;
   deploymentsModal?: boolean;
   settingsModal?: boolean;
 }


### PR DESCRIPTION
this adds the ability to clear the canvas with a button, and a confirmation modal that can be reused throughout the app. also moved the buttons to the left of the integration name as I think this looks cleaner and will "scale" better.

cc @mmelko 

![Screen Shot 2022-07-08 at 1 22 35 pm](https://user-images.githubusercontent.com/3844502/177991392-af14c434-804d-4e99-9836-bc1feb9a70e3.png)

![Screen Shot 2022-07-08 at 1 22 41 pm](https://user-images.githubusercontent.com/3844502/177991404-35ceb808-8e26-439e-80c2-8765b6b6305d.png)

cc @mmelko there is a bug (I think) in PatternFly that shows this when we use the `titleIconVariant={'warning'}` instead of our own custom icon `titleIconVariant={ExclamationTriangleIcon}`, which is a shame because we would have to do our styling to get the icon to be orange. Not sure if you'd want to help with this until we are able to get it fixed in PF?

![Screen Shot 2022-07-08 at 1 22 56 pm](https://user-images.githubusercontent.com/3844502/177991664-dbee2a4d-f693-4905-9f2e-c36ad7baceb7.png)

