### PR TITLE
feat(viz): add ability to prepend step to branch steps

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -81,6 +81,12 @@
     padding: 0.4em;
 }
 
+.stepNode__Prepend {
+    position: absolute;
+    left: -24px;
+    top: 38%;
+}
+
 .stepNode__Slot {
     border: 2px solid var(--pf-global--BorderColor--100);
     border-radius: 50%;

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -1,0 +1,7 @@
+import { prependableStepTypes } from './validationService';
+
+describe('validationService', () => {
+  it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {
+    expect(prependableStepTypes()).toEqual('MIDDLE');
+  });
+});

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -94,3 +94,10 @@ export function isNameValidCheck(name: string) {
   const regexPattern = /^[a-z\d]([-a-z\d]*[a-z\d])?(\.[a-z\d]([-a-z\d]*[a-z\d])?)*$/gm;
   return regexPattern.test(name);
 }
+
+/**
+ * Returns the step types that can be prepended to a step.
+ */
+export function prependableStepTypes(): string {
+  return 'MIDDLE';
+}

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -26,6 +26,7 @@ import {
   isFirstStepStart,
   isMiddleStep,
   isStartStep,
+  prependStep,
   regenerateUuids,
   shouldAddEdge,
 } from './visualizationService';
@@ -336,6 +337,8 @@ describe('visualizationService', () => {
     ] as IStepProps[];
 
     expect(insertStep(steps, 2, { name: 'peach' } as IStepProps)).toHaveLength(3);
+    // does it insert it at the correct spot?
+    expect(insertStep(steps, 2, { name: 'peach' } as IStepProps)[2]).toEqual({ name: 'peach' });
   });
 
   /**
@@ -391,6 +394,23 @@ describe('visualizationService', () => {
   it('isStartStep(): should determine if the provided step is a START step', () => {
     expect(isStartStep(eipIntegration[0])).toBe(true);
     expect(isStartStep(eipIntegration[1])).toBe(false);
+  });
+
+  /**
+   * prependStep
+   */
+  it('prependStep(): should insert the provided step at the beginning of a given array of steps', () => {
+    const steps = [
+      {
+        name: 'strawberry',
+      },
+      {
+        name: 'blueberry',
+      },
+    ] as IStepProps[];
+
+    expect(prependStep(steps, { name: 'peach' } as IStepProps)).toHaveLength(3);
+    expect(prependStep(steps, { name: 'mango' } as IStepProps)[0]).toEqual({ name: 'mango' });
   });
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -526,7 +526,11 @@ export function insertBranchGroupNode(
  * @param insertIndex
  * @param newStep
  */
-export function insertStep(steps: IStepProps[], insertIndex: number, newStep: IStepProps) {
+export function insertStep(
+  steps: IStepProps[],
+  insertIndex: number,
+  newStep: IStepProps
+): IStepProps[] {
   return [
     // part of array before the index
     ...steps.slice(0, insertIndex),
@@ -555,6 +559,18 @@ export function isMiddleStep(step: IStepProps): boolean {
 
 export function isStartStep(step: IStepProps): boolean {
   return step.type === 'START';
+}
+
+/**
+ * Inserts the given step at the beginning of the
+ * array of provided steps, returning the modified array
+ * @param steps
+ * @param newStep
+ */
+export function prependStep(steps: IStepProps[], newStep: IStepProps): IStepProps[] {
+  const newSteps = [...steps];
+  newSteps.unshift(newStep);
+  return newSteps;
 }
 
 /**


### PR DESCRIPTION
This PR adds the ability to prepend a step in an array of branch steps (insert it into the first position of branch steps). Resolves #1161.

## Changes
- adds prepend button to the visualization & a conditional check for first steps in a branch
- adds handler to the mini catalog for clicking the prepend button
- adds `prependStep` function to `visualizationService`
- adds validation check for `prependable step types
- adds test for `validationService` prependable steps
- adds test for `prependStep` service function

## Screenshots

### Prepend button

![Screen Shot 2023-01-27 at 3 21 18 pm copy](https://user-images.githubusercontent.com/3844502/215134324-9b6574cc-bcac-4054-9c25-3b7a7151aeef.png)


### Prepending a step

![Kapture 2023-01-27 at 16 01 56](https://user-images.githubusercontent.com/3844502/215133951-e2fb7fdc-e393-440d-a598-8b558d466e6e.gif)
