### PR TITLE
chore(ci): add job names to make status checks required

### DIFF
--- a/.github/workflows/generate-docker-image.yml
+++ b/.github/workflows/generate-docker-image.yml
@@ -13,6 +13,7 @@ on:
     - cron:  '12 0 * * *'
 jobs:
   build:
+    name: 🐳 Generate Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/generate-draft-release.yml
+++ b/.github/workflows/generate-draft-release.yml
@@ -1,4 +1,4 @@
-name: 🏷 Generate Draft Release 🎁
+name: 🏷 Generate Draft Release
 
 on:
   push:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: 🧪 Unit Tests (Jest) 🧪
+name: 🧪 Unit Tests (Jest)
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: 🧪 Unit Tests (Jest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
In order to list a status check as required, the job must contain a name, and the workflow name does not count.