### PR TITLE
feat(branching): add append for branch steps and branch-containing steps

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -34,8 +34,8 @@
 
 .stepNode__Add {
     position: absolute;
-    right: -22px;
-    top: 35%;
+    right: -24px;
+    top: 38%;
 }
 
 .stepNode__Delete {

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -227,7 +227,7 @@ const Visualization = ({ toggleCatalog }: IVisualization) => {
             integrationJson.steps
           );
 
-          replaceStep(newStep, oldStepIdx, currentStepNested.path);
+          replaceStep(newStep, oldStepIdx, currentStepNested.pathToStep);
         }
       } else {
         const oldStepIdx = findStepIdxWithUUID(newStep.UUID, integrationJson.steps);

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -361,27 +361,12 @@ describe('visualizationService', () => {
           name: 'pdf-action',
           type: 'MIDDLE',
           UUID: 'pdf-action-1',
-          description: 'Create a PDF',
           group: 'PDF',
-          icon: 'data:image/svg+xml;base64',
           kind: 'Kamelet',
-          maxBranches: 0,
-          minBranches: 0,
-          parameters: [],
           title: 'PDF Action',
-        },
+        } as IStepProps,
       ])
     ).toBe(false);
-  });
-
-  /**
-   * isLastNode
-   */
-  it('isLastNode(): should determine if the provided node is the last one, given an array of nodes', () => {
-    const firstBranch = eipIntegration[1].branches![0];
-    // the first step is just a normal Camel-Connector
-    expect(isFirstStepEip(eipIntegration)).toBe(false);
-    expect(isFirstStepEip(firstBranch.steps)).toBe(true);
   });
 
   /**
@@ -423,18 +408,16 @@ describe('visualizationService', () => {
   it('shouldAddEdge(): given a node, should determine whether to add an edge for it', () => {
     const nodeWithoutBranches = {
       id: 'node-without-branches',
-      position: { x: 0, y: 0 },
-      data: { label: '', step: { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '' } },
-    };
+      data: { label: '', step: { UUID: '' } },
+    } as IVizStepNode;
 
     const nextNode = {
       id: 'next-node',
-      position: { x: 0, y: 0 },
       data: {
         label: 'Next Node',
-        step: { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '' },
+        step: { UUID: '' },
       },
-    };
+    } as IVizStepNode;
 
     // there is no next node, so it should be false
     expect(shouldAddEdge(nodeWithoutBranches)).toBeFalsy();
@@ -442,28 +425,21 @@ describe('visualizationService', () => {
 
     const nodeWithBranches = {
       id: 'node-with-branches',
-      position: { x: 0, y: 0 },
       data: {
-        label: '',
         step: {
-          UUID: '',
-          name: '',
-          maxBranches: 0,
-          minBranches: 0,
-          type: '',
           branches: [
             {
               identifier: 'branch-1',
-              steps: [{ UUID: 'abcd', name: 'abcd', maxBranches: 0, minBranches: 0, type: '' }],
+              steps: [{ UUID: 'abcd', name: 'abcd' }],
             },
             {
               identifier: 'branch-2',
-              steps: [{ UUID: 'efgh', name: 'efgh', maxBranches: 0, minBranches: 0, type: '' }],
+              steps: [{ UUID: 'efgh', name: 'efgh' }],
             },
           ],
         },
       },
-    };
+    } as IVizStepNode;
 
     // there is no next node, so it should be false
     expect(shouldAddEdge(nodeWithBranches)).toBeFalsy();
@@ -474,15 +450,8 @@ describe('visualizationService', () => {
 
     const nodeWithEmptyBranch = {
       id: 'node-with-empty-branch',
-      position: { x: 0, y: 0 },
       data: {
-        label: '',
         step: {
-          UUID: '',
-          name: '',
-          maxBranches: 0,
-          minBranches: 0,
-          type: '',
           branches: [
             {
               identifier: 'branch-1',
@@ -495,7 +464,7 @@ describe('visualizationService', () => {
           ],
         },
       },
-    };
+    } as IVizStepNode;
 
     // there is no next node, so it should be false
     expect(shouldAddEdge(nodeWithEmptyBranch)).toBeFalsy();

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -104,20 +104,20 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           },
         }));
       },
-      replaceStep: (newStep, oldStepIndex, path) => {
-        let newSteps = get().integrationJson.steps.slice();
+      replaceStep: (newStep, oldStepIndex, pathToStep) => {
+        let stepsCopy = get().integrationJson.steps.slice();
         if (oldStepIndex === undefined) {
           // replacing a slot step with no pre-existing step
-          newSteps.unshift(newStep);
-        } else if (path) {
+          stepsCopy.unshift(newStep);
+        } else if (pathToStep) {
           // replacing a deeply nested step
-          newSteps = setDeepValue(newSteps, path, newStep);
+          stepsCopy = setDeepValue(stepsCopy, pathToStep, newStep);
         } else {
           // replacing an existing step
-          newSteps[oldStepIndex] = newStep;
+          stepsCopy[oldStepIndex] = newStep;
         }
 
-        const stepsWithNewUuids = regenerateUuids(newSteps);
+        const stepsWithNewUuids = regenerateUuids(stepsCopy);
         const { updateSteps } = useNestedStepsStore.getState();
         updateSteps(extractNestedSteps(stepsWithNewUuids));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,9 +104,9 @@ export interface IKaotoApi {
 }
 
 export interface INestedStep {
-  branchUuid?: string;
+  branchUuid: string;
   originStepUuid: string;
-  path: string[] | undefined;
+  pathToStep: string[] | undefined;
   stepUuid: string;
 }
 
@@ -138,6 +138,7 @@ export interface IStepProps {
 }
 
 export interface IStepPropsBranch {
+  branchUuid: string;
   condition?: string;
   identifier: string;
   steps: IStepProps[];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,33 @@ export function formatDateTime(date: string) {
   );
 }
 
+/**
+ * Given a complex array or object and a path,
+ * returns the value located at the path
+ * @param obj
+ * @param path
+ */
+export function getDeepValue(obj: any, path: any) {
+  // If path is not defined or it has false value
+  if (!path) return undefined;
+  // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
+  // Regex explained: https://regexr.com/58j0k
+  const pathArray = Array.isArray(path) ? path : path.match(/([^[.\]])+/g);
+  // Find value
+  return pathArray.reduce(
+    (prevObj: { [x: string]: any }, key: string | number) => prevObj && prevObj[key],
+    obj
+  );
+}
+
+/**
+ * Given a complex array or object, a path, and a value to modify,
+ * it will update the object at that path with the provided value.
+ * Returns the complex array or object with the new value.
+ * @param obj
+ * @param path
+ * @param value
+ */
 export function setDeepValue(obj: any, path: any, value: any) {
   const pathArray = Array.isArray(path) ? path : path.match(/([^[.\]])+/g);
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
-import { findPath, setDeepValue } from './index';
+import { findPath, getDeepValue, setDeepValue } from './index';
 import { filterNestedSteps } from '@kaoto/services';
 
 describe('utils', () => {
@@ -29,6 +29,17 @@ describe('utils', () => {
       (step) => step.UUID !== 'log-340230'
     );
     expect(filteredNestedBranch![1].branches![0].steps[0].branches![0].steps).toHaveLength(0);
+  });
+
+  /**
+   * getDeepValue
+   */
+  it('getDeepValue(): given a complex object & path, should return the value of the object at the path', () => {
+    const object = { a: [{ bar: { c: 3 }, baz: { d: 2 } }] };
+    expect(getDeepValue(object, 'a[0].baz.d')).toEqual(2);
+
+    const objectArray = [object];
+    expect(getDeepValue(objectArray, '[0].a[0].bar.c')).toEqual(3);
   });
 
   /**


### PR DESCRIPTION
This PR adds the ability to append steps to branch steps and steps that contain branches. Resolves #1117.

## Changes
- Changes `onMiniCatalogClickAdd` to `onMiniCatalogClickInsert` for clarity
- Updates `onMiniCatalogClickInsert` to handle branch steps specially
- Generates a `branchUuid` now for all branches, for faster reference
- Adds helper utility function `getDeepValue` for easier access to nested steps
- Updates the `path` prop to `pathToStep` so it's clearer
- CSS: Aligns the insert step button with append step

## Screenshots

![Kapture 2023-01-25 at 17 06 36](https://user-images.githubusercontent.com/3844502/214638449-a641533d-5928-4d69-b118-5381264e4aa8.gif)
