### PR TITLE
Fix properties view in prod version compiled with build:lib

### DIFF
--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "lib": ["es6", "dom", "es2018.promise", "es2019", "esnext"],
     "outDir": "dist/lib",
-    "target": "es5",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Due to:
- inheritance of CustomJSonSchemaBridge to JSonSchemaBridge from uniforms-bridge-json-schema using a super method for the constructor
- uniforms-json-schema-bridge compiled in es6
- prod build of Kaoto compiled in es5
- no more rights to call constructor without new in es6 and es5 generating code without the constructor

It was working in development mode because the tsconfig of prod was overriding the target version from es6 to es5.

fixes vscode-kaoto#115

Thoughts for later:
- the tsconfig.lib.json is overriding/duplicating a lot of things from tsconfig, will be nice to cleanup this file to avoid this kind of discrepancies. https://github.com/KaotoIO/kaoto-ui/issues/1170
- would be nice to have the tests played with the prod build