### PR TITLE
chore(ci): add codecov.yml

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Add a `codecov.yml` file with configuration settings, and makes Codecov informational, rather than gating pull requests and failing the status: https://docs.codecov.com/docs/commit-status#informational

note: I'm actually on the fence about this, as I don't want us to let our code coverage slip either, but sometimes the coverage change is -0.1% and it still fails. I know we can change the threshold, but I figured maybe making it informational makes more sense? Let me know what you think.