### PR TITLE
fix(miniCatalog): fetch mini catalog steps using updated dsl

### DIFF
--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -34,8 +34,8 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
   const [catalogData, setCatalogData] = useState<IStepProps[]>([]);
   const [isSelected, setIsSelected] = useState('START');
   const [query, setQuery] = useState(``);
-  const { settings } = useSettingsStore();
-  const previousDSL = usePrevious(settings.dsl);
+  const dsl = useSettingsStore((state) => state.settings.dsl);
+  const previousDSL = usePrevious(dsl);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const { addAlert } = useAlert() || {};
@@ -45,9 +45,9 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
    * Checks for changes to the settings for DSL
    */
   useEffect(() => {
-    if (previousDSL === settings.dsl) return;
+    if (previousDSL === dsl) return;
     fetchCatalogSteps({
-      dsl: settings.dsl,
+      dsl,
     })
       .then((value) => {
         if (value) {
@@ -65,8 +65,7 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
           });
       });
     searchInputRef.current?.focus();
-  }, [settings.dsl]);
-
+  }, [dsl]);
 
   const changeSearch = (e: any) => {
     setQuery(e);

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -1,4 +1,5 @@
 import { fetchCatalogSteps } from '@kaoto/api';
+import { useSettingsStore } from '@kaoto/store';
 import { IStepProps, IStepQueryParams } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
 import {
@@ -28,17 +29,22 @@ export interface IMiniCatalog {
 export const MiniCatalog = (props: IMiniCatalog) => {
   const [catalogData, setCatalogData] = useState<IStepProps[]>(props.steps ?? []);
   const [query, setQuery] = useState(``);
+  const dsl = useSettingsStore((state) => state.settings.dsl);
   const typesAllowedArray = props.queryParams?.type?.split(',');
   const [isSelected, setIsSelected] = useState(typesAllowedArray ? typesAllowedArray[0] : 'MIDDLE');
 
   const { addAlert } = useAlert() || {};
   const searchInputRef = useRef<HTMLInputElement>(null);
+
   /**
    * Sort & fetch all Steps for the Catalog
    */
   useEffect(() => {
     if (!props.steps) {
-      fetchCatalogSteps(props.queryParams)
+      fetchCatalogSteps({
+        ...props.queryParams,
+        dsl,
+      })
         .then((value) => {
           if (value) {
             value.sort((a: IStepProps, b: IStepProps) => a.name.localeCompare(b.name));
@@ -56,7 +62,7 @@ export const MiniCatalog = (props: IMiniCatalog) => {
         });
     }
     searchInputRef.current?.focus();
-  }, []);
+  }, [dsl]);
 
   const changeSearch = (e: string) => {
     setQuery(e);

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -1,15 +1,13 @@
 import './PlusButtonEdge.css';
 import { MiniCatalog } from '@kaoto/components';
 import { findStepIdxWithUUID, insertableStepTypes } from '@kaoto/services';
-import { useIntegrationJsonStore, useSettingsStore } from '@kaoto/store';
+import { useIntegrationJsonStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
 import { Popover } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { getBezierPath, Node, Position, useNodes, useReactFlow } from 'reactflow';
 
 const foreignObjectSize = 40;
-
-const currentDSL = useSettingsStore.getState().settings.dsl;
 const insertStep = useIntegrationJsonStore.getState().insertStep;
 
 export interface IPlusButtonEdge {
@@ -80,7 +78,6 @@ const PlusButtonEdge = ({
               <MiniCatalog
                 handleSelectStep={onMiniCatalogClickInsert}
                 queryParams={{
-                  dsl: currentDSL,
                   type: insertableStepTypes(nodes[currentIdx - 1]?.data, nodes[currentIdx]?.data),
                 }}
               />


### PR DESCRIPTION
Changes:
- Update Mini Catalog on changing DSL
- Update Mini Catalog fetch request to use updated Settings DSL
- Prevent passing entire `settings` object to main Catalog

fixes #789 