### PR TITLE
chore: update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaoto/kaoto-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": false,
   "federatedModuleName": "kaoto",
   "engines": {


### PR DESCRIPTION
@Delawen - this is so that we can do another release for v0.4.2, create a tag, and test if the workflows are 1) correctly creating a draft release, and 2) publishing the new package to the npm registry on creating the new release.

After all of that, we'll have to create a new PR that manually updates the `package.json` with `v0.4.3-dev`, until we can automate this further down the line.

cc @apupier 