### PR TITLE
chore: bump kaoto version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaoto-ui",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "private": false,
   "federatedModuleName": "kaoto",
   "engines": {


### PR DESCRIPTION
@apupier @Delawen - maybe we can do something about the fact that I always forget to bump the version in the `package.json` before a release. 😂  We need to do this in order to publish the correct npm package version.