### PR TITLE
chore(ci): add github action to bump version & publish package

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 🔒 CodeQL
 
 on:
   push:

--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -1,4 +1,4 @@
-name: 🧐 Generate Docker image
+name: 🐳 Generate Docker image
 on:
   pull_request:
     branches:
@@ -13,7 +13,6 @@ on:
     - cron:  '12 0 * * *'
 jobs:
   build:
-    name: 👩🏼‍🏭 Build Docker Image 👩🏼‍🏭
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -8,7 +8,6 @@ jobs:
     steps:
       - name: 'Checkout source code'
         uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
       - name: 'cat package.json'
         run: cat ./package.json
       - name: 'Bump package.json version'

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,0 +1,19 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@kaoto'
+      - run: yarn
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -14,6 +14,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@kaoto'
       - run: yarn
+      - run: yarn build
       - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,7 +1,4 @@
 name: 🏷 Bump Version & 📦 Publish Package to npm
-on:
-  release:
-    types: [created]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,7 +8,7 @@ jobs:
       - name: 'cat package.json'
         run: cat ./package.json
       - name: 'Bump package.json version'
-        uses: 'phips28/gh-action-bump-version@master'
+        uses: 'phips28/gh-action-bump-version@v9.0.42'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,4 +1,5 @@
 name: 🏷 Bump Version & 📦 Publish Package to npm
+on: workflow_dispatch
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,4 +1,4 @@
-name: Publish Package to npmjs
+name: 🏷 Bump Version & 📦 Publish Package to npm
 on:
   release:
     types: [created]
@@ -6,8 +6,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
       # Setup .npmrc file to publish to npm
+      - name: 'cat package.json'
+        run: cat ./package.json
+      - name: 'Bump package.json version'
+        uses: 'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          skip-tag: 'true'
+      - name: 'cat package.json'
+        run: cat ./package.json
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
@@ -15,6 +26,7 @@ jobs:
           scope: '@kaoto'
       - run: yarn
       - run: yarn build
-      - run: yarn publish
+      - name: 📦 Publish Package to npm
+        run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/roadmap-add-epics.yml
+++ b/.github/workflows/roadmap-add-epics.yml
@@ -1,4 +1,4 @@
-name: ✨ Add epics to Roadmap ✨
+name: ✨ Add Epics to Roadmap ✨
 
 on:
   issues:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to run Kaoto-ui in your machine, follow these instructions. Remember
 
 ### Requirements
 
-- Node >= 14
+- Node >= 16
 - [Yarn](https://classic.yarnpkg.com/en/docs/install#mac-stable) (1.x)
 
 ### Install & Setup

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "federatedModuleName": "kaoto",
   "engines": {
-    "node": ">=14.x"
+    "node": ">=16.x"
   },
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## Changes
- adds a new github action with steps to bump the version in `package.json` and subsequently publish the package to npm
- bump minimum node version to >= v16.x
- updates some emojis 🤪

implements #859 