### PR TITLE
fix(Catalog): Avoid creating gaps between steps. #797

### DIFF
--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -155,7 +155,7 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
       </Toolbar>
       <Gallery
         hasGutter={true}
-        style={{ flex: '1 1', overflow: 'auto', padding: '0 10px' }}
+        style={{ flex: '1 1', overflow: 'auto', padding: '0 10px', alignContent: 'flex-start' }}
       >
         {catalogData &&
           search(catalogData).map((step, idx) => {


### PR DESCRIPTION
At the moment, the Catalog component doesn't have the align-content property set, forcing its children to fill the entire available space. This behaves as `align-content: stretch`.

Setting the `align-content` property to `flex-start` aligns its children to the top, without forcing them to grow.

This handles #797

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/16512618/200959921-1e332d3d-95a7-48cf-a779-b1fecd16713a.png) | ![image](https://user-images.githubusercontent.com/16512618/200959630-bc8e785e-baf5-473c-af30-a91131f90043.png) |

I've taken the information from this article:
https://css-tricks.com/snippets/css/a-guide-to-flexbox/

