### PR TITLE
chore: upgrade TypeScript to 4.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "tsc-watch": "^6.0.0",
     "tsconfig-paths-webpack-plugin": "4.0.0",
     "tslib": "^2.4.1",
-    "typescript": "4.4.4",
+    "typescript": "^4.9.4",
     "url-loader": "4.1.1",
     "web-worker": "^1.2.0",
     "webpack": "5.75.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9009,10 +9009,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
new version of parse5 (7+) used is requiring a TypeScript 4.5 ( https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names ). It was before on 4.4.4

it allows to fix main branch when calling `yarn build:lib` which is used to publish the npm package

fixes #1125
