### PR TITLE
feat(viz): add ability to delete branch steps

### DIFF
--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -185,7 +185,6 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
       );
 
       deleteBranchStep(updatedParentStep, parentStepIdx);
-      // how to delete the node? what is the index?
     } else {
       // `deleteStep` requires the index to be from `integrationJson`, not `nodes`
       const stepsIndex = findStepIdxWithUUID(UUID, integrationJson.steps);

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -16,6 +16,7 @@ import {
   flattenSteps,
   getLayoutedElements,
   containsAddStepPlaceholder,
+  filterStepWithBranches,
 } from '@kaoto/services';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps, IViewData, IVizStepPropsEdge, IVizStepNode } from '@kaoto/types';
@@ -46,7 +47,8 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     type: '',
     UUID: '',
   });
-  const { deleteStep, integrationJson, replaceStep, setViews } = useIntegrationJsonStore();
+  const { deleteBranchStep, deleteStep, integrationJson, replaceStep, setViews } =
+    useIntegrationJsonStore();
   const { nestedSteps } = useNestedStepsStore();
   const layout = useVisualizationStore((state) => state.layout);
   const previousIntegrationJson = useRef(integrationJson);
@@ -168,11 +170,29 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
     setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '' });
     if (isPanelExpanded) setIsPanelExpanded(false);
 
-    // `deleteStep` requires the index to be from `integrationJson`, not `nodes`
-    const stepsIndex = findStepIdxWithUUID(UUID, integrationJson.steps);
+    // check if the step being modified is nested
+    const currentStepNested = nestedSteps.find((ns) => ns.stepUuid === UUID);
+    if (currentStepNested) {
+      const parentStepIdx = findStepIdxWithUUID(
+        currentStepNested.originStepUuid,
+        integrationJson.steps
+      );
 
-    deleteNode(stepsIndex);
-    deleteStep(stepsIndex);
+      // update the original parent step, without the child step
+      const updatedParentStep = filterStepWithBranches(
+        integrationJson.steps[parentStepIdx],
+        (step: { UUID: string }) => step.UUID !== UUID
+      );
+
+      deleteBranchStep(updatedParentStep, parentStepIdx);
+      // how to delete the node? what is the index?
+    } else {
+      // `deleteStep` requires the index to be from `integrationJson`, not `nodes`
+      const stepsIndex = findStepIdxWithUUID(UUID, integrationJson.steps);
+
+      deleteNode(stepsIndex);
+      deleteStep(stepsIndex);
+    }
   };
 
   const onClosePanelClick = () => {

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -26,6 +26,7 @@ import {
   isMiddleStep,
   isStartStep,
   regenerateUuids,
+  shouldAddEdge,
 } from './visualizationService';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
@@ -397,5 +398,90 @@ describe('visualizationService', () => {
     expect(regenerateUuids(steps)[0].UUID).toBeDefined();
     expect(regenerateUuids(branchSteps)[0].UUID).toBeDefined();
     expect(regenerateUuids(branchSteps)[1].UUID).toBeDefined();
+  });
+
+  /**
+   * shouldAddEdge
+   */
+  it('shouldAddEdge(): given a node, should determine whether to add an edge for it', () => {
+    const nodeWithoutBranches = {
+      id: 'node-without-branches',
+      position: { x: 0, y: 0 },
+      data: { label: '', step: { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '' } },
+    };
+
+    const nextNode = {
+      id: 'next-node',
+      position: { x: 0, y: 0 },
+      data: {
+        label: 'Next Node',
+        step: { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '' },
+      },
+    };
+
+    // there is no next node, so it should be false
+    expect(shouldAddEdge(nodeWithoutBranches)).toBeFalsy();
+    expect(shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
+
+    const nodeWithBranches = {
+      id: 'node-with-branches',
+      position: { x: 0, y: 0 },
+      data: {
+        label: '',
+        step: {
+          UUID: '',
+          name: '',
+          maxBranches: 0,
+          minBranches: 0,
+          type: '',
+          branches: [
+            {
+              identifier: 'branch-1',
+              steps: [{ UUID: 'abcd', name: 'abcd', maxBranches: 0, minBranches: 0, type: '' }],
+            },
+            {
+              identifier: 'branch-2',
+              steps: [{ UUID: 'efgh', name: 'efgh', maxBranches: 0, minBranches: 0, type: '' }],
+            },
+          ],
+        },
+      },
+    };
+
+    // there is no next node, so it should be false
+    expect(shouldAddEdge(nodeWithBranches)).toBeFalsy();
+
+    // it has branches with steps, so it should be false because
+    // the steps will connect with the next step later on
+    expect(shouldAddEdge(nodeWithBranches, nextNode)).toBeFalsy();
+
+    const nodeWithEmptyBranch = {
+      id: 'node-with-empty-branch',
+      position: { x: 0, y: 0 },
+      data: {
+        label: '',
+        step: {
+          UUID: '',
+          name: '',
+          maxBranches: 0,
+          minBranches: 0,
+          type: '',
+          branches: [
+            {
+              identifier: 'branch-1',
+              steps: [],
+            },
+            {
+              identifier: 'branch-2',
+              steps: [],
+            },
+          ],
+        },
+      },
+    };
+
+    // there is no next node, so it should be false
+    expect(shouldAddEdge(nodeWithEmptyBranch)).toBeFalsy();
+    expect(shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
   });
 });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -115,13 +115,7 @@ export function buildEdges(nodes: IVizStepNode[]): IVizStepPropsEdge[] {
   nodes.forEach((node) => {
     const nextNodeIdx = findNodeIdxWithUUID(node.data.nextStepUuid, nodes);
 
-    if (
-      node.data.step &&
-      nodes[nextNodeIdx] &&
-      (!containsBranches(node.data.step) ||
-        (containsBranches(node.data.step) &&
-          node.data.step.branches.some((b: IStepPropsBranch) => b.steps.length === 0)))
-    ) {
+    if (shouldAddEdge(node, nodes[nextNodeIdx])) {
       stepEdges.push(
         buildEdgeParams(
           node,
@@ -233,7 +227,7 @@ export function buildNodesFromSteps(
  * Checks if an array of nodes contains an ADD A STEP placeholder step
  * @param stepNodes
  */
-export function containsAddStepPlaceholder(stepNodes: IVizStepNode[]) {
+export function containsAddStepPlaceholder(stepNodes: IVizStepNode[]): boolean {
   return stepNodes.length > 0 && stepNodes[0].data.label === 'ADD A STEP';
 }
 
@@ -305,7 +299,7 @@ export function filterNestedSteps(steps: IStepProps[], predicate: (step: IStepPr
         if (clone && clone.branches) {
           clone.branches.forEach((branch, idx) => {
             const filteredBranchSteps = filterNestedSteps(branch.steps, predicate);
-            if (filteredBranchSteps && clone && clone.branches) {
+            if (filteredBranchSteps && clone?.branches) {
               clone.branches[idx].steps = filteredBranchSteps;
             }
           });
@@ -553,7 +547,7 @@ export function isStartStep(step: IStepProps): boolean {
  * @param steps
  * @param branchSteps
  */
-export function regenerateUuids(steps: IStepProps[], branchSteps: boolean = false) {
+export function regenerateUuids(steps: IStepProps[], branchSteps: boolean = false): IStepProps[] {
   let newSteps = steps.slice();
 
   newSteps.forEach((step, idx) => {
@@ -566,4 +560,20 @@ export function regenerateUuids(steps: IStepProps[], branchSteps: boolean = fals
     }
   });
   return newSteps;
+}
+
+/**
+ * Given a node, determines if an edge should be created for it
+ * @param node
+ * @param nextNode
+ */
+export function shouldAddEdge(node: IVizStepNode, nextNode?: IVizStepNode): boolean {
+  return (
+    node.data.step &&
+    nextNode &&
+    // it either contains no branches, or those branches don't have any steps in them
+    (!containsBranches(node.data.step) ||
+      (containsBranches(node.data.step) &&
+        node.data.step.branches.some((b: IStepPropsBranch) => b.steps.length === 0)))
+  );
 }

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -115,7 +115,13 @@ export function buildEdges(nodes: IVizStepNode[]): IVizStepPropsEdge[] {
   nodes.forEach((node) => {
     const nextNodeIdx = findNodeIdxWithUUID(node.data.nextStepUuid, nodes);
 
-    if (node.data.step && nodes[nextNodeIdx] && !containsBranches(node.data.step)) {
+    if (
+      node.data.step &&
+      nodes[nextNodeIdx] &&
+      (!containsBranches(node.data.step) ||
+        (containsBranches(node.data.step) &&
+          node.data.step.branches.some((b: IStepPropsBranch) => b.steps.length === 0)))
+    ) {
       stepEdges.push(
         buildEdgeParams(
           node,
@@ -170,7 +176,10 @@ export function buildNodesFromSteps(
   let getId = (uuid: string) => `node_${id++}-${uuid}-${getRandomArbitraryNumber()}`;
 
   // if no steps or first step isn't START or an EIP, create a dummy placeholder step
-  if (steps.length === 0 || (!isFirstStepStart(steps) && !isFirstStepEip(steps) && !branchInfo)) {
+  if (
+    (steps.length === 0 && !branchInfo) ||
+    (!isFirstStepStart(steps) && !isFirstStepEip(steps) && !branchInfo)
+  ) {
     insertAddStepPlaceholder(stepNodes, { id: getId(''), nextStepUuid: steps[0]?.UUID });
   }
 

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -13,6 +13,7 @@ import create from 'zustand';
 
 interface IIntegrationJsonStore {
   appendStep: (newStep: IStepProps) => void;
+  deleteBranchStep: (newStep: IStepProps, originalStepIndex: number) => void;
   deleteIntegration: () => void;
   deleteStep: (index: number) => void;
   deleteSteps: () => void;
@@ -53,6 +54,22 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
         });
       },
       deleteIntegration: () => set(initialState),
+      deleteBranchStep: (newStep: IStepProps, originalStepIndex: number) => {
+        let newSteps = get().integrationJson.steps.slice();
+        // replacing the origin parent of a deeply nested step
+        newSteps[originalStepIndex] = newStep;
+
+        const stepsWithNewUuids = regenerateUuids(newSteps);
+        const { updateSteps } = useNestedStepsStore.getState();
+        updateSteps(extractNestedSteps(stepsWithNewUuids));
+
+        return set((state) => ({
+          integrationJson: {
+            ...state.integrationJson,
+            steps: [...stepsWithNewUuids],
+          },
+        }));
+      },
       deleteStep: (stepIdx) => {
         let stepsCopy = get().integrationJson.steps.slice();
         const updatedSteps = stepsCopy.filter((_step: IStepProps, idx: number) => idx !== stepIdx);

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,5 +1,6 @@
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
 import { findPath, setDeepValue } from './index';
+import { filterNestedSteps } from '@kaoto/services';
 
 describe('utils', () => {
   it('findPath(): should find the path from a deeply nested object, given a value', () => {
@@ -14,6 +15,22 @@ describe('utils', () => {
       'steps',
       '0',
     ]);
+  });
+
+  /**
+   * filterNestedSteps
+   */
+  it('filterNestedSteps(): should filter an array of steps given a conditional function', () => {
+    const nestedBranchCopy = nestedBranch.slice();
+    // @ts-ignore
+    expect(nestedBranchCopy[1].branches[0].steps[0].branches[0].steps).toHaveLength(1);
+
+    const filteredNestedBranch = filterNestedSteps(
+      nestedBranchCopy,
+      (step) => step.UUID !== 'log-340230'
+    );
+    // @ts-ignore
+    expect(filteredNestedBranch[1].branches[0].steps[0].branches[0].steps).toHaveLength(0);
   });
 
   it('setDeepValue(): given a path, should modify only a deeply nested value within a complex object', () => {


### PR DESCRIPTION
## Description
This PR adds the ability to delete branch steps.

### Changes
- Adds helper functions like `filterStepWithBranches` and `filterNestedSteps` for faster checking of branches
- Adds a method to the `integrationJsonStore` for deleting branch steps
- Extracts the check for whether an edge should be created to its own function, for easier testing
- Updates the conditional that checks when to add a placeholder step

## Screenshots
![Kapture 2023-01-18 at 11 46 38](https://user-images.githubusercontent.com/3844502/213163861-79b50304-4d4b-4271-815f-333501e9685e.gif)

resolves #1115 