### PR TITLE
add deployment type & error warning

### DIFF
--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -196,11 +196,7 @@ export const DeploymentsModal = ({
                   <Td dataLabel={columnNames.errors}>{dep.errors.length}</Td>
                   <Td dataLabel={columnNames.status}>{dep.status.phase}</Td>
                   <Td isActionCell>
-                    <ActionsColumn
-                      items={defaultActions(dep)}
-                      // isDisabled={dep.name === '4'}
-                      // actionsToggle={customActionsToggle}
-                    />
+                    <ActionsColumn items={defaultActions(dep)} />
                   </Td>
                 </Tr>
               ))}

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -1,6 +1,6 @@
 import { fetchDeployments, stopDeployment, useSettingsContext } from '../api';
 import { IDeployment } from '../types';
-import { usePrevious } from '../utils';
+import { formatDateTime, usePrevious } from '../utils';
 import {
   Button,
   EmptyState,
@@ -192,7 +192,7 @@ export const DeploymentsModal = ({
                 <Tr key={rowIndex}>
                   <Td dataLabel={columnNames.name}>{dep.name}</Td>
                   <Td dataLabel={columnNames.namespace}>{dep.namespace}</Td>
-                  <Td dataLabel={columnNames.date}>{dep.date}</Td>
+                  <Td dataLabel={columnNames.date}>{formatDateTime(dep.date)}</Td>
                   <Td dataLabel={columnNames.errors}>{dep.errors.length}</Td>
                   <Td dataLabel={columnNames.status}>{dep.status.phase}</Td>
                   <Td isActionCell>

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -12,6 +12,7 @@ import {
   Popover,
   Title,
   AlertVariant,
+  Badge,
 } from '@patternfly/react-core';
 import { CubesIcon, HelpIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import {
@@ -86,6 +87,7 @@ export const DeploymentsModal = ({
     date: 'Date',
     errors: 'Errors',
     status: 'Status',
+    type: 'Type',
   };
 
   const defaultActions = (deployment: IDeployment): IAction[] => [
@@ -98,8 +100,8 @@ export const DeploymentsModal = ({
   ];
 
   const getSortableRowValues = (deployment: IDeployment) => {
-    const { name, namespace, date, errors, status } = deployment;
-    return [name, namespace, date, errors, status];
+    const { name, namespace, date, errors, status, type } = deployment;
+    return [name, namespace, date, errors, status, type];
   };
 
   let sortedDeployments = deployments;
@@ -184,6 +186,7 @@ export const DeploymentsModal = ({
                 </Th>
                 <Th modifier="wrap">{columnNames.errors}</Th>
                 <Th modifier="wrap">{columnNames.status}</Th>
+                <Th modifier="wrap">{columnNames.type}</Th>
                 <Th></Th>
               </Tr>
             </Thead>
@@ -202,7 +205,12 @@ export const DeploymentsModal = ({
                     )}
                     {dep.errors.length}
                   </Td>
-                  <Td dataLabel={columnNames.status}>{dep.status.phase}</Td>
+                  <Td dataLabel={columnNames.status}>{dep.status}</Td>
+                  <Td dataLabel={columnNames.type}>
+                    <Badge key={rowIndex} isRead>
+                      {dep.type}
+                    </Badge>
+                  </Td>
                   <Td isActionCell>
                     <ActionsColumn items={defaultActions(dep)} />
                   </Td>

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -13,7 +13,7 @@ import {
   Title,
   AlertVariant,
 } from '@patternfly/react-core';
-import { CubesIcon, HelpIcon } from '@patternfly/react-icons';
+import { CubesIcon, HelpIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import {
   TableComposable,
   Thead,
@@ -193,7 +193,15 @@ export const DeploymentsModal = ({
                   <Td dataLabel={columnNames.name}>{dep.name}</Td>
                   <Td dataLabel={columnNames.namespace}>{dep.namespace}</Td>
                   <Td dataLabel={columnNames.date}>{formatDateTime(dep.date)}</Td>
-                  <Td dataLabel={columnNames.errors}>{dep.errors.length}</Td>
+                  <Td dataLabel={columnNames.errors}>
+                    {dep.errors.length > 0 && (
+                      <span>
+                        <WarningTriangleIcon />
+                        &nbsp;&nbsp;
+                      </span>
+                    )}
+                    {dep.errors.length}
+                  </Td>
                   <Td dataLabel={columnNames.status}>{dep.status.phase}</Td>
                   <Td isActionCell>
                     <ActionsColumn items={defaultActions(dep)} />

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -32,7 +32,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
   useEffect(() => {
     if (previousName === settings.name) return;
     let tmpInt = integrationJson;
-    tmpInt.metadata = { ...settings };
+    tmpInt.metadata = { ...integrationJson.metadata, ...settings };
     fetchIntegrationSourceCode(tmpInt).then((newSrc) => {
       if (typeof newSrc === 'string') setSourceCode(newSrc);
     });
@@ -50,7 +50,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       fetchIntegrationJson(incomingData, settings.dsl)
         .then((res: IIntegration) => {
           let tmpInt = res;
-          tmpInt.metadata = { ...settings };
+          tmpInt.metadata = { ...res.metadata, ...settings };
           dispatch({ type: 'UPDATE_INTEGRATION', payload: tmpInt });
         })
         .catch((e) => {

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -93,7 +93,7 @@ const Visualization = ({ handleUpdateViews, toggleCatalog, views }: IVisualizati
     fetchIntegrationJson(source, settings.dsl)
       .then((newIntegration) => {
         let tmpInt = newIntegration;
-        tmpInt.metadata = { ...settings };
+        tmpInt.metadata = { ...newIntegration.metadata, ...settings };
         dispatch({ type: 'UPDATE_INTEGRATION', payload: tmpInt });
       })
       .catch((err) => {
@@ -112,7 +112,7 @@ const Visualization = ({ handleUpdateViews, toggleCatalog, views }: IVisualizati
     const filteredSteps = integrationJsonSteps.filter((step) => step.type);
     let tempInt = integrationJson;
     tempInt.steps = filteredSteps;
-    tempInt.metadata = { ...settings };
+    tempInt.metadata = { ...integrationJson.metadata, ...settings };
 
     fetchIntegrationSourceCode(tempInt)
       .then((value) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,22 +16,16 @@ declare global {
 
 export interface IDeployment {
   date: string;
+  // array of errors
   errors: any[];
+  // name of integration/deployment
   name: string;
+  // defaults to 'default'
   namespace?: string;
-  status: {
-    conditions?: [
-      {
-        lastTransitionTime: string;
-        lastUpdateTime: string;
-        status: string;
-        type: string;
-      }
-    ];
-    phase?: string;
-    replicas?: number;
-    selector?: string;
-  };
+  // e.g. 'Invalid', 'Running', 'Creating', 'Stopped'
+  status: 'Invalid' | 'Creating' | 'Running' | 'Stopped';
+  // e.g. 'Kamelet', 'KameletBinding'
+  type: string;
 }
 
 export interface ISettings {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,6 +20,12 @@ export function findStepIdxWithUUID(UUID: string, steps: IStepProps[]) {
   return steps.map((s) => s.UUID).indexOf(UUID);
 }
 
+export function formatDateTime(date: string) {
+  return new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'long' }).format(
+    Date.parse(date)
+  );
+}
+
 export function truncateString(str: string, num: number) {
   if (str.length > num) {
     return str.slice(0, num) + '..';


### PR DESCRIPTION
- add deployment type with badge to deployment list
- show warning triangle to users if more than one error in deployment list
- parse date and time of deployment
- fix issue with metadata being overridden (@Delawen )

### Deployment Type
![Screen Shot 2022-07-08 at 2 48 03 pm](https://user-images.githubusercontent.com/3844502/178006291-2fcff117-aef4-458f-859a-f5dd5475b716.png)

### Warning Icon
(this was before adding deployment type to list)
![Screen Shot 2022-07-08 at 2 33 34 pm](https://user-images.githubusercontent.com/3844502/178006378-50b44a7f-456a-407a-82d5-26aac40c64b9.png)


cc @mmelko 