### PR TITLE
fix: Camel routes not being rendered

### DIFF
--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -53,7 +53,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       fetchIntegrationJson(incomingData, settings.dsl.name)
         .then((res: IIntegration) => {
           let tmpInt = res;
-          if (res.metadata.name != '') {
+          if (typeof res.metadata?.name === 'string' && res.metadata.name !== '') {
             settings.name = res.metadata.name;
             setSettings({ name: res.metadata.name });
           }

--- a/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
+++ b/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
@@ -136,11 +136,10 @@ function KogitoEditorIntegrationProviderInternal(
             if (canceled.get()) return;
 
             let tmpInt = res;
-            const name = tmpInt.metadata.name;
 
-            if (name !== '') {
-              settings.name = name;
-              setSettings({ name: name });
+            if (typeof res.metadata?.name === 'string' && res.metadata.name !== '') {
+              settings.name = res.metadata.name;
+              setSettings({ name: res.metadata.name });
             }
 
             tmpInt.metadata = { ...res.metadata, ...settings };


### PR DESCRIPTION
Currently, Camel routes don't have a name property, causing an exception whenever the source code editor attempts to access it to propagate the name to the UI.

This commit adds an extra validation to ensure that the metadata field is not `null` and that the name is a non-empty string.

handles [#958](https://github.com/KaotoIO/kaoto-ui/issues/958)