### PR TITLE
chore: revert to previous scoped package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kaoto-ui",
+  "name": "@kaoto/kaoto-ui",
   "version": "0.4.1",
   "private": false,
   "federatedModuleName": "kaoto",


### PR DESCRIPTION
@apupier will this be a problem for the vscode-plugin? this is so that we can publish to the kaoto org with the nice scoped name like we did previously: `@kaoto/kaoto-ui`