### PR TITLE
fix(Visualization): Initial node isn't always centered

### DIFF
--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -65,7 +65,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
       let reactFlowWrapperRect;
 
       if (reactFlowWrapper) {
-        reactFlowWrapperRect = reactFlowWrapper?.getBoundingClientRect();
+        reactFlowWrapperRect = reactFlowWrapper.getBoundingClientRect();
       }
 
       if (

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -14,8 +14,8 @@ import {
   buildNodesFromSteps,
   findStepIdxWithUUID,
   getLayoutedElements,
+  containsAddStepPlaceholder,
 } from '@kaoto/services';
-import { containsAddStepPlaceholder } from '@kaoto/services';
 import { useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps, IViewData, IVizStepPropsEdge, IVizStepNode } from '@kaoto/types';
 import { useEffect, useMemo, useRef, useState } from 'react';

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -37,7 +37,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
 
   const [isPanelExpanded, setIsPanelExpanded] = useState(false);
   const [, setReactFlowInstance] = useState(null);
-  const reactFlowWrapperRef = useRef(null);
+  const reactFlowWrapperRef = useRef<HTMLDivElement>(null);
   const [selectedStep, setSelectedStep] = useState<IStepProps>({
     maxBranches: 0,
     minBranches: 0,
@@ -60,7 +60,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     const isAddStepPlaceholder = containsAddStepPlaceholder(nodes);
 
     if (isAddStepPlaceholder) {
-      const reactFlowWrapper = reactFlowWrapperRef?.current as any;
+      const reactFlowWrapper = reactFlowWrapperRef.current;
 
       let reactFlowWrapperRect;
 


### PR DESCRIPTION
This PR fix and Close: #952 

## Summary of changes
- [x] Add a new `useEffect` to detect if nodes only have the initial "ADD A STEP" node to set their position in the React Flow viewport

If user switch between horizontal/vertical flow, the position should be re calculated in the `useEffect`

## Screenshots
![kaoto-center-1](https://user-images.githubusercontent.com/1202463/206875576-1ac4811f-6702-4626-bbae-a9fa704f758e.gif)
![kaoto-center-2](https://user-images.githubusercontent.com/1202463/206875579-8100a70c-a22c-4881-b90e-cecf18982f40.gif)
