### PR TITLE
Add a waiting screen instead of blank page

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -20,7 +20,7 @@ export async function fetchCapabilities(namespace?: string) {
 
     return await resp.json();
   } catch (err) {
-    return err;
+    throw new Error(`Unable to fetch Cababilities ${err}`);
   }
 }
 

--- a/src/components/WaitingPage.tsx
+++ b/src/components/WaitingPage.tsx
@@ -1,0 +1,83 @@
+import { fetchCapabilities } from '@kaoto/api';
+import { sleep } from '@kaoto/utils';
+import {
+  Grid,
+  GridItem,
+  Icon,
+  Page,
+  PageSection,
+  Spinner,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { useEffect, useState } from 'react';
+
+interface ILoadingScreen {
+  setBackendAvailable: (b: boolean) => void;
+}
+const WaitingPage = ({ setBackendAvailable }: ILoadingScreen) => {
+  const [message, setMessage] = useState('Trying to reach the Kaoto API');
+  const [fetching, setFetching] = useState(true);
+
+  // Method that tries to connect to capabilities endpoint and evaluate if the API is available
+  const tryApiAvailable = (retries: number) => {
+    fetchCapabilities()
+      .then((resp) => {
+        if (resp) {
+          setBackendAvailable(true);
+        }
+      })
+      .catch(() => {
+        if (retries > 0) {
+          sleep(1000).then(() => {
+            tryApiAvailable(retries - 1);
+          });
+        } else {
+          setBackendAvailable(false);
+          setMessage('Kaoto API is unreachable');
+          setFetching(false);
+        }
+      });
+  };
+
+  useEffect(() => {
+    // try to fetch api for 120seconds
+    tryApiAvailable(120);
+  }, []);
+  return (
+    <Page>
+      <PageSection isFilled={true}>
+        <Grid
+          hasGutter
+          style={{
+            display: 'flex',
+            height: '100%',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <GridItem span={12}>
+            {!fetching && (
+              <Icon size="lg">
+                <ExclamationCircleIcon style={{ color: 'red' }} />
+              </Icon>
+            )}
+            {fetching && <Spinner isSVG diameter="60px" aria-label="Backend loading" />}
+          </GridItem>
+          <GridItem span={12}>
+            <TextContent>
+              <Text className={'--pf-global--Color--200'} component={TextVariants.h3}>
+                {message}
+              </Text>
+            </TextContent>
+          </GridItem>
+        </Grid>
+      </PageSection>
+    </Page>
+  );
+};
+
+export default WaitingPage;

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,14 +1,15 @@
 // @ts-ignore
 import logo from '../assets/images/logo-kaoto.png';
+import WaitingPage from '../components/WaitingPage';
 import { Page, PageHeader, SkipToContent } from '@patternfly/react-core';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 interface IAppLayout {
   children: ReactNode;
 }
-
 const AppLayout = ({ children }: IAppLayout) => {
+  const [backendAvailable, setBackendAvailable] = useState(false);
   function LogoImg() {
     const history = useHistory();
     function handleClick() {
@@ -35,7 +36,7 @@ const AppLayout = ({ children }: IAppLayout) => {
   );
   return (
     <Page mainContainerId={pageId} header={Header} skipToContent={PageSkipToContent}>
-      {children}
+      {backendAvailable ? children : <WaitingPage setBackendAvailable={setBackendAvailable} />}
     </Page>
   );
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -82,3 +82,6 @@ export function bindUndoRedo(undoCallback: () => void, redoCallback: () => void)
 export function unbindUndoRedo(callback: (event: KeyboardEvent) => void) {
   document.removeEventListener('keydown', callback);
 }
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Waiting screen in case of backend unavailability is added. Kaoto will try to fetch capabilities endpoint for 120s. 

close #826 

![loading2](https://user-images.githubusercontent.com/6814482/198557423-a57eb45e-f79a-49f1-8692-50049675b500.gif)
