### PR TITLE
chore: bump to v0.4.3, change to use dist

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -15,6 +15,7 @@ jobs:
           scope: '@kaoto'
       - run: yarn
       - run: yarn build
+      - run: yarn build:lib
       - name: 📦 Publish Package to npm
         run: yarn publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaoto/kaoto-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "federatedModuleName": "kaoto",
   "engines": {
@@ -167,7 +167,7 @@
   },
   "files": [
     "node_modules",
-    "dist/lib",
+    "dist",
     "src",
     "tsconfig.json"
   ]


### PR DESCRIPTION
The PR aims to solve the issue with the NPM package not including all relevant build files, making it unconsumable by `vscode-kaoto`.

Changes:
~~First trying to change the `files` array to see if this will fix the issue of directories missing in `npm publish`, otherwise we will need to add an `npmignore` file.~~

- Bump `package.json` version to be able to republish the npm package
- Add step to `Publish NPM Package` GitHub action to run `yarn build:lib` so that the `lib` files get included
- Update `files` array in `package.json` to include the entire `dist` directory