### PR TITLE
Add monaco-yaml plugin for the code editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lodash.isequal": "^4.5.0",
     "monaco-editor": "^0.34.1",
     "monaco-editor-webpack-plugin": "^7.0.1",
+    "monaco-yaml": "^4.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -15,6 +15,7 @@ const initDsl: IDsl = {
   output: '',
   stepKinds: '',
   name: 'KameletBinding',
+  validationSchema: '',
 };
 
 const initialSettings: ISettings = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,7 @@ export interface IDsl {
   name: string;
   description: string;
   stepKinds: string;
+  validationSchema: string;
 }
 
 /**

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -75,6 +75,16 @@ module.exports = () => {
       new MonacoWebpackPlugin({
         languages: ['yaml'],
         globalAPI: true,
+        customLanguages: [
+          {
+            label: 'yaml',
+            entry: 'monaco-yaml',
+            worker: {
+              id: 'monaco-yaml/yamlWorker',
+              entry: 'monaco-yaml/yaml.worker',
+            },
+          },
+        ],
       }),
       new MiniCssExtractPlugin({
         insert: (linkTag) => {


### PR DESCRIPTION
monaco-yaml plugin  enables client side validation based on json schema. This requires https://github.com/KaotoIO/kaoto-backend/pull/393 to be merged. 
Closes: #991 
