### PR TITLE
fix(KaotoToolbar): Focus input when editing integration name. #768

### DIFF
--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -41,7 +41,7 @@ import {
   TimesIcon,
 } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface IKaotoToolbar {
   toggleCatalog: () => void;
@@ -58,6 +58,9 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor }: IKaotoToolbar)
   const [appMenuIsOpen, setAppMenuIsOpen] = useState(false);
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
+  const focusIntegrationInput = useCallback(( element: HTMLInputElement ) => {
+    element?.focus();
+  }, []);
   const [localName, setLocalName] = useState(settings.name);
   const [nameValidation, setNameValidation] = useState<
     'default' | 'warning' | 'success' | 'error' | undefined
@@ -250,6 +253,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor }: IKaotoToolbar)
                   id="edit-integration-name"
                   data-testid={'kaoto-toolbar--name__edit'}
                   type="text"
+                  ref={focusIntegrationInput}
                   onChange={(val) => {
                     // save to local state while typing
                     setLocalName(val);


### PR DESCRIPTION
### Context
Currently, when clicking on the edit button labeled with a pencil icon, enables the edit mode but doesn't focus on the input field.

This commit adds a callback to be executed whenever the input field appears to set focus on it and avoid the need to click on it to start editing.

I've chosen a `ref={}` property combined with an `useCallback` hook to execute the focus only once per editing cycle. It seems that there's no other `InputField` at the same time competing with the focus, so probably this is not a hard requirement but still a good idea IMHO 🤔.

Relates to #768

### Before - No focus on editing
https://user-images.githubusercontent.com/16512618/201195461-a07fb4eb-7172-43dc-867f-378a406bff06.mp4

### After - Focusing Input field upon editing
https://user-images.githubusercontent.com/16512618/201195497-1accf208-3c0f-4272-9240-37d5f16a2815.mp4

