### PR TITLE
feat(viz): add ability to insert branch steps

### DIFF
--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -71,7 +71,7 @@ export function canStepBeReplaced(
  * @param _prevStep
  * @param _nextStep
  */
-export function insertableStepTypes(_prevStep?: any, _nextStep?: any): string {
+export function insertableStepTypes(_prevStep?: IStepProps, _nextStep?: IStepProps): string {
   let possibleSteps: string[] = ['START', 'MIDDLE', 'END'];
   if (_prevStep) {
     // inserted step can be MIDDLE or END

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -20,6 +20,7 @@ import {
   getRandomArbitraryNumber,
   insertAddStepPlaceholder,
   insertBranchGroupNode,
+  insertStep,
   isEndStep,
   isFirstStepEip,
   isFirstStepStart,
@@ -319,6 +320,22 @@ describe('visualizationService', () => {
     const nodes: IVizStepNode[] = [];
     insertBranchGroupNode(nodes, { x: 0, y: 0 }, 150, groupWidth);
     expect(nodes).toHaveLength(1);
+  });
+
+  /**
+   * insertStep
+   */
+  it('insertStep(): should insert the provided step at the index specified, in a given array of steps', () => {
+    const steps = [
+      {
+        name: 'strawberry',
+      },
+      {
+        name: 'blueberry',
+      },
+    ] as IStepProps[];
+
+    expect(insertStep(steps, 2, { name: 'peach' } as IStepProps)).toHaveLength(3);
   });
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -58,7 +58,7 @@ export function buildBranchSpecialEdges(stepNodes: IVizStepNode[]): IVizStepProp
     ) {
       const branchStepNextIdx = findNodeIdxWithUUID(node.data.nextStepUuid, stepNodes);
       if (stepNodes[branchStepNextIdx]) {
-        specialEdges.push(buildEdgeParams(node, stepNodes[branchStepNextIdx], 'default'));
+        specialEdges.push(buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert'));
       }
     }
 
@@ -514,6 +514,24 @@ export function insertBranchGroupNode(
       backgroundColor: 'rgba(37, 150, 190, 0.1)',
     },
   });
+}
+
+/**
+ * Insert the given step at the specified index of
+ * an array of provided steps
+ * @param steps
+ * @param insertIndex
+ * @param newStep
+ */
+export function insertStep(steps: IStepProps[], insertIndex: number, newStep: IStepProps) {
+  return [
+    // part of array before the index
+    ...steps.slice(0, insertIndex),
+    // inserted item
+    newStep,
+    // part of array after the index
+    ...steps.slice(insertIndex),
+  ];
 }
 
 export function isEndStep(step: IStepProps): boolean {

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -3,7 +3,7 @@ import { useIntegrationSourceStore } from './integrationSourceStore';
 import { useNestedStepsStore } from './nestedStepsStore';
 import { useSettingsStore } from './settingsStore';
 import { useVisualizationStore } from './visualizationStore';
-import { extractNestedSteps, regenerateUuids } from '@kaoto/services';
+import { extractNestedSteps, insertStep, regenerateUuids } from '@kaoto/services';
 import { IIntegration, IStepProps, IViewProps } from '@kaoto/types';
 import { setDeepValue } from '@kaoto/utils';
 import isEqual from 'lodash.isequal';
@@ -17,7 +17,7 @@ interface IIntegrationJsonStore {
   deleteIntegration: () => void;
   deleteStep: (index: number) => void;
   deleteSteps: () => void;
-  insertStep: (newStep: IStepProps, index: number) => void;
+  insertStep: (newStep: IStepProps, insertIndex: number) => void;
   integrationJson: IIntegration;
   replaceStep: (newStep: IStepProps, oldStepIndex?: number, path?: string[]) => void;
   setViews: (views: IViewProps[]) => void;
@@ -91,20 +91,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           },
         }));
       },
-      insertStep: (newStep, currentStepIdx) => {
+      insertStep: (newStep, insertIndex) => {
         let steps = get().integrationJson.steps.slice();
-
-        // unlike appendStep, we need to also regenerate all UUIDs
-        // because positions are changing
-        const stepsWithNewUuids = regenerateUuids([
-          // part of array before the index
-          ...steps.slice(0, currentStepIdx),
-          // inserted item
-          newStep,
-          // part of array after the index
-          ...steps.slice(currentStepIdx),
-        ]);
-
+        const stepsWithNewUuids = regenerateUuids(insertStep(steps, insertIndex, newStep));
         const updateSteps = useNestedStepsStore.getState().updateSteps;
         updateSteps(extractNestedSteps(stepsWithNewUuids));
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -22,17 +22,18 @@ describe('utils', () => {
    */
   it('filterNestedSteps(): should filter an array of steps given a conditional function', () => {
     const nestedBranchCopy = nestedBranch.slice();
-    // @ts-ignore
-    expect(nestedBranchCopy[1].branches[0].steps[0].branches[0].steps).toHaveLength(1);
+    expect(nestedBranchCopy[1].branches![0].steps[0].branches![0].steps).toHaveLength(1);
 
     const filteredNestedBranch = filterNestedSteps(
       nestedBranchCopy,
       (step) => step.UUID !== 'log-340230'
     );
-    // @ts-ignore
-    expect(filteredNestedBranch[1].branches[0].steps[0].branches[0].steps).toHaveLength(0);
+    expect(filteredNestedBranch![1].branches![0].steps[0].branches![0].steps).toHaveLength(0);
   });
 
+  /**
+   * setDeepValue
+   */
   it('setDeepValue(): given a path, should modify only a deeply nested value within a complex object', () => {
     const object = { a: [{ bar: { c: 3 }, baz: { d: 2 } }] };
 


### PR DESCRIPTION
This PR adds the ability to insert a step in between two branch steps. Resolves #1114.

## Changes
- Add check in mini catalog to validate inserting branch steps
- Add handling in mini catalog step selection for branch steps
- Enable `insert` edge type for branch steps
- Extract `insertStep` logic into its own testable function
- Improve query params for API request to be more accurate with source/target step
- Improve typings

## Screenshots

![Kapture 2023-01-20 at 11 09 00-2](https://user-images.githubusercontent.com/3844502/213689929-17e5ab23-5657-405e-bbf9-02405a72d51e.gif)
