### PR TITLE
feature(release): Add a script to update versions easily

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+git reset --hard 
+git pull
+
+echo "Enter version of Kaoto to release:"
+echo "Example: 1.0.0"
+read -r version
+
+echo "Updating to version $version"
+sed -i 's/\"version\".*/\"version\"\: \"'$version'\",/g' package.json
+git add .
+git commit -m "Updating to version $version"
+git tag v$version
+
+echo "Now we are going to test the new version."
+
+yarn install
+yarn build
+yarn test --coverage
+
+echo "Enter new development version:"
+echo "('-dev' will be added automatically)"
+echo "Example: 1.0.1"
+read -r version2
+
+echo "Updating to version $version2-dev"
+sed -i 's/\"version\".*/\"version\"\: \"'$version2'-dev\",/g' package.json
+git add .
+git commit -m "Updating to version $version2-dev"
+
+echo ""
+echo "Check the git log and if you like what you see, just do"
+echo "'git push' and 'git push --tags'."
+echo "This will trigger the release creation."
+echo ""
+echo "Then go to https://github.com/KaotoIO/kaoto-ui/releases/ to review"
+echo "the text of the release and publish it. "
+echo ""
+echo "Congratulations! Your job here is done."


### PR DESCRIPTION
@kahboom created a bash script (which I think you should be able to run in MacOS too normally) that updates the versions.

It runs some tests after changing the version release because you never know what will happen, to check if at least all the tests pass. **This script does not push**. It is interactive and will tell you what to input on each step:

1. Do a git reset to make sure we are clean
2. Asks for release version
3. Changes it in package.json
4. Generates commit and tag
5. Run tests (please, check if the commands are the right ones here)
6. Asks for next version
7. Changes it in package.json (with the `-dev` suffix)
8. Generates commit
9. Ask you to push and review release.

You can safely test it if you move to a new branch, don't push, and **remove the git tag created**.