### PR TITLE
chore: update `package.json` version to `dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaoto/kaoto-ui",
-  "version": "0.4.3",
+  "version": "0.5.0-dev",
   "private": false,
   "federatedModuleName": "kaoto",
   "engines": {


### PR DESCRIPTION
This way we can continue to make changes that don't affect the released version `v0.4.3`.