### PR TITLE
Fetch default namespace from the backend

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -24,6 +24,18 @@ export async function fetchCapabilities(namespace?: string) {
   }
 }
 
+export async function fetchDefaultNamespace() {
+  try {
+    const resp = await request.get({
+      endpoint: `${apiVersion}/capabilities/namespace`,
+      contentType: 'application/json',
+    });
+    return await resp.json();
+  } catch (err) {
+    return err;
+  }
+}
+
 /**
  * Fetch all Catalog Steps, optionally with specified query params
  * @param queryParams

--- a/src/components/DeploymentsModal.tsx
+++ b/src/components/DeploymentsModal.tsx
@@ -56,25 +56,29 @@ export const DeploymentsModal = ({ handleCloseModal, isModalOpen }: IDeployments
 
   useEffect(() => {
     // fetch deployments
-    fetchDeployments('no-cache', settings.namespace)
-      .then((output) => {
-        setDeployments(output);
-      })
-      .catch((e) => {
-        throw Error(e);
-      });
+    if (settings.namespace !== '') {
+      fetchDeployments('no-cache', settings.namespace)
+          .then((output) => {
+            setDeployments(output);
+          })
+          .catch((e) => {
+            throw Error(e);
+          });
+    }
   }, [settings.namespace]);
 
   // on changes to deployment, re-fetch list of deployments
   useEffect(() => {
     // fetch deployments
-    fetchDeployments('no-cache', settings.namespace)
-      .then((output) => {
-        setDeployments(output);
-      })
-      .catch((e) => {
-        throw Error(e);
-      });
+    if (settings.namespace !== '') {
+      fetchDeployments('no-cache', settings.namespace)
+          .then((output) => {
+            setDeployments(output);
+          })
+          .catch((e) => {
+            throw Error(e);
+          });
+    }
   }, [deployment, settings.namespace]);
 
   const columnNames = {

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,4 +1,4 @@
-import { startDeployment } from '@kaoto/api';
+import {fetchDefaultNamespace, startDeployment} from '@kaoto/api';
 import {
   AppearanceModal,
   ConfirmationModal,
@@ -75,6 +75,15 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor }: IKaotoToolbar)
   useEffect(() => {
     setLocalName(settings.name);
   }, [settings.name]);
+
+  // fetch default namespace from the API,
+  useEffect(() => {
+    fetchDefaultNamespace().then(data => {
+      const newSettings = settings;
+      newSettings.namespace = data.namespace;
+      setSettings(newSettings);
+    });
+  }, [])
 
   const handleDeployStartClick = () => {
     startDeployment(sourceCode, settings.name, settings.namespace)

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -40,6 +40,7 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
   const { setSourceCode } = useIntegrationSourceStore();
   const previousIntegrationJson = usePrevious(integrationJson);
   const previousName = usePrevious(localSettings.name);
+  const previousNamespace = usePrevious(localSettings.namespace);
   const [nameValidation, setNameValidation] = useState<
     'default' | 'warning' | 'success' | 'error' | undefined
   >('default');
@@ -54,6 +55,12 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
     if (settings.name === previousName) return;
     setLocalSettings({ ...localSettings, name: settings.name });
   }, [settings.name]);
+
+  useEffect(() => {
+    // update settings with the default namespace fetched from the API
+    if (settings.namespace === previousNamespace) return;
+    setLocalSettings({ ...localSettings, namespace: settings.namespace });
+  }, [settings.namespace]);
 
   useEffect(() => {
     if (previousIntegrationJson === integrationJson) return;

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -14,7 +14,7 @@ const initialSettings: ISettings = {
   dsl: 'KameletBinding',
   icon: svg,
   name: 'integration',
-  namespace: 'default',
+  namespace: '',
 };
 
 export const useSettingsStore = create<ISettingsStore>((set) => ({


### PR DESCRIPTION
close #726 
fetching the default namespace is done in useEffects KaotoModal.  Also fetching of deployments were done even before so I added checks to fetch deployments only if there is namespace set. 

There is probably a better way how to do this but I'm not sure yet. 