### PR TITLE
fix(viz): recursively check for branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,10 @@
     "lint": "eslint --ext .ts,.tsx,.js ./src",
     "lint:fix": "yarn lint --fix",
     "lint-staged": "yarn lint:fix && yarn format:fix",
-    "test": "jest src/**/*.test.ts*",
-    "test:coverage": "jest --coverage --watchAll=false",
+    "test": "jest --coverage src/**/*.test.ts*",
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@deepsource/shifty": "^1.0.0",
     "@kie-tools-core/editor": "0.25.0",
     "@kie-tools-core/guided-tour": "0.25.0",
     "@kie-tools-core/monaco-editor": "0.25.0",
@@ -82,7 +80,6 @@
     "@types/react-dom": "18.0.9",
     "@types/react-router-dom": "5.3.3",
     "@types/testing-library__jest-dom": "5.14.5",
-    "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "5.45.0",
     "copy-webpack-plugin": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@deepsource/shifty": "^1.0.0",
     "@kie-tools-core/editor": "0.25.0",
     "@kie-tools-core/guided-tour": "0.25.0",
     "@kie-tools-core/monaco-editor": "0.25.0",
@@ -62,7 +63,6 @@
     "uniforms-bridge-json-schema": "^3.10.1",
     "uniforms-patternfly": "^4.7.6",
     "use-debounce": "8.0.4",
-    "uuid": "9.0.0",
     "web-vitals": "3.1.0",
     "zundo": "^2.0.0-beta.6",
     "zustand": "^4.1.4"

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -39,7 +39,7 @@ const PlusButtonEdge = ({
   // substring is used to remove the 'e-' from the id (i.e. e-{nodeId}>{nodeId})
   const nodeIds = id.substring(2).split('>');
   const targetNode = useReactFlow().getNode(nodeIds[1]);
-  const currentIdx = findStepIdxWithUUID(targetNode?.data.UUID!);
+  const currentIdx = findStepIdxWithUUID(targetNode?.data.step.UUID!);
 
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({
     sourceX,

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -9,7 +9,6 @@ import {
   VisualizationStepViews,
 } from '@kaoto/components';
 import {
-  buildBranch,
   buildBranchSpecialEdges,
   buildEdges,
   buildNodesFromSteps,
@@ -29,7 +28,6 @@ interface IVisualization {
 const Visualization = ({ toggleCatalog }: IVisualization) => {
   // `nodes` is an array of UI-specific objects that represent
   // the Integration.Steps model visually, while `edges` connect them
-  // const rendererSize = getBoundingClientRect();
   const defaultViewport: Viewport = {
     x: window.innerWidth / 2,
     y: window.innerHeight / 2 - 160,
@@ -53,9 +51,8 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
 
   // initial loading of visualization steps
   useEffect(() => {
-    // const { combinedNodes, combinedEdges } = buildNodesAndEdges(integrationJson.steps);
     const { stepNodes, stepEdges } = buildNodesAndEdges(integrationJson.steps);
-    // getLayoutedElements(combinedNodes, combinedEdges, layout)
+
     getLayoutedElements(stepNodes, stepEdges, layout)
       .then((res) => {
         const { layoutedNodes, layoutedEdges } = res;
@@ -76,9 +73,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
       setViews(views);
     });
 
-    // const { combinedNodes, combinedEdges } = buildNodesAndEdges(integrationJson.steps);
     const { stepNodes, stepEdges } = buildNodesAndEdges(integrationJson.steps);
-    // getLayoutedElements(combinedNodes, combinedEdges, layout)
     getLayoutedElements(stepNodes, stepEdges, layout)
       .then((res) => {
         const { layoutedNodes, layoutedEdges } = res;
@@ -113,36 +108,22 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
   );
 
   function buildNodesAndEdges(steps: IStepProps[]) {
-    // const combinedEdges: IVizStepPropsEdge[] = [];
-    // const combinedNodes: IVizStepNode[] = [];
-
-    // const { stepNodes, branchOriginStepNodes } = buildNodesFromSteps(steps, layout, {
-    //   handleDeleteStep,
-    // });
     const stepNodes = buildNodesFromSteps(steps, layout, {
       handleDeleteStep,
     });
 
-    // const { branchNodes, branchStepEdges } = buildBranch(branchOriginStepNodes, layout);
+    const filteredNodes = stepNodes.filter((node) => !node.data.branchStep);
+    // console.table(filteredNodes);
+    let stepEdges: IVizStepPropsEdge[] = buildEdges(filteredNodes);
 
-    let stepEdges: IVizStepPropsEdge[] = buildEdges(stepNodes);
-    // const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(branchNodes, stepNodes);
     const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(stepNodes);
     // console.table(branchSpecialEdges);
     stepEdges = stepEdges.concat(...branchSpecialEdges);
-    console.table(stepEdges);
-
-    // combinedNodes.push(...stepNodes, ...branchNodes);
-    // combinedEdges.push(...stepEdges, ...branchStepEdges);
-    // combinedEdges.push(...branchSpecialEdges);
-
-    // console.table(combinedNodes);
-    // console.table(combinedEdges);
+    // console.table(stepEdges);
 
     // console.table(stepNodes);
     // console.table(stepEdges);
 
-    // return { combinedNodes, combinedEdges };
     return { stepNodes, stepEdges };
   }
 

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -37,10 +37,11 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
   const [, setReactFlowInstance] = useState(null);
   const reactFlowWrapper = useRef(null);
   const [selectedStep, setSelectedStep] = useState<IStepProps>({
-    name: '',
-    type: '',
     maxBranches: 0,
     minBranches: 0,
+    name: '',
+    type: '',
+    UUID: '',
   });
   const { deleteStep, integrationJson, replaceStep, setViews } = useIntegrationJsonStore();
   const layout = useVisualizationStore((state) => state.layout);
@@ -113,16 +114,11 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     });
 
     const filteredNodes = stepNodes.filter((node) => !node.data.branchStep);
-    // console.table(filteredNodes);
     let stepEdges: IVizStepPropsEdge[] = buildEdges(filteredNodes);
 
     const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(stepNodes);
-    // console.table(branchSpecialEdges);
-    stepEdges = stepEdges.concat(...branchSpecialEdges);
-    console.table(stepEdges);
 
-    // console.table(stepNodes);
-    // console.table(stepEdges);
+    stepEdges = stepEdges.concat(...branchSpecialEdges);
 
     return { stepNodes, stepEdges };
   }
@@ -130,7 +126,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
   const handleDeleteStep = (UUID?: string) => {
     if (!UUID) return;
 
-    setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '' });
+    setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '' });
     if (isPanelExpanded) setIsPanelExpanded(false);
 
     // `deleteStep` requires the index to be from `integrationJson`, not `nodes`
@@ -166,7 +162,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     // workaround for https://github.com/wbkd/react-flow/issues/2202
     if (!_e.target.classList.contains('stepNode__clickable')) return;
 
-    if (!node.data.UUID) {
+    if (!node.data.step.UUID) {
       // prevent slots from being selected, passive-aggressively open the steps catalog
       if (toggleCatalog) toggleCatalog();
       return;
@@ -174,7 +170,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
 
     // Only set state again if the ID is not the same
     const findStep: IStepProps =
-      integrationJson.steps.find((step) => step.UUID === node.data.UUID) ?? selectedStep;
+      integrationJson.steps.find((step) => step.UUID === node.data.step.UUID) ?? selectedStep;
     setSelectedStep(findStep);
 
     // show/hide the panel regardless

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -53,8 +53,10 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
 
   // initial loading of visualization steps
   useEffect(() => {
-    const { combinedNodes, combinedEdges } = buildNodesAndEdges(integrationJson.steps);
-    getLayoutedElements(combinedNodes, combinedEdges, layout)
+    // const { combinedNodes, combinedEdges } = buildNodesAndEdges(integrationJson.steps);
+    const { stepNodes, stepEdges } = buildNodesAndEdges(integrationJson.steps);
+    // getLayoutedElements(combinedNodes, combinedEdges, layout)
+    getLayoutedElements(stepNodes, stepEdges, layout)
       .then((res) => {
         const { layoutedNodes, layoutedEdges } = res;
         setNodes(layoutedNodes);
@@ -74,8 +76,10 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
       setViews(views);
     });
 
-    const { combinedNodes, combinedEdges } = buildNodesAndEdges(integrationJson.steps);
-    getLayoutedElements(combinedNodes, combinedEdges, layout)
+    // const { combinedNodes, combinedEdges } = buildNodesAndEdges(integrationJson.steps);
+    const { stepNodes, stepEdges } = buildNodesAndEdges(integrationJson.steps);
+    // getLayoutedElements(combinedNodes, combinedEdges, layout)
+    getLayoutedElements(stepNodes, stepEdges, layout)
       .then((res) => {
         const { layoutedNodes, layoutedEdges } = res;
         setNodes(layoutedNodes);
@@ -109,23 +113,37 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
   );
 
   function buildNodesAndEdges(steps: IStepProps[]) {
-    const combinedEdges: IVizStepPropsEdge[] = [];
-    const combinedNodes: IVizStepNode[] = [];
+    // const combinedEdges: IVizStepPropsEdge[] = [];
+    // const combinedNodes: IVizStepNode[] = [];
 
-    const { stepNodes, branchOriginStepNodes } = buildNodesFromSteps(steps, layout, {
+    // const { stepNodes, branchOriginStepNodes } = buildNodesFromSteps(steps, layout, {
+    //   handleDeleteStep,
+    // });
+    const stepNodes = buildNodesFromSteps(steps, layout, {
       handleDeleteStep,
     });
 
-    const { branchNodes, branchStepEdges } = buildBranch(branchOriginStepNodes, layout);
+    // const { branchNodes, branchStepEdges } = buildBranch(branchOriginStepNodes, layout);
 
-    const stepEdges: IVizStepPropsEdge[] = buildEdges(stepNodes);
-    const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(branchNodes, stepNodes);
+    let stepEdges: IVizStepPropsEdge[] = buildEdges(stepNodes);
+    // const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(branchNodes, stepNodes);
+    const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(stepNodes);
+    // console.table(branchSpecialEdges);
+    stepEdges = stepEdges.concat(...branchSpecialEdges);
+    console.table(stepEdges);
 
-    combinedNodes.push(...stepNodes, ...branchNodes);
-    combinedEdges.push(...stepEdges, ...branchStepEdges);
-    combinedEdges.push(...branchSpecialEdges);
+    // combinedNodes.push(...stepNodes, ...branchNodes);
+    // combinedEdges.push(...stepEdges, ...branchStepEdges);
+    // combinedEdges.push(...branchSpecialEdges);
 
-    return { combinedNodes, combinedEdges };
+    // console.table(combinedNodes);
+    // console.table(combinedEdges);
+
+    // console.table(stepNodes);
+    // console.table(stepEdges);
+
+    // return { combinedNodes, combinedEdges };
+    return { stepNodes, stepEdges };
   }
 
   const handleDeleteStep = (UUID?: string) => {

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -119,7 +119,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(stepNodes);
     // console.table(branchSpecialEdges);
     stepEdges = stepEdges.concat(...branchSpecialEdges);
-    // console.table(stepEdges);
+    console.table(stepEdges);
 
     // console.table(stepNodes);
     // console.table(stepEdges);

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -99,7 +99,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
   return (
     <>
-      {data.step && data.UUID ? (
+      {data.step && data.step.UUID ? (
         <div
           className={`stepNode`}
           onDrop={onDropReplace}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -24,9 +24,9 @@ const replaceStep = useIntegrationJsonStore.getState().replaceStep;
 // Custom Node type and component for React Flow
 const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const nodes: Node[] = useNodes();
-  const lastNode = isLastNode(nodes, data.UUID!);
+  const lastNode = isLastNode(nodes, data.step?.UUID);
   const endStep = isEndStep(data.step!);
-  const currentIdx = findStepIdxWithUUID(data.UUID!);
+  const currentIdx = findStepIdxWithUUID(data.step?.UUID);
   const layout = useVisualizationStore((state) => state.layout);
   const steps = useIntegrationJsonStore((state) => state.integrationJson.steps);
 
@@ -41,7 +41,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   };
 
   const handleTrashClick = () => {
-    data.handleDeleteStep && data.handleDeleteStep(data.step?.UUID!);
+    data.handleDeleteStep && data.handleDeleteStep(data.step?.UUID);
   };
 
   /**
@@ -99,7 +99,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
   return (
     <>
-      {data.step && data.step.UUID ? (
+      {data.step?.UUID ? (
         <div
           className={`stepNode`}
           onDrop={onDropReplace}

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -69,7 +69,8 @@ export function buildBranchSpecialEdges(stepNodes: IVizStepNode[]): IVizStepProp
   stepNodes.forEach((node) => {
     if (node.type === 'group') return;
 
-    const ogNodeIndex = findNodeIdxWithUUID(node.data?.branchParentUuid, stepNodes);
+    // const ogNodeIndex = findNodeIdxWithUUID(node.data?.branchParentUuid, stepNodes);
+    const parentNodeIndex = findNodeIdxWithUUID(node.data?.parentUuid, stepNodes);
     const ogNodeNextIndex = findNodeIdxWithUUID(node.data?.branchParentNextUuid, stepNodes);
 
     // handle all "normal" steps within a branch
@@ -80,9 +81,9 @@ export function buildBranchSpecialEdges(stepNodes: IVizStepNode[]): IVizStepProp
       }
     }
 
-    // handle special first step, needs to be connected to parent step
+    // handle special first step, needs to be connected to its immediate parent
     if (node.data?.isFirstStep) {
-      const ogNodeStep = stepNodes[ogNodeIndex];
+      const ogNodeStep = stepNodes[parentNodeIndex];
       const firstStep = node;
 
       let edgeProps: { id: string; source: string; target: string; [prop: string]: any } = {
@@ -242,8 +243,15 @@ export function buildNodesFromSteps(
         stepNodes = stepNodes.concat(
           buildNodesFromSteps(branch.steps, layout, props, {
             branchIdentifier: branch.identifier,
+
+            // branchParentUuid is the parent for a first branch step,
+            // and grandparent for a second (sub) branch step
             branchParentUuid: branchInfo?.branchParentUuid ?? steps[index].UUID,
             branchParentNextUuid: branchInfo?.branchParentNextUuid ?? steps[index + 1]?.UUID,
+
+            // parentUuid is always the parent of the branch step, no matter
+            // how nested
+            parentUuid: steps[index].UUID,
           })
         );
       });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,4 +1,3 @@
-import Shifty from '@deepsource/shifty';
 import { useIntegrationJsonStore } from '@kaoto/store';
 import { IStepProps, IStepPropsBranch, IVizStepNode, IVizStepPropsEdge } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
@@ -42,10 +41,8 @@ export function buildBranchNodeParams(
   layout: string,
   dataProps?: { [prop: string]: any }
 ): IVizStepNode {
-  const shifty = new Shifty(false);
   return {
     data: {
-      UUID: `b_${step.name}-s${shifty.generate(16)}`,
       kind: step.kind,
       label: truncateString(step.name, 14),
       step,
@@ -171,7 +168,7 @@ export function buildNodeDefaultParams(
 ): IVizStepNode {
   return {
     data: {
-      UUID: step.UUID,
+      // UUID: step.UUID,
       kind: step.kind,
       label: truncateString(step.name, 14),
       step,
@@ -289,7 +286,7 @@ export function findStepIdxWithUUID(UUID: string, steps?: IStepProps[]) {
  * @param nodes
  */
 export function findNodeIdxWithUUID(UUID: string, nodes: IVizStepNode[]) {
-  return nodes.map((n) => n.data.UUID).indexOf(UUID);
+  return nodes.map((n) => n.data.step.UUID).indexOf(UUID);
 }
 
 export async function getLayoutedElements(

--- a/src/store/data/branchSteps.ts
+++ b/src/store/data/branchSteps.ts
@@ -13,6 +13,7 @@ export default [
     minBranches: 0,
     parameters: [],
     title: 'Kamelet Source',
+    UUID: 'kamelet:source-233189',
   },
   {
     id: 'choice',
@@ -63,6 +64,7 @@ export default [
             ],
             required: ['name'],
             title: 'Set Header',
+            UUID: 'set-header-337596',
           },
         ],
       },
@@ -110,6 +112,7 @@ export default [
             ],
             required: ['name'],
             title: 'Set Property',
+            UUID: 'set-property-00823',
           },
           {
             id: 'remove-property',
@@ -132,6 +135,7 @@ export default [
             ],
             required: ['name'],
             title: 'Remove Property',
+            UUID: 'remove-property-2403409',
           },
         ],
       },
@@ -161,6 +165,7 @@ export default [
               },
             ],
             title: 'Transform',
+            UUID: 'transform-208704',
           },
         ],
       },
@@ -189,6 +194,7 @@ export default [
               },
             ],
             title: 'Set Body',
+            UUID: 'set-body-28904309',
           },
           {
             id: 'remove-header',
@@ -211,6 +217,7 @@ export default [
             ],
             required: ['name'],
             title: 'Remove Header',
+            UUID: 'remove-header-281047',
           },
         ],
       },
@@ -234,6 +241,7 @@ export default [
       },
     ],
     title: 'Content Based Router.',
+    UUID: 'choice-344294',
   },
   {
     id: 'filter',
@@ -266,6 +274,7 @@ export default [
               },
             ],
             title: 'Set Body',
+            UUID: 'set-body-12334',
           },
         ],
       },
@@ -289,6 +298,7 @@ export default [
       },
     ],
     title: 'Filter',
+    UUID: 'filter-3923735',
   },
   {
     id: 'kamelet:sink',
@@ -302,5 +312,6 @@ export default [
     minBranches: 0,
     parameters: [],
     title: 'Kamelet Sink',
+    UUID: 'kamelet:sink-559424',
   },
 ] as IStepProps[];

--- a/src/store/data/nodes.ts
+++ b/src/store/data/nodes.ts
@@ -58,7 +58,6 @@ export default [
         title: 'AWS Kinesis Source',
         UUID: 'aws-kinesis-source0',
       },
-      UUID: 'aws-kinesis-source0',
     },
     id: 'dndnode_4',
     position: {
@@ -109,7 +108,6 @@ export default [
         title: 'Avro Deserialize Action',
         UUID: 'avro-deserialize-action1',
       },
-      UUID: 'avro-deserialize-action1',
     },
     id: 'dndnode_5',
     position: {
@@ -176,7 +174,6 @@ export default [
         title: 'AWS Kinesis Firehose Sink',
         UUID: 'aws-kinesis-firehose-sink3',
       },
-      UUID: 'aws-kinesis-firehose-sink2',
     },
     id: 'dndnode_6',
     position: {

--- a/src/store/data/steps.ts
+++ b/src/store/data/steps.ts
@@ -5,7 +5,7 @@ export default [
     id: 'twitter-search-source',
     name: 'twitter-search-source',
     type: 'START',
-    UUID: '0twitter-search-source',
+    UUID: 'twitter-search-source-0',
     description:
       'Allows to get all tweets on particular keywords from Twitter.\n\nIt requires tokens that can be obtained by creating an application \nin the Twitter developer portal: https://developer.twitter.com/.',
     group: 'Twitter',
@@ -71,7 +71,7 @@ export default [
     id: 'pdf-action',
     name: 'pdf-action',
     type: 'MIDDLE',
-    UUID: '1pdf-action',
+    UUID: 'pdf-action-1',
     description: 'Create a PDF',
     group: 'PDF',
     icon: 'data:image/svg+xml',
@@ -115,7 +115,7 @@ export default [
     id: 'caffeine-action',
     name: 'caffeine-action',
     type: 'MIDDLE',
-    UUID: '2caffeine-action',
+    UUID: 'caffeine-action-2',
     description:
       "Perform operations on a caffeine cache\n\nThe Kamelet expects the following headers to be set:\n\n- `caffeine-key` / `ce-caffeinekey`: as the cache key used in the operation\n\n- `caffeine-operation` / `ce-caffeineoperation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.\n\nIf the caffeine-key header won't be set the exchange ID will be used as key.\n\nIf the caffeine-operation header won't be set, the GET operation will be performed.",
     group: 'Caffeine',
@@ -140,7 +140,7 @@ export default [
     id: 'kafka-sink',
     name: 'kafka-sink',
     type: 'END',
-    UUID: '3kafka-sink',
+    UUID: 'kafka-sink-3',
     description:
       'Send data to Kafka topics.\n\nThe Kamelet is able to understand the following headers to be set:\n\n- `key` / `ce-key`: as message key\n\n- `partition-key` / `ce-partitionkey`: as message partition key\n\nBoth the headers are optional.',
     group: 'Kafka',

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -39,7 +39,7 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
         set((state) => {
           let newSteps = state.integrationJson.steps.slice();
           // manually generate UUID for the new step
-          newStep.UUID = newStep.name + newSteps.length;
+          newStep.UUID = `${newStep.name}-${newSteps.length}`;
           newSteps.push(newStep);
           return {
             integrationJson: {
@@ -52,7 +52,7 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
       deleteIntegration: () => set(initialState),
       deleteStep: (stepIdx) => {
         let stepsCopy = get().integrationJson.steps.slice();
-        const updatedSteps = stepsCopy.filter((_step: any, idx: any) => idx !== stepIdx);
+        const updatedSteps = stepsCopy.filter((_step: IStepProps, idx: number) => idx !== stepIdx);
         const stepsWithNewUuids = regenerateUuids(updatedSteps);
         set((state) => ({
           integrationJson: {
@@ -107,7 +107,7 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
       setViews: (viewData: IViewProps[]) => {
         set({ views: viewData });
       },
-      updateIntegration: (newInt) => {
+      updateIntegration: (newInt: IIntegration) => {
         let newIntegration = { ...get().integrationJson, ...newInt };
         newIntegration.steps = regenerateUuids(newIntegration.steps);
         return set({ integrationJson: { ...newIntegration } });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,7 +120,7 @@ export interface IStepProps {
   type: string;
 
   // generated only for integration steps
-  UUID?: string;
+  UUID: string;
 }
 
 export interface IStepPropsBranch {
@@ -176,8 +176,7 @@ export interface IVizStepNodeData {
   icon?: string;
   kind?: string;
   label: string;
-  step?: IStepProps;
-  UUID?: string;
+  step: IStepProps;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@deepsource/shifty@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@deepsource/shifty/-/shifty-1.0.0.tgz#ecacb5337fd0ad9022af1df602bcede23664b485"
+  integrity sha512-n+xr3puUHlsh5S7eYKtnJ+ASQqzfJ/SpUPi/ADZjiGqpZZu+Q1bSqiVfpUr670ceGL64AUEpAIeVe/N9eHLQ4w==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -9010,11 +9015,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
-
-uuid@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 uuid@^8.3.2:
   version "8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,11 +468,6 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@deepsource/shifty@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@deepsource/shifty/-/shifty-1.0.0.tgz#ecacb5337fd0ad9022af1df602bcede23664b485"
-  integrity sha512-n+xr3puUHlsh5S7eYKtnJ+ASQqzfJ/SpUPi/ADZjiGqpZZu+Q1bSqiVfpUr670ceGL64AUEpAIeVe/N9eHLQ4w==
-
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -1882,11 +1877,6 @@
   integrity sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==
   dependencies:
     "@types/jest" "*"
-
-"@types/uuid@8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/ws@^8.5.1":
   version "8.5.3"


### PR DESCRIPTION
This PR fixes #960 , where nested branches are not rendered properly. Apologies for the big PR, but since so much of it touched `UUID`s of steps, it was not possible to break it up without breaking the UI.

## Changes
- Checks for branch steps recursively, for both `nodes` and `edges`
- Regenerate `UUID`s for steps recursively, including within branches (will also help with #784)
- Removes duplicate line for branch steps (fixes #788)
- Removes duplicate `UUID` property, so now we should only use `data.step.UUID` (the actual step `UUID`) within nodes, rather than `data.UUID`
- Checks for branch information instead of `EIP` (fixes #940)
- To better support branches, edges are now built from `currentStep` to `nextStep`, as opposed to `previousStep` to `currentStep`
- Makes `UUID` a required property for all steps
- Removes `uuid` types library we aren't using anyway

## Screenshots
To test this branch, you can use any of the following YAML examples, or your own.

### `buggy.yaml`
This was the originally buggy YAML from the issue (#960).

![Screen Shot 2022-11-29 at 4 28 05 pm](https://user-images.githubusercontent.com/3844502/204586476-8a301743-1007-4d60-8f99-1a6d18e6ef7a.png)

The Camel component `aws2-eventbridge` is not connected due to a known issue unrelated to this PR (https://github.com/KaotoIO/kaoto-backend/issues/352).

```yaml
apiVersion: camel.apache.org/v1alpha1
kind: Kamelet
metadata:
  annotations:
    camel.apache.org/kamelet.support.level: Preview
    camel.apache.org/catalog.version: main-SNAPSHOT
    camel.apache.org/kamelet.icon: whatever
    camel.apache.org/provider: Apache Software Foundation
    camel.apache.org/kamelet.group: Kaoto
  labels:
    camel.apache.org/kamelet.type: sink
  name: eip-action-sink
spec:
  definition:
    title: EIP Kamelet
    description: Used to test all EIP we implement
    properties: {}
  dependencies:
    - camel:core
    - camel:kamelet
    - camel:bean
    - camel:aws2-eventbridge
    - camel:chunk
  template:
    from:
      uri: kamelet:source
      steps:
        - choice:
            when:
              - simple: "{{?baz}}"
                steps:
                  - load-balance:
                      weighted:
                        distribution-ratio: 2,1
                        round-robin: false
                      steps:
                        - log:
                            message: test
                            logging-level: INFO
                            log-name: yaml
            otherwise:
              steps:
                - remove-header:
                    name: removeme
        - filter:
            simple: "{{?foo}}"
            steps:
              - set-body:
                  simple: abc
              - idempotent-consumer:
                  idempotent-repository: myRepo
                  simple: ${header.id}
                  steps:
                    - set-body:
                        simple: cheesecubez
        - to:
            uri: aws2-eventbridge
        - to:
            uri: chunk:null
```

### `repeated-set-header.yaml`

![kamelet-repeated-set-header](https://user-images.githubusercontent.com/3844502/204577396-c3fec5c1-b8e2-4399-aa66-2d609919b10b.png)

```yaml
apiVersion: camel.apache.org/v1alpha1
kind: Kamelet
metadata:
  annotations:
    camel.apache.org/kamelet.icon: whatever
  labels:
    camel.apache.org/kamelet.type: action
  name: eip-action
spec:
  definition:
    title: EIP Kamelet
  dependencies:
    - camel:core
    - camel:kamelet
  template:
    from:
      uri: kamelet:source
      steps:
        - choice:
            when:
              - simple: "{{?foo}}"
                steps:
                  - set-header:
                      name: bar
                      simple: foo
              - simple: "{{?foo2}}"
                steps:
                  - set-header:
                      name: bar
                      simple: foo2
              - simple: "{{?foo3}}"
                steps:
                  - set-header:
                      name: bar
                      simple: foo3
            otherwise:
              steps:
                - set-body:
                    simple: cheesecubez
        - to:
            uri: kamelet:sink
```

### `eip-action-sink.yaml`

![kamelet-eip-action-sink](https://user-images.githubusercontent.com/3844502/204578635-7611e730-4386-4c4e-970d-074595d4d4b3.png)



```yaml
apiVersion: camel.apache.org/v1alpha1
kind: Kamelet
metadata:
  annotations:
    camel.apache.org/kamelet.icon: cherry
  labels:
    camel.apache.org/kamelet.type: sink
  name: eip-action-sink
spec:
  definition:
    title: EIP Kamelet
    description: Used to test all EIP we implement
    properties: {}
  dependencies:
    - camel:core
    - camel:kamelet
  template:
    from:
      uri: kamelet:source
      steps:
        - loop:
            constant: "3"
            copy: true
            steps:
              - delay:
                  expression:
                    simple: ${body}
                  async-delayed: true
        - choice:
            when:
              - simple: "{{?foo}}"
                steps:
                  - dynamic-router:
                      expression:
                        simple: ${body}
                  - set-header:
                      name: bar
                      simple: foo
              - simple: "{{?bar}}"
                steps:
                  - set-property:
                      name: property
                      simple: bar
                  - remove-property:
                      name: property
                  - marshal:
                      json:
                        library: Gson
              - simple: "{{?baz}}"
                steps:
                  - transform:
                      simple: baz
                  - aggregate:
                      correlation-expression:
                        simple: ${header.StockSymbol}
                      aggregation-strategy: myAggregatorStrategy
                      completion-size: 2
                  - log:
                      message: test
                      logging-level: INFO
                      log-name: yaml
            otherwise:
              steps:
                - set-body:
                    simple: cheesecubez
                - remove-header:
                    name: removeme
                - claim-check:
                    operation: Push
                    key: foo
                    filter: header:(foo|bar)
```

### `evil-eip.yaml`

![kamelet-evil-eip](https://user-images.githubusercontent.com/3844502/204578566-4a533a1a-83a3-40ee-90ff-fb4f69330d1b.png)

The Camel component `dropbox` is not connected due to a known issue unrelated to this PR (https://github.com/KaotoIO/kaoto-backend/issues/352).

```yaml
apiVersion: camel.apache.org/v1alpha1
kind: Kamelet
metadata:
  annotations:
    camel.apache.org/kamelet.icon: cherry
  labels:
    camel.apache.org/kamelet.type: action
  name: eip-action
spec:
  definition:
    title: EIP Kamelet
    description: Used to test all EIP we implement
    properties: {}
  dependencies:
    - camel:core
    - camel:kamelet
  template:
    from:
      uri: kamelet:source
      steps:
        - loop:
            constant: "3"
            copy: true
            steps:
              - delay:
                  expression:
                    simple: ${body}
                  async-delayed: true
        - choice:
            when:
              - simple: "{{?foo}}"
                steps:
                  - dynamic-router:
                      expression:
                        simple: ${body}
                  - set-header:
                      name: bar
                      simple: foo
              - simple: "{{?bar}}"
                steps:
                  - set-property:
                      name: property
                      simple: bar
                  - remove-property:
                      name: property
                  - marshal:
                      json:
                        library: Gson
              - simple: "{{?baz}}"
                steps:
                  - transform:
                      simple: baz
                  - aggregate:
                      correlation-expression:
                        simple: ${header.StockSymbol}
                      aggregation-strategy: myAggregatorStrategy
                      completion-size: 2
                  - log:
                      message: test
                      logging-level: INFO
                      log-name: yaml
            otherwise:
              steps:
                - set-body:
                    simple: ola ke ase
                - remove-header:
                    name: removeme
                - claim-check:
                    operation: Push
                    key: foo
                    filter: header:(foo|bar)
        - filter:
            simple: "{{?foo}}"
            steps:
              - set-body:
                  simple: abc
              - unmarshal:
                  json:
                    unmarshal-type-name: MyClass
              - circuit-breaker:
                  description:
                    text: Another one
                    lang: eng
                  steps:
                    - enrich:
                        expression:
                          simple: ${body}
                    - to:
                        uri: dropbox:put
                        parameters:
                          accessToken: "{{accessToken}}"
                    - convert-body-to:
                        type: java.lang.String
                        charset: UTF8
                  on-fallback:
                    steps:
                      - log:
                          message: test
                          logging-level: INFO
                          log-name: yaml
        - to:
            uri: kamelet:sink
```