### PR TITLE
chore : package-ecosystem in dependabot for yarn shoudl use npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "yarn" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#supported-repositories-and-ecosystems


https://github.com/KaotoIO/kaoto-ui/network/updates
![image](https://user-images.githubusercontent.com/1105127/200524439-bbc78b87-3bef-4d21-bd8e-de7b0c16bfcd.png)

