### PR TITLE
chore: Add GitHub Workflow to check "prod" build

### DIFF
--- a/.github/workflows/build-npm-package.yml
+++ b/.github/workflows/build-npm-package.yml
@@ -1,0 +1,21 @@
+name:  📦 Build npm Package
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@kaoto'
+      - run: yarn
+      - run: yarn build
+      - run: yarn build:lib


### PR DESCRIPTION
The idea is to follow the steps used when publishing to npm and ensure that they are working on main branch to always stay in a releasable state

fixes #1122
