### PR TITLE
bug fixes for deployment

### DIFF
--- a/src/api/IntegrationJsonProvider.tsx
+++ b/src/api/IntegrationJsonProvider.tsx
@@ -55,7 +55,7 @@ function integrationJsonReducer(state: IIntegration, action: IntegrationJsonActi
       return { ...state, steps: newSteps };
     }
     case 'DELETE_INTEGRATION': {
-      return { ...initialIntegration };
+      return initialIntegration;
     }
     case 'DELETE_STEP': {
       let stepsCopy = state.steps.slice();

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -27,19 +27,24 @@ export async function fetchCapabilities(namespace?: string) {
 /**
  * Fetch all Catalog Steps, optionally with specified query params
  * @param queryParams
+ * @param cache
  */
-export async function fetchCatalogSteps(queryParams?: {
-  // e.g. 'KameletBinding'
-  dsl?: string;
-  // e.g. 'Kamelet'
-  kind?: string;
-  // e.g. 'START', 'END', 'MIDDLE'
-  type?: string;
-  namespace?: string;
-}) {
+export async function fetchCatalogSteps(
+  queryParams?: {
+    // e.g. 'KameletBinding'
+    dsl?: string;
+    // e.g. 'Kamelet'
+    kind?: string;
+    // e.g. 'START', 'END', 'MIDDLE'
+    type?: string;
+    namespace?: string;
+  },
+  cache?: RequestCache | undefined
+) {
   try {
     const resp = await request.get({
       endpoint: `${apiVersion}/steps`,
+      cache,
       queryParams: {
         ...queryParams,
         namespace: queryParams?.namespace ?? 'default',

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -34,7 +34,11 @@ function shorten(str: string, maxLen: number, separator = ' ') {
   return str.substr(0, str.lastIndexOf(separator, maxLen)) + '..';
 }
 
-export const Catalog = () => {
+export interface ICatalog {
+  currentDeployment?: string;
+}
+
+export const Catalog = ({ currentDeployment }: ICatalog) => {
   // If the catalog data won't be changing, consider removing this state
   const [catalogData, setCatalogData] = useState<IStepProps[]>([]);
   const [isSelected, setIsSelected] = useState('START');
@@ -50,6 +54,29 @@ export const Catalog = () => {
    */
   useEffect(() => {
     if (previousDSL === settings.dsl) return;
+    fetchCatalogSteps({
+      dsl: settings.dsl,
+    })
+      .then((value) => {
+        if (value) {
+          value.sort((a: IStepProps, b: IStepProps) => a.name.localeCompare(b.name));
+          setCatalogData(value);
+        }
+      })
+      .catch((e) => {
+        console.error(e);
+        addAlert &&
+          addAlert({
+            title: 'Something went wrong',
+            variant: AlertVariant.danger,
+            description: 'There was a problem fetching the catalog steps. Please try again later.',
+          });
+      });
+  }, [settings.dsl]);
+
+  useEffect(() => {
+    // verify that we actually need this, as the API
+    // isn't returning deployed kamelets in time anyway
     fetchCatalogSteps(
       {
         dsl: settings.dsl,
@@ -71,7 +98,7 @@ export const Catalog = () => {
             description: 'There was a problem fetching the catalog steps. Please try again later.',
           });
       });
-  }, [settings.dsl]);
+  }, [currentDeployment]);
 
   const changeSearch = (e: any) => {
     setQuery(e);

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -29,6 +29,7 @@ import { useEffect, useState } from 'react';
 
 // Shorten a string to less than maxLen characters without truncating words.
 function shorten(str: string, maxLen: number, separator = ' ') {
+  if (!str) return;
   if (str.length <= maxLen) return str;
   return str.substr(0, str.lastIndexOf(separator, maxLen)) + '..';
 }
@@ -192,7 +193,7 @@ export const Catalog = () => {
                     <CardTitle>
                       <span>{step.name}</span>
                     </CardTitle>
-                    <CardBody>{shorten(step.description, 60)}</CardBody>
+                    <CardBody>{shorten(step?.description, 60)}</CardBody>
                   </GridItem>
                   <GridItem span={3}>
                     <Label

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -50,9 +50,12 @@ export const Catalog = () => {
    */
   useEffect(() => {
     if (previousDSL === settings.dsl) return;
-    fetchCatalogSteps({
-      dsl: settings.dsl,
-    })
+    fetchCatalogSteps(
+      {
+        dsl: settings.dsl,
+      },
+      'no-cache'
+    )
       .then((value) => {
         if (value) {
           value.sort((a: IStepProps, b: IStepProps) => a.name.localeCompare(b.name));

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -1,6 +1,7 @@
 import { fetchDeployments, stopDeployment, useSettingsContext } from '../api';
 import { IDeployment } from '../types';
 import { formatDateTime, usePrevious } from '../utils';
+import { CustomExclamationTriangleIcon } from './Icons';
 import {
   Button,
   EmptyState,
@@ -14,7 +15,7 @@ import {
   AlertVariant,
   Badge,
 } from '@patternfly/react-core';
-import {CubesIcon, HelpIcon} from '@patternfly/react-icons';
+import { CubesIcon, HelpIcon } from '@patternfly/react-icons';
 import {
   TableComposable,
   Thead,
@@ -28,7 +29,6 @@ import {
 } from '@patternfly/react-table';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useEffect, useState } from 'react';
-import {CustomExclamationTriangleIcon} from "./Icons";
 
 export interface IDeploymentsModal {
   currentDeployment?: string;
@@ -60,7 +60,7 @@ export const DeploymentsModal = ({
 
   useEffect(() => {
     // fetch deployments
-    fetchDeployments()
+    fetchDeployments('no-cache')
       .then((output) => {
         setDeployments(output);
       })
@@ -73,7 +73,7 @@ export const DeploymentsModal = ({
   useEffect(() => {
     if (previousDeployment === currentDeployment) return;
     // fetch deployments
-    fetchDeployments()
+    fetchDeployments('no-cache')
       .then((output) => {
         setDeployments(output);
       })
@@ -204,7 +204,7 @@ export const DeploymentsModal = ({
                   <Td dataLabel={columnNames.errors}>
                     {dep.errors.length > 0 && (
                       <span>
-                        <CustomExclamationTriangleIcon color='red' />
+                        <CustomExclamationTriangleIcon color="red" />
                         &nbsp;&nbsp;
                       </span>
                     )}

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -60,7 +60,7 @@ export const DeploymentsModal = ({
 
   useEffect(() => {
     // fetch deployments
-    fetchDeployments('no-cache')
+    fetchDeployments('no-cache', settings.namespace)
       .then((output) => {
         setDeployments(output);
       })
@@ -73,7 +73,7 @@ export const DeploymentsModal = ({
   useEffect(() => {
     if (previousDeployment === currentDeployment) return;
     // fetch deployments
-    fetchDeployments('no-cache')
+    fetchDeployments('no-cache', settings.namespace)
       .then((output) => {
         setDeployments(output);
       })

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -134,6 +134,15 @@ export const DeploymentsModal = ({
   const handleDeleteDeployment = (deployment: IDeployment) => {
     stopDeployment(deployment.name, settings.namespace)
       .then(() => {
+        // fetch deployments
+        fetchDeployments('no-cache', settings.namespace)
+          .then((output) => {
+            setDeployments(output);
+          })
+          .catch((e) => {
+            throw Error(e);
+          });
+
         addAlert &&
           addAlert({
             title: 'Deleted Deployment',

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -50,9 +50,9 @@ export const DeploymentsModal = ({
 }: IDeploymentsModal) => {
   const [deployments, setDeployments] = useState<IDeployment[]>([]);
   const [settings] = useSettingsContext();
-  const [activeSortIndex, setActiveSortIndex] = useState<number | undefined>(undefined);
+  const [activeSortIndex, setActiveSortIndex] = useState<number | undefined>(2);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | undefined>(
-    undefined
+    'desc'
   );
   const previousDeployment = usePrevious(currentDeployment);
 

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -374,6 +374,7 @@ export const KaotoToolbar = ({
         }}
         handleConfirm={() => {
           dispatch({ type: 'DELETE_INTEGRATION', payload: null });
+          setSettings({ dsl: 'KameletBinding', name: 'integration', namespace: 'default' });
           setIsConfirmationModalOpen(false);
         }}
         isModalOpen={isConfirmationModalOpen}

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  fetchIntegrationSourceCode,
   startDeployment,
   stopDeployment,
   useIntegrationJsonContext,
@@ -60,8 +61,8 @@ export const KaotoToolbar = ({
   const [isEditingName, setIsEditingName] = useState(false);
   const [settings, setSettings] = useSettingsContext();
   const [localName, setLocalName] = useState(settings.name);
-  const [, dispatch] = useIntegrationJsonContext();
-  const [sourceCode] = useIntegrationSourceContext();
+  const [integrationJson, dispatch] = useIntegrationJsonContext();
+  const [sourceCode, setSourceCode] = useIntegrationSourceContext();
   const [nameValidation, setNameValidation] = useState<
     'default' | 'warning' | 'success' | 'error' | undefined
   >('default');
@@ -262,6 +263,11 @@ export const KaotoToolbar = ({
                     if (isNameValidCheck(localName)) {
                       setIsEditingName(false);
                       setSettings({ ...settings, name: localName });
+                      let tmpInt = integrationJson;
+                      tmpInt.metadata = { ...integrationJson.metadata, ...settings };
+                      fetchIntegrationSourceCode(tmpInt, settings.namespace).then((newSrc) => {
+                        if (typeof newSrc === 'string') setSourceCode(newSrc);
+                      });
                     }
                   }}
                   aria-disabled={nameValidation === 'error'}

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -94,7 +94,7 @@ export const KaotoToolbar = ({
 
   const handleDeployStopClick = () => {
     try {
-      stopDeployment(settings.name).then((res) => {
+      stopDeployment(settings.name, settings.namespace).then((res) => {
         console.log('stop deployment response: ', res);
 
         addAlert &&

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -105,7 +105,7 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
   const onSave = () => {
     setSettings(localSettings);
     let tmpInt = integrationJson;
-    tmpInt.metadata = { ...localSettings, ...integrationJson.metadata };
+    tmpInt.metadata = { ...integrationJson.metadata, ...localSettings };
 
     fetchIntegrationSourceCode(tmpInt)
       .then((source) => {

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -3,14 +3,12 @@ import {
   useIntegrationSourceContext,
   useIntegrationJsonContext,
   useSettingsContext,
-  fetchIntegrationSourceCode,
 } from '../api';
 import { IIntegration } from '../types';
-import { usePrevious } from '../utils';
 import { StepErrorBoundary } from './StepErrorBoundary';
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
 import { RedoIcon, UndoIcon } from '@patternfly/react-icons';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import EditorDidMount from 'react-monaco-editor';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -25,18 +23,8 @@ interface ISourceCodeEditor {
 const SourceCodeEditor = (props: ISourceCodeEditor) => {
   const editorRef = useRef<EditorDidMount['editor'] | null>(null);
   const [sourceCode, setSourceCode] = useIntegrationSourceContext();
-  const [integrationJson, dispatch] = useIntegrationJsonContext();
+  const [, dispatch] = useIntegrationJsonContext();
   const [settings] = useSettingsContext();
-  const previousName = usePrevious(settings.name);
-
-  useEffect(() => {
-    if (previousName === settings.name) return;
-    let tmpInt = integrationJson;
-    tmpInt.metadata = { ...integrationJson.metadata, ...settings };
-    fetchIntegrationSourceCode(tmpInt).then((newSrc) => {
-      if (typeof newSrc === 'string') setSourceCode(newSrc);
-    });
-  }, [settings.name]);
 
   /**
    * On detected changes to YAML state, issue POST to external endpoint

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -62,7 +62,7 @@ const Dashboard = () => {
                   </GridItem>
                 ) : expanded.catalog ? (
                   <GridItem span={3}>
-                    <Catalog />
+                    <Catalog currentDeployment={deployment} />
                   </GridItem>
                 ) : (
                   <></>


### PR DESCRIPTION
- fix issue where deployment sometimes uses old integration name
- sort deployment list automatically by date/time (wasn't doing this by default before)
- fix issue where the UI explodes on new kamelet deployment due to string shortening of nonexistent string
- refresh catalog list again on new deployment, though it seems the backend still isn't returning an up-to-date list of steps (cc @Delawen ), unlike the deployment list, so it still won't show the new kamelet.
- automatically remove the deployment from the list once it's been deleted without having to refresh
- allow overriding cache setting for requests to fetch catalog steps