### PR TITLE
Add custom schema bridge to introduce field description

### DIFF
--- a/src/components/CustomJsonSchemaBridge.tsx
+++ b/src/components/CustomJsonSchemaBridge.tsx
@@ -1,0 +1,43 @@
+import { Popover } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import JSONSchemaBridge from 'uniforms-bridge-json-schema';
+
+/**
+ * Returns a label tooltip element for the form or undefined if the field has no description
+ * @param description 
+ * @returns 
+ */
+const getLabelIcon = (description: string) =>
+  typeof (description) !== 'undefined' ?
+    (
+      <Popover bodyContent={description}>
+        <button
+          type="button"
+          aria-label="More info for field"
+          aria-describedby="form-group-label-info"
+          className="pf-c-form__group-label-help"
+        >
+          <HelpIcon /></button>
+      </Popover>
+    ) : undefined;
+
+/**
+ * CustomJsonSchemaBridge generates the appropriate attributes for uniforms-patternfly
+ * based on the incoming model data
+ */
+export class CustomJsonSchemaBridge extends JSONSchemaBridge {
+
+  constructor(schema: any, validator: any) {
+    super(schema, validator);
+  }
+
+  getField(name: string): Record<string, any> {
+    const field = super.getField(name);
+    const { description, ...props } = field;
+
+    return {
+      labelIcon: getLabelIcon(description),
+      ...props
+    };
+  }
+}

--- a/src/components/JsonSchemaConfigurator.tsx
+++ b/src/components/JsonSchemaConfigurator.tsx
@@ -1,8 +1,8 @@
 import Ajv from 'ajv';
 import { useRef } from 'react';
 import { AutoForm } from 'uniforms';
-import { JSONSchemaBridge } from 'uniforms-bridge-json-schema';
 import { AutoFields, ErrorsField } from 'uniforms-patternfly';
+import { CustomJsonSchemaBridge } from './CustomJsonSchemaBridge';
 
 const ajv = new Ajv({
   allErrors: true,
@@ -33,7 +33,7 @@ export const JsonSchemaConfigurator = ({
 }: JsonSchemaConfiguratorProps) => {
   schema.type = schema.type || 'object';
   const schemaValidator = createValidator(schema);
-  const bridge = new JSONSchemaBridge(schema, schemaValidator);
+  const bridge = new CustomJsonSchemaBridge(schema, schemaValidator);
   const previousModel = useRef(configuration);
   return (
     <AutoForm

--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -80,13 +80,16 @@ const VisualizationStepViews = ({
   };
 
   useEffect(() => {
-    let tempSchemaObject: { [label: string]: { type: string; value?: any } } = {};
+    let tempSchemaObject: { [label: string]: { type: string; value?: any; description?: string } } = {};
+
     let tempModelObject: { [label: string]: any } = {};
 
     const schemaProps = (parameter: { [label: string]: any }) => {
       const propKey = parameter.id;
-      const { type } = parameter;
-      tempSchemaObject[propKey] = { type };
+      const description = parameter.description;
+      const type = parameter.type;
+
+      tempSchemaObject[propKey] = { type, description };
       tempModelObject[propKey] = parameter.value;
     };
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './AppearanceModal';
 export * from './Catalog';
 export * from './ConfirmationModal';
 export * from './Console';
+export * from './CustomJsonSchemaBridge';
 export * from './DeploymentsModal';
 export * from './Extension';
 export * from './JsonSchemaConfigurator';


### PR DESCRIPTION
Added custom bridge, based on [this doc](https://uniforms.tools/docs/examples-custom-bridge/). 
The related issue is https://github.com/KaotoIO/kaoto-ui/issues/674

Currently the forms look like this:
![Screenshot from 2022-12-13 12-15-12](https://user-images.githubusercontent.com/4180208/207303558-dd40dd28-5947-4065-9941-fdbd2022b2b5.png)

Please let me know, if this is what the helper functionality was supposed to look like.