### PR TITLE
KaotoIO/kaoto-component-library#2 Remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,12 +119,6 @@
     "webpack-merge": "^5.8.0",
     "whatwg-fetch": "^3.6.2"
   },
-  "peerDependencies": {
-    "@patternfly/patternfly": "4.210.2",
-    "@patternfly/react-core": "4.235.7",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  },
   "lint-staged": {
     "*.js": "eslint --cache --fix",
     "*.{tsx,ts}": "prettier --write",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,7 +3,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
-const { dependencies, federatedModuleName, peerDependencies } = require('./package.json');
+const { dependencies, federatedModuleName } = require('./package.json');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
@@ -101,29 +101,6 @@ module.exports = () => {
         // exposes: ['./src/@kaoto/index.ts'],
         shared: {
           ...deps,
-          react: {
-            eager: true,
-            singleton: true,
-            requiredVersion: peerDependencies['react'],
-          },
-          'react-dom': {
-            eager: true,
-            singleton: true,
-            requiredVersion: peerDependencies['react-dom'],
-          },
-          'react-router-dom': {
-            requiredVersion: dependencies['react-router-dom'],
-          },
-          '@patternfly/patternfly/': {
-            singleton: true,
-            eager: true,
-            requiredVersion: peerDependencies['@patternfly/patternfly'],
-          },
-          '@patternfly/react-core/': {
-            singleton: true,
-            eager: true,
-            requiredVersion: peerDependencies['@patternfly/react-core'],
-          },
         },
       }),
       // new FederatedTypesPlugin(),


### PR DESCRIPTION
Using peer dependencies is causing build errors in
kaoto-component-library. A workaround would have been to use `npm
install --legacy-peer-deps` but seems better to not have to have extra
parameter to provide in dependent projects

Is there something to check carefully when removing a peer dependencies? What are the drawbacks of not having it?