### PR TITLE
fix issue with mini catalog over-filtering

### DIFF
--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -195,7 +195,9 @@ export const DeploymentsModal = ({
             <Tbody>
               {sortedDeployments.map((dep, rowIndex) => (
                 <Tr key={rowIndex}>
-                  <Td dataLabel={columnNames.name}>{dep.name}</Td>
+                  <Td dataLabel={columnNames.name}>
+                    <b>{dep.name}</b>
+                  </Td>
                   <Td dataLabel={columnNames.namespace}>{dep.namespace}</Td>
                   <Td dataLabel={columnNames.date}>{formatDateTime(dep.date)}</Td>
                   <Td dataLabel={columnNames.errors}>

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -180,8 +180,10 @@ export const DeploymentsModal = ({
             <Thead>
               <Tr>
                 <Th sort={getSortParams(0)}>{columnNames.name}</Th>
-                <Th modifier="wrap">{columnNames.namespace}</Th>
-                <Th modifier="wrap" sort={getSortParams(2)} info={{ tooltip: 'More information ' }}>
+                <Th modifier="wrap" info={{ tooltip: 'Cluster namespace' }}>
+                  {columnNames.namespace}
+                </Th>
+                <Th modifier="wrap" sort={getSortParams(2)}>
                   {columnNames.date}
                 </Th>
                 <Th modifier="wrap">{columnNames.errors}</Th>

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -342,7 +342,6 @@ export const KaotoToolbar = ({
                   icon={<StopIcon />}
                   data-testid={'toolbar-deploy-stop-btn'}
                   onClick={handleDeployStopClick}
-                  isDisabled={true}
                 />
               </Tooltip>
             </ToolbarItem>

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -6,7 +6,7 @@ import {
   useSettingsContext,
 } from '../api';
 import { IExpanded } from '../pages/Dashboard';
-import { canBeDeployed, isNameValidCheck } from '../utils/validationService';
+import { isNameValidCheck } from '../utils/validationService';
 import { ConfirmationModal } from './ConfirmationModal';
 import {
   AlertVariant,
@@ -321,18 +321,7 @@ export const KaotoToolbar = ({
             </Tooltip>
           </ToolbarItem>
 
-          {/*<ToolbarItem>*/}
-          {/*  <Button*/}
-          {/*    variant="primary"*/}
-          {/*    data-testid={'toolbar-save-btn'}*/}
-          {/*    onClick={() => alert('YAY')}*/}
-          {/*    isDisabled*/}
-          {/*  >*/}
-          {/*    Save*/}
-          {/*  </Button>*/}
-          {/*</ToolbarItem>*/}
-
-          {canBeDeployed() ? (
+          {!deployment ? (
             <ToolbarItem>
               <Tooltip content={<div>Deploy</div>} position={'bottom'}>
                 <Button

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -374,7 +374,7 @@ export const KaotoToolbar = ({
         }}
         isModalOpen={isConfirmationModalOpen}
         modalBody={
-          'This will clear the whole canvas, and you will lose your current work. Are you sure you will' +
+          'This will clear the whole canvas, and you will lose your current work. Are you sure you would' +
           ' like to proceed?'
         }
       />

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -51,15 +51,15 @@ export const MiniCatalog = (props: IMiniCatalog) => {
     }
   }, []);
 
-  const changeSearch = (e: any) => {
+  const changeSearch = (e: string) => {
     setQuery(e);
   };
 
-  function search(items: any[]) {
+  function search(items: IStepProps[]) {
     return items.filter((item) => item.name.toLowerCase().indexOf(query.toLowerCase()) > -1);
   }
 
-  function handleSelectStep(selectedStep: any) {
+  function handleSelectStep(selectedStep: IStepProps) {
     if (props.handleSelectStep) {
       props.handleSelectStep(selectedStep);
     }

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -1,5 +1,5 @@
 import { fetchCatalogSteps } from '../api';
-import { IStepProps } from '../types';
+import { IStepProps, IStepQueryParams } from '../types';
 import {
   AlertVariant,
   Bullseye,
@@ -17,14 +17,7 @@ import { useEffect, useState } from 'react';
 
 export interface IMiniCatalog {
   handleSelectStep?: (selectedStep: any) => void;
-  queryParams?: {
-    // e.g. 'KameletBinding'
-    dsl?: string;
-    // e.g. 'Kamelet'
-    kind?: string;
-    // e.g. 'START', 'END', 'MIDDLE'
-    type?: string;
-  };
+  queryParams?: IStepQueryParams;
   steps?: IStepProps[];
 }
 

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -51,7 +51,6 @@ const VisualizationStep = ({ data }: IVisualizationStep) => {
               handleSelectStep={onMiniCatalogClickAdd}
               queryParams={{
                 dsl: data.dsl,
-                kind: data.kind,
                 type: appendableStepTypes(data.connectorType),
               }}
             />

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -63,24 +63,19 @@ export interface IIntegrationParams {
 }
 
 export interface IStepProps {
-  apiVersion?: string;
+  branches?: IStepPropsBranch[];
   description?: string;
-
-  // ?
   group?: string;
   icon?: string;
   id?: string;
 
-  // ?
-  kameletType?: string;
-
   // e.g. 'Kamelet', 'Camel-Connector', 'EIP'
   kind?: string;
   name: string;
-  parameters?: IStepPropsParameters[];
 
-  // should be 'KAMELET' for now
-  subType?: string;
+  // parameters provided for this step
+  parameters?: IStepPropsParameters[];
+  required?: string[];
   title?: string;
 
   // e.g. 'START', 'MIDDLE', 'END'
@@ -88,6 +83,15 @@ export interface IStepProps {
 
   // generated only for integration steps
   UUID?: string;
+}
+
+export interface IStepPropsBranch {
+  steps?: IStepProps[];
+  parameters?: IStepPropsParameters[];
+}
+
+export interface IStepPropsParameters {
+  [key: string]: any;
 }
 
 export interface IStepQueryParams {
@@ -99,10 +103,6 @@ export interface IStepQueryParams {
   namespace?: string;
   // e.g. 'START', 'END', 'MIDDLE'
   type?: string;
-}
-
-export interface IStepPropsParameters {
-  [key: string]: any;
 }
 
 export interface IViewConstraintsProps {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,7 +74,7 @@ export interface IStepProps {
   // ?
   kameletType?: string;
 
-  // e.g. 'Kamelet'
+  // e.g. 'Kamelet', 'Camel-Connector', 'EIP'
   kind?: string;
   name: string;
   parameters?: IStepPropsParameters[];
@@ -88,6 +88,17 @@ export interface IStepProps {
 
   // generated only for integration steps
   UUID?: string;
+}
+
+export interface IStepQueryParams {
+  // e.g. 'KameletBinding', 'Kamelet'
+  dsl?: string;
+  // e.g. 'Kamelet', 'Camel-Connector', 'EIP'
+  kind?: string;
+  // cluster namespace, defaults to 'default' if not provided
+  namespace?: string;
+  // e.g. 'START', 'END', 'MIDDLE'
+  type?: string;
 }
 
 export interface IStepPropsParameters {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { IStepProps } from '../types';
+import { IDeployment, IStepProps } from '../types';
 import { useEffect, useRef } from 'react';
 
 export function accessibleRouteChangeHandler() {
@@ -8,6 +8,10 @@ export function accessibleRouteChangeHandler() {
       mainContainer.focus();
     }
   }, 50);
+}
+
+export function findDeploymentFromList(name: string, deployments: IDeployment[]) {
+  return deployments.find((dep) => dep.name === name);
 }
 
 /**

--- a/src/utils/validationService.ts
+++ b/src/utils/validationService.ts
@@ -18,19 +18,6 @@ export function appendableStepTypes(existingStepType: string): string {
   return possibleSteps;
 }
 
-export function canBeDeployed(): boolean {
-  // console.log('check if can be deployed: ', integrationSteps);
-  // let valid = true;
-  // in order for an integration to be deployable, it needs to have at least
-  // one step, and no mis-configured steps or placeholders
-  // if (integrationSteps > 0 && integrationSteps[0].type !== 'slot') {
-  //   valid = true;
-  // }
-
-  // return valid;
-  return true;
-}
-
 /**
  * Checks whether a proposed step can be inserted between two existing steps.
  * @param _previousStep

--- a/src/utils/validationService.ts
+++ b/src/utils/validationService.ts
@@ -101,9 +101,5 @@ export function canStepBeReplaced(
  */
 export function isNameValidCheck(name: string) {
   const regexPattern = /^[a-z\d]([-a-z\d]*[a-z\d])?(\.[a-z\d]([-a-z\d]*[a-z\d])?)*$/gm;
-  if (!regexPattern.test(name)) {
-    return false;
-  } else {
-    return true;
-  }
+  return regexPattern.test(name);
 }


### PR DESCRIPTION
- fix an issue where the `kind` is getting added to requests for the mini catalog, leaving less steps to select than it should
- re-enable "stop deployment" button
- additional typings and cleanup