### PR TITLE
feat(codeEditor): Disabling autosync

### DIFF
--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -75,6 +75,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       );
     });
 
+    editor?.revealLine(editor.getModel()?.getLineCount() ?? 0);
     editorRef.current = editor;
   };
 
@@ -172,6 +173,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
         code={sourceCode ?? props.initialData}
         className="code-editor"
         height="80vh"
+        width={'100%'}
         onCodeChange={debounced}
         language={(props.language as Language) ?? Language.yaml}
         onEditorDidMount={handleEditorDidMount}
@@ -181,9 +183,14 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
         isDarkTheme
         isDownloadEnabled
         isLanguageLabelVisible
+        allowFullScreen={true}
         isUploadEnabled
         options={{
           readOnly: props.mode === CodeEditorMode.READ_ONLY || !props.editable,
+          scrollbar: {
+            horizontal: 'visible',
+            vertical: 'visible',
+          },
         }}
       />
     </StepErrorBoundary>

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -1,11 +1,17 @@
 import { fetchIntegrationJson, fetchIntegrationSourceCode } from '@kaoto/api';
 import { StepErrorBoundary } from '@kaoto/components';
 import { useIntegrationJsonStore, useIntegrationSourceStore, useSettingsStore } from '@kaoto/store';
-import { IIntegration } from '@kaoto/types';
+import { CodeEditorMode, IIntegration } from '@kaoto/types';
 import { usePrevious } from '@kaoto/utils';
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
-import { EraserIcon, RedoIcon, UndoIcon } from '@patternfly/react-icons';
-import { useEffect, useRef } from 'react';
+import {
+  CheckCircleIcon,
+  EraserIcon,
+  PencilAltIcon,
+  RedoIcon,
+  UndoIcon,
+} from '@patternfly/react-icons';
+import { ReactNode, useEffect, useRef } from 'react';
 import EditorDidMount from 'react-monaco-editor';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -13,6 +19,10 @@ interface ISourceCodeEditor {
   initialData?: string;
   language?: Language;
   theme?: string;
+  mode?: CodeEditorMode | CodeEditorMode.FREE_EDIT;
+  editable?: boolean | false;
+  editAction?: (code: string, event?: any) => void;
+  syncAction?: () => {};
 }
 
 const SourceCodeEditor = (props: ISourceCodeEditor) => {
@@ -57,23 +67,39 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
   };
 
   const handleEditorDidMount = (editor: EditorDidMount['editor']) => {
+    const messageContribution: any = editor?.getContribution('editor.contrib.messageController');
+    editor?.onDidAttemptReadOnlyEdit(() => {
+      messageContribution?.showMessage(
+        'Cannot edit in read-only editor mode.',
+        editor.getPosition()
+      );
+    });
+
     editorRef.current = editor;
   };
 
   const debounced = useDebouncedCallback((value: string) => {
-    handleChanges(value);
+    // if editor is in read only mode file can be still uploaded.
+    if (props.mode !== CodeEditorMode.FREE_EDIT) {
+      handleChanges(value);
+    }
   }, 1000);
 
   const clearAction = () => {
     setSourceCode('');
   };
-
   const undoAction = () => {
     (editorRef.current?.getModel() as any)?.undo();
   };
 
   const redoAction = () => {
     (editorRef.current?.getModel() as any)?.redo();
+  };
+  const updateModelFromTheEditor = () => {
+    const updatedCode = editorRef.current?.getValue();
+    if (updatedCode) {
+      handleChanges(updatedCode);
+    }
   };
 
   const ClearButton = (
@@ -84,6 +110,16 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       onClick={clearAction}
       isVisible={sourceCode !== ''}
       tooltipProps={{ content: 'Clear', position: 'right' }}
+    />
+  );
+  const EditButton = (
+    <CodeEditorControl
+      key={'editButton'}
+      icon={<PencilAltIcon color="#0066CC" />}
+      data-testid={'sourceCode--editButton'}
+      onClick={props.editAction ?? (() => {})}
+      isVisible={props.mode === CodeEditorMode.FREE_EDIT}
+      tooltipProps={{ content: 'Edit the source code', position: 'right' }}
     />
   );
 
@@ -111,6 +147,25 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
     />
   );
 
+  const UpdateButton = (
+    <CodeEditorControl
+      key="updateButton"
+      icon={<CheckCircleIcon color={'green'} />}
+      aria-label="Apply the code"
+      data-testid={'sourceCode--applyButton'}
+      onClick={updateModelFromTheEditor}
+      tooltipProps={{ content: 'Sync your code', position: 'right' }}
+      isVisible={sourceCode !== ''}
+    />
+  );
+
+  let customControls: ReactNode[] = [EditButton];
+  if (props.mode === CodeEditorMode.TWO_WAY_SYNC) {
+    customControls = [UndoButton, RedoButton, ClearButton];
+  } else if (props.mode === CodeEditorMode.FREE_EDIT && props.editable) {
+    customControls = [UndoButton, RedoButton, ClearButton, UpdateButton];
+  }
+
   return (
     <StepErrorBoundary>
       <CodeEditor
@@ -121,12 +176,15 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
         language={(props.language as Language) ?? Language.yaml}
         onEditorDidMount={handleEditorDidMount}
         toolTipPosition="right"
-        customControls={[UndoButton, RedoButton, ClearButton]}
+        customControls={customControls}
         isCopyEnabled
         isDarkTheme
         isDownloadEnabled
         isLanguageLabelVisible
         isUploadEnabled
+        options={{
+          readOnly: props.mode === CodeEditorMode.READ_ONLY || !props.editable,
+        }}
       />
     </StepErrorBoundary>
   );

--- a/src/components/SourceCodeEditorModal.tsx
+++ b/src/components/SourceCodeEditorModal.tsx
@@ -1,0 +1,32 @@
+import { SourceCodeEditor } from './SourceCodeEditor';
+import { CodeEditorMode } from '@kaoto/types';
+import { Alert, AlertActionCloseButton, Modal, ModalVariant } from '@patternfly/react-core';
+import { useState } from 'react';
+
+type ISourceCodeEditorModalProps = {
+  close: () => void;
+  isOpen: boolean;
+};
+export const SourceCodeEditorModal = (props: ISourceCodeEditorModalProps) => {
+  const [alertVisible, setAlertVisible] = useState(true);
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title="Edit the source code"
+      isOpen={props.isOpen}
+      onClose={props.close}
+    >
+      {alertVisible && (
+        <Alert
+          title="Warning"
+          variant="warning"
+          actionClose={<AlertActionCloseButton onClose={() => setAlertVisible(false)} />}
+        >
+          Any invalid code will be replaced after sync. If you don't want to lose your changes
+          please make a backup.
+        </Alert>
+      )}
+      <SourceCodeEditor editable={true} mode={CodeEditorMode.FREE_EDIT} />
+    </Modal>
+  );
+};

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import svg from '../assets/images/kaoto.svg';
-import { IDsl, ISettings } from '@kaoto/types';
+import { CodeEditorMode, IDsl, ISettings } from '@kaoto/types';
 import create from 'zustand';
 
 interface ISettingsStore {
@@ -23,6 +23,7 @@ const initialSettings: ISettings = {
   icon: svg,
   name: 'integration',
   namespace: '',
+  editorMode: CodeEditorMode.FREE_EDIT,
 };
 
 export const useSettingsStore = create<ISettingsStore>((set) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,11 @@ declare global {
   // const __webpack_init_sharing__: any;
   const __webpack_share_scopes__: any;
 }
+export enum CodeEditorMode {
+  FREE_EDIT = 0,
+  READ_ONLY = 1,
+  TWO_WAY_SYNC = 2,
+}
 
 export interface IDeployment {
   // yaml CRD of deployment
@@ -57,6 +62,7 @@ export interface ISettings {
   name: string;
   // Cluster namespace
   namespace: string;
+  editorMode: CodeEditorMode;
 }
 
 export interface ICapabilities {


### PR DESCRIPTION
This PR introduces three modes how code editor will work. This currently cannot be changed in the settings.. it can be a following PR if we will to have it configurable.
- `FREE_EDIT`:
  - Editor is Read only, and new Edit button is added into controls:
     <img width="1423" alt="Screenshot 2022-11-25 at 10 35 21" src="https://user-images.githubusercontent.com/6814482/203953901-b5d3cea7-9342-47aa-a920-2738da38f37e.png">
  - After clicking on edit, a modal window will appear when user can edit the code and sync changes:
     <img width="1425" alt="Screenshot 2022-11-25 at 10 35 03" src="https://user-images.githubusercontent.com/6814482/203954133-3f29f095-98e7-4f8a-9548-61fc1fe3087f.png">
- `READ_ONLY`: 
  - Editor is read_only and edit modal cannot be displayed. This might be useful in Vscode plugin, or when we don't want to change the code at all.
     <img width="1423" alt="Screenshot 2022-11-25 at 10 33 47" src="https://user-images.githubusercontent.com/6814482/203954694-0838451a-83fb-47e5-ac1c-3ad9636d420c.png">
-  `TWO_WAY_SYNC`:
  -  Old behaviour when editor is editable, and code is automatically replaced if it's invalid:
      <img width="568" alt="Screenshot 2022-11-25 at 11 00 43" src="https://user-images.githubusercontent.com/6814482/203955680-fe06304d-fc55-40e9-b014-5a645fba1b5f.png">
