### PR TITLE
feat(viz): show empty branches with placeholder

### DIFF
--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -1,6 +1,99 @@
-import { prependableStepTypes } from './validationService';
+import { canStepBeReplaced, prependableStepTypes } from './validationService';
+import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 
 describe('validationService', () => {
+  it('canStepBeReplaced(): should return a boolean to determine if a step can be replaced', () => {
+    // start steps
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'START' } } as IVizStepNodeData,
+        { type: 'START' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'START' } } as IVizStepNodeData,
+        { type: 'MIDDLE' } as IStepProps
+      ).isValid
+    ).toBeFalsy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'START' } } as IVizStepNodeData,
+        { type: 'END' } as IStepProps
+      ).isValid
+    ).toBeFalsy();
+
+    // middle steps
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'MIDDLE' } } as IVizStepNodeData,
+        { type: 'START' } as IStepProps
+      ).isValid
+    ).toBeFalsy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'MIDDLE' } } as IVizStepNodeData,
+        { type: 'MIDDLE' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'MIDDLE' }, isLastStep: false } as IVizStepNodeData,
+        { type: 'END' } as IStepProps
+      ).isValid
+    ).toBeFalsy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'MIDDLE' }, isLastStep: true } as IVizStepNodeData,
+        { type: 'END' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+
+    // end steps
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'END' } } as IVizStepNodeData,
+        { type: 'START' } as IStepProps
+      ).isValid
+    ).toBeFalsy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'END' }, isLastStep: true } as IVizStepNodeData,
+        { type: 'MIDDLE' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'END' }, isLastStep: true } as IVizStepNodeData,
+        { type: 'END' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+
+    // branch placeholder step
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'START' }, branchInfo: {}, isPlaceholder: true } as IVizStepNodeData,
+        { type: 'START' } as IStepProps
+      ).isValid
+    ).toBeFalsy();
+    expect(
+      canStepBeReplaced(
+        { step: { type: 'START' }, branchInfo: {}, isPlaceholder: true } as IVizStepNodeData,
+        { type: 'MIDDLE' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+    expect(
+      canStepBeReplaced(
+        {
+          step: { type: 'START' },
+          branchInfo: {},
+          isPlaceholder: true,
+        } as IVizStepNodeData,
+        { type: 'END' } as IStepProps
+      ).isValid
+    ).toBeTruthy();
+  });
+
   it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {
     expect(prependableStepTypes()).toEqual('MIDDLE');
   });

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -5,6 +5,7 @@ import nodes from '../store/data/nodes';
 import steps from '../store/data/steps';
 import {
   buildBranchNodeParams,
+  buildBranchSingleStepEdges,
   buildEdgeParams,
   buildEdges,
   buildNodeDefaultParams,
@@ -77,6 +78,23 @@ describe('visualizationService', () => {
     });
   });
 
+  it('buildBranchSingleStepEdges(): should build edges before and after a branch with only one step', () => {
+    const node = {
+      data: {
+        step: {
+          branches: [
+            {
+              steps: [{ UUID: 'single-step' }],
+            },
+          ],
+        },
+      },
+    } as IVizStepNode;
+    const rootNode = {} as IVizStepNode;
+    const rootNodeNext = {} as IVizStepNode;
+    expect(buildBranchSingleStepEdges(node, rootNode, rootNodeNext)).toHaveLength(2);
+  });
+
   /**
    * buildEdgeParams
    */
@@ -130,11 +148,13 @@ describe('visualizationService', () => {
    */
   it('buildNodeDefaultParams(): should build the default parameters for a single node, given a step', () => {
     const position = { x: 0, y: 0 };
-    const step = nodes[1].data.step;
+    const step = { name: 'avro-deserialize-action', icon: '', kind: 'Kamelet' } as IStepProps;
 
     expect(buildNodeDefaultParams(step, 'dummy-id', position)).toEqual({
       data: {
+        branchInfo: undefined,
         icon: step.icon,
+        isPlaceholder: false,
         kind: step.kind,
         label: truncateString(step.name, 14),
         step,
@@ -310,7 +330,7 @@ describe('visualizationService', () => {
    */
   it('insertAddStepPlaceholder(): should add an ADD STEP placeholder to the beginning of the array', () => {
     const nodes: IVizStepNode[] = [];
-    insertAddStepPlaceholder(nodes, { id: '', nextStepUuid: '' });
+    insertAddStepPlaceholder(nodes, '', { nextStepUuid: '' });
     expect(nodes).toHaveLength(1);
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -222,6 +222,7 @@ export interface IVizStepNodeData {
   icon?: string;
   isFirstStep?: boolean;
   isLastStep?: boolean;
+  isPlaceholder?: boolean;
   kind?: string;
   label: string;
   nextStepUuid?: string;


### PR DESCRIPTION
This PR adds the ability to see branches even when they contain no steps. They will instead show a placeholder step that users can drag a new step onto. Resolves #1158.

## Changes
- fix(viz): normal edge should not be created for empty branches
- fix(viz): add left handle for add step placeholder within a branch
- feat(viz): add edge to connect placeholder to branch parent
- fix(viz): fix issue with validation error messaging
- feat(viz): allow branch placeholders to be replaced
- viz: connect placeholder back to next step
- fix(viz): fix warning for branch end steps and edges
  - This was a warning that I discovered was happening on `main` as well, when you add an `END` step to a branch
- fix(test): fix `buildNodeDefaultParams` test
- chore(test): add tests for step validation
- fix(viz): open catalog instead of step view when clicking a branch placeholder
- fix(viz): allow replacing branch placeholder with end step

## Screenshots

Empty branches before were showing an additional edge like this:

![Screen Shot 2023-02-02 at 12 49 01 pm](https://user-images.githubusercontent.com/3844502/216612666-6cef2f73-11dd-45ea-ba73-4134c6c95ba4.png)

With new changes:

<img width="1011" alt="Screen Shot 2023-02-02 at 7 25 57 pm" src="https://user-images.githubusercontent.com/3844502/216613004-3e1d761b-9fc7-49b6-b188-e1f8fa0395f6.png">

Another example:

<img width="898" alt="Screen Shot 2023-02-02 at 7 26 59 pm" src="https://user-images.githubusercontent.com/3844502/216612827-9a47ba0f-fecf-4b20-8971-581e2e6e1c73.png">

On placeholder replacement:

<img width="844" alt="Screen Shot 2023-02-02 at 7 27 19 pm" src="https://user-images.githubusercontent.com/3844502/216612849-7ed5500f-f43c-4660-8b34-0fa21a538a4a.png">

With an `END` step in one branch:

<img width="1198" alt="Screen Shot 2023-02-02 at 7 28 32 pm" src="https://user-images.githubusercontent.com/3844502/216612918-f7b2daa0-1246-4b8c-b8a9-0c37453e2cc3.png">

Fixed an issue I just discovered where the validation message for replacing a branch step wasn't correct, just the generic one:

![Screen Shot 2023-02-03 at 1 20 21 pm](https://user-images.githubusercontent.com/3844502/216613527-58b22a6f-2f58-4a7c-b904-dc12a167cbcb.png)

Now you get better warnings, as originally intended:

![Screen Shot 2023-02-03 at 1 21 22 pm](https://user-images.githubusercontent.com/3844502/216613767-eeb83702-f946-48a1-9f0a-11f442b1ecf0.png)

![Screen Shot 2023-02-03 at 1 21 36 pm](https://user-images.githubusercontent.com/3844502/216613788-2355b002-7bf8-4ceb-af6c-63f21fcd1beb.png)

