### PR TITLE
fix(refactor): Clearer separation of concerns for visualization (#1183)

### DIFF
--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -7,7 +7,7 @@ import {
   DeploymentsModal,
   SettingsModal,
 } from '@kaoto/components';
-import { isNameValidCheck } from '@kaoto/services';
+import { ValidationService } from '@kaoto/services';
 import {
   useDeploymentStore,
   useIntegrationJsonStore,
@@ -267,7 +267,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel }:
                   onChange={(val) => {
                     // save to local state while typing
                     setLocalName(val);
-                    if (isNameValidCheck(val)) {
+                    if (ValidationService.isNameValidCheck(val)) {
                       setNameValidation('success');
                     } else {
                       setNameValidation('error');
@@ -280,7 +280,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel }:
                   onKeyUp={(e) => {
                     // allow users to save by pressing enter
                     if (e.key !== 'Enter') return;
-                    if (isNameValidCheck(localName)) {
+                    if (ValidationService.isNameValidCheck(localName)) {
                       setIsEditingName(false);
                       // only issue change if different from current settings
                       if (localName !== settings.name) {
@@ -293,7 +293,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel }:
                   variant="plain"
                   aria-label="save button for editing integration name"
                   onClick={() => {
-                    if (isNameValidCheck(localName)) {
+                    if (ValidationService.isNameValidCheck(localName)) {
                       setIsEditingName(false);
                       // only issue change if different from current settings
                       if (localName !== settings.name) {

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -1,7 +1,7 @@
 import './PlusButtonEdge.css';
 import { MiniCatalog } from '@kaoto/components';
-import { findStepIdxWithUUID, insertableStepTypes, insertStep } from '@kaoto/services';
-import { useIntegrationJsonStore, useNestedStepsStore } from '@kaoto/store';
+import { StepsService, ValidationService } from '@kaoto/services';
+import {useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore} from '@kaoto/store';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { Popover } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
@@ -40,9 +40,11 @@ const PlusButtonEdge = ({
   const nodeIds = id.substring(2).split('>');
   const sourceNode: IVizStepNode | undefined = useReactFlow().getNode(nodeIds[0]);
   const targetNode: IVizStepNode | undefined = useReactFlow().getNode(nodeIds[1]);
-  const currentIdx = findStepIdxWithUUID(targetNode?.data.step.UUID);
-  const { integrationJson } = useIntegrationJsonStore();
-  const { nestedSteps } = useNestedStepsStore();
+  const integrationJsonStore = useIntegrationJsonStore();
+  const nestedStepsStore = useNestedStepsStore();
+  const visualizationStore = useVisualizationStore();
+  const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
+  const currentIdx = stepsService.findStepIdxWithUUID(targetNode?.data.step.UUID);
 
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({
     sourceX,
@@ -55,18 +57,18 @@ const PlusButtonEdge = ({
 
   const onMiniCatalogClickInsert = (selectedStep: IStepProps) => {
     if (targetNode?.data.branchInfo) {
-      const rootStepIdx = findStepIdxWithUUID(targetNode?.data.branchInfo.parentUuid);
-      const currentStepNested = nestedSteps.map((ns) => ns.stepUuid === targetNode?.data.step.UUID);
+      const rootStepIdx = stepsService.findStepIdxWithUUID(targetNode?.data.branchInfo.parentUuid);
+      const currentStepNested = nestedStepsStore.nestedSteps.map((ns) => ns.stepUuid === targetNode?.data.step.UUID);
 
       if (currentStepNested) {
         // 1. make a copy of the steps, get the root step
-        const newStep = integrationJson.steps.slice()[rootStepIdx];
+        const newStep = integrationJsonStore.integrationJson.steps.slice()[rootStepIdx];
         // 2. find the correct branch, insert new step there
         newStep.branches?.forEach((b, bIdx) => {
           b.steps.map((bs, bsIdx) => {
             if (bs.UUID === targetNode?.data.step.UUID) {
               // 3. assign the new steps back to the branch
-              newStep.branches![bIdx].steps = insertStep(b.steps, bsIdx, selectedStep);
+              newStep.branches![bIdx].steps = StepsService.insertStep(b.steps, bsIdx, selectedStep);
             }
           });
         });
@@ -103,7 +105,7 @@ const PlusButtonEdge = ({
               <MiniCatalog
                 handleSelectStep={onMiniCatalogClickInsert}
                 queryParams={{
-                  type: insertableStepTypes(sourceNode?.data.step, targetNode?.data.step),
+                  type: ValidationService.insertableStepTypes(sourceNode?.data.step, targetNode?.data.step),
                 }}
               />
             }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { fetchCapabilities, fetchCompatibleDSLs, fetchIntegrationSourceCode } from '@kaoto/api';
-import { isNameValidCheck } from '@kaoto/services';
+import { ValidationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useIntegrationSourceStore, useSettingsStore } from '@kaoto/store';
 import { ICapabilities, ISettings } from '@kaoto/types';
 import { usePrevious } from '@kaoto/utils';
@@ -87,7 +87,7 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
   const onChangeName = (newName: string) => {
     setLocalSettings({ ...localSettings, name: newName });
 
-    if (isNameValidCheck(newName)) {
+    if (ValidationService.isNameValidCheck(newName)) {
       setNameValidation('success');
     } else {
       setNameValidation('error');
@@ -110,7 +110,7 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
   const onChangeNamespace = (newNamespace: string) => {
     setLocalSettings({ ...localSettings, namespace: newNamespace });
 
-    if (isNameValidCheck(newNamespace)) {
+    if (ValidationService.isNameValidCheck(newNamespace)) {
       setNamespaceValidation('success');
     } else {
       setNamespaceValidation('error');

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -1,5 +1,4 @@
 import './Visualization.css';
-import { fetchViews } from '@kaoto/api';
 import {
   KaotoDrawer,
   PlusButtonEdge,
@@ -8,17 +7,9 @@ import {
   VisualizationStep,
   VisualizationStepViews,
 } from '@kaoto/components';
-import {
-  buildBranchSpecialEdges,
-  buildEdges,
-  buildNodesFromSteps,
-  findStepIdxWithUUID,
-  flattenSteps,
-  getLayoutedElements,
-  filterStepWithBranches,
-} from '@kaoto/services';
+import { StepsService, VisualizationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
-import { IStepProps, IVizStepPropsEdge, IVizStepNode } from '@kaoto/types';
+import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, { Background, Viewport } from 'reactflow';
 
@@ -42,31 +33,17 @@ const Visualization = () => {
     type: '',
     UUID: '',
   });
-  const {
-    deleteBranchStep,
-    deleteStep,
-    integrationJson,
-    replaceBranchStep,
-    replaceStep,
-    setViews,
-  } = useIntegrationJsonStore();
-  const { nestedSteps } = useNestedStepsStore();
-  const layout = useVisualizationStore((state) => state.layout);
-  const previousIntegrationJson = useRef(integrationJson);
-  const previousLayout = useRef(layout);
-  const { nodes, setNodes, onNodesChange, edges, setEdges, onEdgesChange, deleteNode } =
-    useVisualizationStore();
+  const integrationJsonStore = useIntegrationJsonStore();
+  const nestedStepsStore = useNestedStepsStore();
+  const visualizationStore = useVisualizationStore();
+  const previousLayout = useRef(visualizationStore.layout);
+  const previousIntegrationJson = useRef(integrationJsonStore.integrationJson);
+  const visualizationService = new VisualizationService(integrationJsonStore, visualizationStore);
+  const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
 
   // initial loading of visualization steps
   useEffect(() => {
-    const { stepNodes, stepEdges } = buildNodesAndEdges(integrationJson.steps);
-
-    getLayoutedElements(stepNodes, stepEdges, layout)
-      .then((res) => {
-        const { layoutedNodes, layoutedEdges } = res;
-        setNodes(layoutedNodes);
-        setEdges(layoutedEdges);
-      })
+    visualizationService.redrawDiagram(handleDeleteStep, true)
       .catch((e) => console.error(e));
   }, []);
 
@@ -75,37 +52,23 @@ const Visualization = () => {
    * which causes Visualization nodes to all be redrawn
    */
   useEffect(() => {
-    if (previousIntegrationJson.current === integrationJson) return;
+    if (previousIntegrationJson.current === integrationJsonStore.integrationJson) return;
 
-    fetchViews(integrationJson.steps).then((views) => {
-      setViews(views);
-    });
-
-    const { stepNodes, stepEdges } = buildNodesAndEdges(integrationJson.steps);
-    getLayoutedElements(stepNodes, stepEdges, layout)
-      .then((res) => {
-        const { layoutedNodes, layoutedEdges } = res;
-        setNodes(layoutedNodes);
-        setEdges(layoutedEdges);
-      })
+    stepsService.updateViews();
+    visualizationService.redrawDiagram(handleDeleteStep, true)
       .catch((e) => console.error(e));
 
-    previousIntegrationJson.current = integrationJson;
-  }, [integrationJson]);
+    previousIntegrationJson.current = integrationJsonStore.integrationJson;
+  }, [integrationJsonStore.integrationJson]);
 
   useEffect(() => {
-    if (previousLayout.current === layout) return;
+    if (previousLayout.current === visualizationStore.layout) return;
 
-    getLayoutedElements(nodes, edges, layout)
-      .then((res) => {
-        const { layoutedNodes, layoutedEdges } = res;
-        setNodes(layoutedNodes);
-        setEdges(layoutedEdges);
-      })
+    visualizationService.redrawDiagram(handleDeleteStep, false)
       .catch((e) => console.error(e));
 
-    previousLayout.current = layout;
-  }, [layout]);
+    previousLayout.current = visualizationStore.layout;
+  }, [visualizationStore.layout]);
 
   const nodeTypes = useMemo(() => ({ step: VisualizationStep }), []);
   const edgeTypes = useMemo(
@@ -115,52 +78,13 @@ const Visualization = () => {
     []
   );
 
-  function buildNodesAndEdges(steps: IStepProps[]) {
-    // build all nodes
-    const stepNodes = buildNodesFromSteps(steps, layout, {
-      handleDeleteStep,
-    });
-
-    // build edges only for main nodes
-    const filteredNodes = stepNodes.filter((node) => !node.data.branchInfo?.branchStep);
-    let stepEdges: IVizStepPropsEdge[] = buildEdges(filteredNodes);
-
-    // build edges for branch nodes
-    const branchSpecialEdges: IVizStepPropsEdge[] = buildBranchSpecialEdges(stepNodes);
-
-    stepEdges = stepEdges.concat(...branchSpecialEdges);
-
-    return { stepNodes, stepEdges };
-  }
-
   const handleDeleteStep = (UUID?: string) => {
     if (!UUID) return;
 
     setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '' });
     if (isPanelExpanded) setIsPanelExpanded(false);
 
-    // check if the step being modified is nested
-    const currentStepNested = nestedSteps.find((ns) => ns.stepUuid === UUID);
-    if (currentStepNested) {
-      const parentStepIdx = findStepIdxWithUUID(
-        currentStepNested.originStepUuid,
-        integrationJson.steps
-      );
-
-      // update the original parent step, without the child step
-      const updatedParentStep = filterStepWithBranches(
-        integrationJson.steps[parentStepIdx],
-        (step: { UUID: string }) => step.UUID !== UUID
-      );
-
-      deleteBranchStep(updatedParentStep, parentStepIdx);
-    } else {
-      // `deleteStep` requires the index to be from `integrationJson`, not `nodes`
-      const stepsIndex = findStepIdxWithUUID(UUID, integrationJson.steps);
-
-      deleteNode(stepsIndex);
-      deleteStep(stepsIndex);
-    }
+    stepsService.deleteStep(UUID);
   };
 
   const onClosePanelClick = () => {
@@ -190,10 +114,8 @@ const Visualization = () => {
     if (!_e.target.classList.contains('stepNode__clickable')) return;
 
     if (!node.data.isPlaceholder) {
-      const flatSteps = flattenSteps(integrationJson.steps);
-      const stepIdx = flatSteps.map((s: IStepProps) => s.UUID).indexOf(node.data.step.UUID);
-
-      if (stepIdx !== -1) setSelectedStep(flatSteps[stepIdx]);
+      const step = stepsService.findStepWithUUID(node.data.step.UUID);
+      if (step) setSelectedStep(step);
 
       if (!isPanelExpanded) setIsPanelExpanded(true);
     }
@@ -208,29 +130,7 @@ const Visualization = () => {
    * @param newValues
    */
   const saveConfig = (newValues: { [s: string]: unknown } | ArrayLike<unknown>) => {
-    let newStep: IStepProps = selectedStep;
-    const newStepParameters = newStep.parameters?.slice();
-
-    if (newStepParameters && newStepParameters.length > 0) {
-      Object.entries(newValues).map(([key, value]) => {
-        const paramIndex = newStepParameters.findIndex((p) => p.id === key);
-        newStepParameters[paramIndex!].value = value;
-      });
-
-      // check if the step being modified is nested
-      if (nestedSteps.some((ns) => ns.stepUuid === newStep.UUID)) {
-        // use its path to replace only this part of the original step
-        const currentStepNested = nestedSteps.find((ns) => ns.stepUuid === newStep.UUID);
-        if (currentStepNested) {
-          replaceBranchStep(newStep, currentStepNested.pathToStep);
-        }
-      } else {
-        const oldStepIdx = findStepIdxWithUUID(newStep.UUID, integrationJson.steps);
-        replaceStep(newStep, oldStepIdx);
-      }
-    } else {
-      return;
-    }
+    stepsService.updateStepParameters(selectedStep, newValues);
   };
 
   return (
@@ -262,15 +162,15 @@ const Visualization = () => {
           }}
         >
           <ReactFlow
-            nodes={nodes}
-            edges={edges}
+            nodes={visualizationStore.nodes}
+            edges={visualizationStore.edges}
             defaultViewport={defaultViewport}
             edgeTypes={edgeTypes}
             nodeTypes={nodeTypes}
             onDragOver={onDragOver}
             onNodeClick={onNodeClick}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
+            onNodesChange={visualizationStore.onNodesChange}
+            onEdgesChange={visualizationStore.onEdgesChange}
             onLoad={onLoad}
             snapToGrid={true}
             snapGrid={[15, 15]}

--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -6,8 +6,8 @@ import {
   stopDeployment,
 } from '@kaoto/api';
 import { Extension, JsonSchemaConfigurator, StepErrorBoundary } from '@kaoto/components';
-import { findStepIdxWithUUID } from '@kaoto/services';
-import { useIntegrationJsonStore } from '@kaoto/store';
+import { StepsService } from '@kaoto/services';
+import {useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore} from '@kaoto/store';
 import { IIntegration, IKaotoApi, IStepProps } from '@kaoto/types';
 import {
   AlertVariant,
@@ -37,15 +37,18 @@ const VisualizationStepViews = ({
   saveConfig,
   step,
 }: IStepViewsProps) => {
-  const views = useIntegrationJsonStore((state) =>
-    state.views.filter((view) => view.step === step.UUID)
-  );
+  const integrationJsonStore = useIntegrationJsonStore();
+  const views = integrationJsonStore.views.filter((view) => view.step === step.UUID);
+
   const hasDetailView = views?.some((v) => v.id === 'detail-step');
   const detailsTabIndex = views?.length! + 1; // provide an index that won't be used by custom views
   const extensionConfigViewIndex = views?.findIndex((v) => v.name === 'Config');
   const hasConfigView = extensionConfigViewIndex !== -1
   const configTabIndex = !hasConfigView ? views?.length! + 2 : extensionConfigViewIndex;
-  const currentIdx = findStepIdxWithUUID(step.UUID!);
+  const nestedStepsStore = useNestedStepsStore();
+  const visualizationStore = useVisualizationStore();
+  const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
+  const currentIdx = stepsService.findStepIdxWithUUID(step.UUID);
   const [activeTabKey, setActiveTabKey] = useState(configTabIndex);
   const [stepPropertySchema, setStepPropertySchema] = useState<{
     [label: string]: { type: string };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,3 @@
-export * from './validationService';
-export * from './visualizationService';
+export { StepsService } from "./stepsService";
+export { ValidationService } from './validationService';
+export { VisualizationService } from './visualizationService';

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -1,0 +1,192 @@
+import branchSteps from '../store/data/branchSteps';
+import nestedBranch from '../store/data/kamelet.nested-branch.steps';
+import steps from '../store/data/steps';
+import { IStepProps } from '@kaoto/types';
+import { StepsService } from "./stepsService";
+import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from "@kaoto/store";
+
+describe('stepsService', () => {
+
+  const stepsService = new StepsService(
+    useIntegrationJsonStore.getState(),
+    useNestedStepsStore.getState(),
+    useVisualizationStore.getState()
+  );
+
+  /**
+   * containsBranches
+   */
+  it('containsBranches(): should determine if a given step contains branches', () => {
+    expect(StepsService.containsBranches(branchSteps[0])).toBe(false);
+    expect(StepsService.containsBranches(branchSteps[1])).toBe(true);
+  });
+
+  /**
+   * extractNestedSteps
+   */
+  it('extractNestedSteps(): should create an array of properties for all nested steps', () => {
+    const nested = nestedBranch.slice();
+    expect(StepsService.extractNestedSteps(nested)).toHaveLength(6);
+  });
+
+  /**
+   * filterNestedSteps
+   */
+  it('filterNestedSteps(): should filter an array of steps given a conditional function', () => {
+    const nestedSteps = [
+      { branches: [{ steps: [{ branches: [{ steps: [{ UUID: 'log-340230' }] }] }] }] },
+    ] as IStepProps[];
+    expect(nestedSteps[0].branches![0].steps[0].branches![0].steps).toHaveLength(1);
+
+    const filtered = StepsService.filterNestedSteps(nestedSteps, (step) => step.UUID !== 'log-340230');
+    expect(filtered![0].branches![0].steps[0].branches![0].steps).toHaveLength(0);
+  });
+
+  /**
+   * filterStepWithBranches
+   */
+  it('filterStepWithBranches(): should filter the branch steps for a given step and conditional', () => {
+    const step = {
+      branches: [
+        {
+          steps: [
+            {
+              UUID: 'step-one',
+              branches: [{ steps: [{ UUID: 'strawberry' }, { UUID: 'banana' }] }],
+            },
+            { UUID: 'step-two', branches: [{ steps: [{ UUID: 'cherry' }] }] },
+          ],
+        },
+      ],
+    } as IStepProps;
+
+    expect(step.branches![0].steps[0].branches![0].steps).toHaveLength(2);
+
+    const filtered = StepsService.filterStepWithBranches(
+      step,
+      (step: { UUID: string }) => step.UUID !== 'banana'
+    );
+
+    expect(filtered.branches![0].steps[0].branches![0].steps).toHaveLength(1);
+  });
+
+  /**
+   * findStepIdxWithUUID
+   */
+  it("findStepIdxWithUUID(): should find a step's index, given a particular UUID", () => {
+    expect(stepsService.findStepIdxWithUUID('caffeine-action-2', steps)).toEqual(2);
+  });
+
+  /**
+   * flattenSteps
+   */
+  it('flattenSteps(): should flatten an array of deeply nested steps', () => {
+    expect(nestedBranch).toHaveLength(4);
+    const deeplyNestedBranchStepUuid = 'set-body-877932';
+    expect(nestedBranch.some((s) => s.UUID === deeplyNestedBranchStepUuid)).toBeFalsy();
+
+    const flattenedSteps = StepsService.flattenSteps(nestedBranch);
+    expect(flattenedSteps).toHaveLength(10);
+    expect(flattenedSteps.some((s) => s.UUID === deeplyNestedBranchStepUuid)).toBeTruthy();
+  });
+
+  /**
+   * insertStep
+   */
+  it('insertStep(): should insert the provided step at the index specified, in a given array of steps', () => {
+    const steps = [
+      {
+        name: 'strawberry',
+      },
+      {
+        name: 'blueberry',
+      },
+    ] as IStepProps[];
+
+    expect(StepsService.insertStep(steps, 2, { name: 'peach' } as IStepProps)).toHaveLength(3);
+    // does it insert it at the correct spot?
+    expect(StepsService.insertStep(steps, 2, { name: 'peach' } as IStepProps)[2]).toEqual({ name: 'peach' });
+  });
+
+  /**
+   * isFirstStepEip
+   */
+  it('isFirstStepEip(): should determine if the provided step is an EIP', () => {
+    const firstBranch = branchSteps[1].branches![0];
+    expect(StepsService.isFirstStepEip(branchSteps)).toBe(false);
+    expect(StepsService.isFirstStepEip(firstBranch.steps)).toBe(true);
+  });
+
+  /**
+   * isFirstStepStart
+   */
+  it('isFirstStepStart(): should determine if the first step is a START', () => {
+    // first step is a START
+    expect(StepsService.isFirstStepStart(steps)).toBe(true);
+
+    expect(
+      StepsService.isFirstStepStart([
+        {
+          id: 'pdf-action',
+          name: 'pdf-action',
+          type: 'MIDDLE',
+          UUID: 'pdf-action-1',
+          group: 'PDF',
+          kind: 'Kamelet',
+          title: 'PDF Action',
+        } as IStepProps,
+      ])
+    ).toBe(false);
+  });
+
+  /**
+   * isEndStep
+   */
+  it('isEndStep(): should determine if the provided step is an END step', () => {
+    expect(StepsService.isEndStep(branchSteps[3])).toBe(true);
+    expect(StepsService.isEndStep(branchSteps[0])).toBe(false);
+  });
+
+  /**
+   * isMiddleStep
+   */
+  it('isMiddleStep(): should determine if the provided step is a MIDDLE step', () => {
+    expect(StepsService.isMiddleStep(branchSteps[1])).toBe(true);
+    expect(StepsService.isMiddleStep(branchSteps[0])).toBe(false);
+  });
+
+  /**
+   * isStartStep
+   */
+  it('isStartStep(): should determine if the provided step is a START step', () => {
+    expect(StepsService.isStartStep(branchSteps[0])).toBe(true);
+    expect(StepsService.isStartStep(branchSteps[1])).toBe(false);
+  });
+
+  /**
+   * prependStep
+   */
+  it('prependStep(): should insert the provided step at the beginning of a given array of steps', () => {
+    const steps = [
+      {
+        name: 'strawberry',
+      },
+      {
+        name: 'blueberry',
+      },
+    ] as IStepProps[];
+
+    expect(StepsService.prependStep(steps, { name: 'peach' } as IStepProps)).toHaveLength(3);
+    expect(StepsService.prependStep(steps, { name: 'mango' } as IStepProps)[0]).toEqual({ name: 'mango' });
+  });
+
+  /**
+   * regenerateUuids
+   */
+  it('regenerateUuids(): should regenerate UUIDs for an array of steps', () => {
+    expect(StepsService.regenerateUuids(steps)[0].UUID).toBeDefined();
+    expect(StepsService.regenerateUuids(branchSteps)[0].UUID).toBeDefined();
+    expect(StepsService.regenerateUuids(branchSteps)[1].UUID).toBeDefined();
+  });
+
+});

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -1,0 +1,435 @@
+import {INestedStep, IStepProps, IStepPropsBranch, IVizStepNodeData} from "@kaoto/types";
+import {findPath, getDeepValue, getRandomArbitraryNumber, setDeepValue} from "@kaoto/utils";
+import {IIntegrationJsonStore, INestedStepStore, RFState} from "@kaoto/store";
+import {fetchStepDetails, fetchViews} from "@kaoto/api";
+import {ValidationService} from "./validationService";
+
+/**
+ * A collection of business logic to handle logical model objects of the integration,
+ * which is represented by a collection of "Step".
+ * This class focuses on handling logical model objects. For handling visualization,
+ * see {@link VisualizationService}.
+ * @see IStepProps
+ * @see IStepPropsBranch
+ * @see VisualizationService
+ */
+export class StepsService {
+
+  constructor(
+    private integrationJsonStore: IIntegrationJsonStore,
+    private nestedStepsStore: INestedStepStore,
+    private visualizationStore: RFState
+  ) {}
+
+  /**
+   * Checks if a Step contains branches
+   * @param step
+   */
+  static containsBranches(step: IStepProps): boolean {
+    let containsBranching = false;
+    if (step.branches) {
+      containsBranching = true;
+    }
+    return containsBranching;
+  }
+
+  /**
+   * Given an array of Steps, return an array containing *only*
+   * the steps which are nested
+   * @param steps
+   */
+  static extractNestedSteps(steps: IStepProps[]) {
+    let tempSteps = steps.slice();
+    let nestedSteps: INestedStep[] = [];
+
+    const loopOverSteps = (steps: IStepProps[], originalStepUuid?: string, branchUuid?: string) => {
+      steps.forEach((step) => {
+        if (originalStepUuid) {
+          // this is a nested step
+          nestedSteps.push({
+            branchUuid,
+            stepUuid: step.UUID,
+            originStepUuid: originalStepUuid,
+            pathToStep: findPath(tempSteps, step.UUID, 'UUID'),
+          } as INestedStep);
+        }
+
+        if (step.branches) {
+          step.branches.forEach((branch) => {
+            // it contains nested steps; we will need to store the branch info
+            // and the path to it, for each of those steps
+            return loopOverSteps(branch.steps, step.UUID, branch.branchUuid);
+          });
+        }
+      });
+    };
+
+    loopOverSteps(tempSteps);
+
+    return nestedSteps;
+  }
+
+  /**
+   * Given an array of steps and a function with a condition,
+   * return a new filtered array
+   * @param steps
+   * @param predicate
+   */
+  static filterNestedSteps(steps: IStepProps[], predicate: (step: IStepProps) => boolean) {
+    if (!steps) return null;
+
+    return steps.reduce((list: IStepProps[], step: IStepProps) => {
+        let clone: IStepProps | null = null;
+
+        if (predicate(step) && steps.some((s) => s.UUID === step.UUID)) {
+          // clone the step if it matches the condition and isn't a nested step
+          clone = Object.assign({}, step);
+        }
+
+        // overwrite the branch if one of its steps contains a match
+        if (clone && clone.branches) {
+          clone.branches.forEach((branch, idx) => {
+            const filteredBranchSteps = StepsService.filterNestedSteps(branch.steps, predicate);
+            if (filteredBranchSteps && clone?.branches) {
+              clone.branches[idx].steps = filteredBranchSteps;
+            }
+          });
+        }
+
+        // if there's a cloned step, push it to the output list
+        clone && list.push(clone);
+        return list;
+      }, []);
+  }
+
+  /**
+   * Given a step and a function with a condition,
+   * return a new step with filtered branch steps
+   * @param step
+   * @param predicate
+   */
+  static filterStepWithBranches(step: IStepProps, predicate: (step: IStepProps) => boolean) {
+    const stepCopy: IStepProps = {...step};
+    const loopOverBranches = (branches: IStepPropsBranch[]) => {
+      if (step.branches?.length === 0) return;
+      branches.forEach((branch, idx) => {
+        const branchCopy = {...branch};
+        if (stepCopy.branches && stepCopy.branches[idx].steps) {
+          const filtered = StepsService.filterNestedSteps(branchCopy.steps, predicate);
+          if (filtered) stepCopy.branches[idx].steps = filtered;
+        }
+      });
+    };
+
+    if (stepCopy.branches) loopOverBranches(stepCopy.branches);
+
+    return stepCopy;
+  }
+
+  /**
+   * Returns a Step index when provided with the `UUID`.
+   * `UUID` is originally set using the Step UUID.
+   * @param UUID
+   * @param steps
+   */
+  findStepIdxWithUUID(UUID: string, steps?: IStepProps[]): number {
+    // optional steps allows for dependency injection in testing
+    if (!steps) {
+      return this.integrationJsonStore
+        .integrationJson.steps.map((s) => s.UUID)
+        .indexOf(UUID);
+    } else {
+      return steps.map((s) => s.UUID).indexOf(UUID);
+    }
+  }
+
+  /**
+   * Returns a Step when provided with the `UUID`, or null if not found.
+   * `UUID` is originally set using the Step UUID.
+   * @param UUID
+   */
+  findStepWithUUID(UUID: string): IStepProps | null {
+    const flatSteps = StepsService.flattenSteps(this.integrationJsonStore.integrationJson.steps);
+    const stepIdx = flatSteps.map((s: IStepProps) => s.UUID).indexOf(UUID);
+    return stepIdx !== -1 ? flatSteps[stepIdx] : null;
+  }
+
+  /**
+   * Flattens a deeply nested array of Steps and their respective
+   * branches, and their Steps, into a single array.
+   * Typically used for quickly fetching a Step.
+   */
+  static flattenSteps(steps: IStepProps[]): IStepProps[] {
+    let children: IStepProps[] = [];
+    const flattenMembers = steps.map((s) => {
+      if (s.branches && s.branches.length) {
+        s.branches.forEach((b) => {
+          children = [...children, ...b.steps];
+        });
+      }
+      return s;
+    });
+
+    return flattenMembers.concat(children.length ? StepsService.flattenSteps(children) : children);
+  }
+
+  /**
+   * Insert the given step at the specified index of
+   * an array of provided steps
+   * @param steps
+   * @param insertIndex
+   * @param newStep
+   */
+  static insertStep(
+    steps: IStepProps[],
+    insertIndex: number,
+    newStep: IStepProps
+  ): IStepProps[] {
+    return [
+      // part of array before the index
+      ...steps.slice(0, insertIndex),
+      // inserted item
+      newStep,
+      // part of array after the index
+      ...steps.slice(insertIndex),
+    ];
+  }
+
+  static isEndStep(step: IStepProps): boolean {
+    return step.type === 'END';
+  }
+
+  static isFirstStepEip(steps: IStepProps[]): boolean {
+    return steps.length > 0 && steps[0].kind === 'EIP';
+  }
+
+  static isFirstStepStart(steps: IStepProps[]): boolean {
+    return steps.length > 0 && steps[0].type === 'START';
+  }
+
+  static isMiddleStep(step: IStepProps): boolean {
+    return step.type === 'MIDDLE';
+  }
+
+  static isStartStep(step: IStepProps): boolean {
+    return step.type === 'START';
+  }
+
+  /**
+   * Regenerate a UUID for a list of Steps
+   * Every time there is a change to steps or their positioning in the Steps array,
+   * their UUIDs need to be regenerated
+   * @param steps
+   * @param branchSteps
+   */
+  static regenerateUuids(steps: IStepProps[], branchSteps: boolean = false): IStepProps[] {
+    let newSteps = steps.slice();
+
+    newSteps.forEach((step, idx) => {
+      step.UUID = `${step.name}-${idx}`;
+      if (branchSteps) step.UUID = `${step.name}-${idx}-${getRandomArbitraryNumber()}`;
+      if (step.branches) {
+        step.branches.forEach((branch) => {
+          branch.branchUuid = `b-${idx}-${getRandomArbitraryNumber()}`;
+          return newSteps.concat(StepsService.regenerateUuids(branch.steps, true));
+        });
+      }
+    });
+    return newSteps;
+  }
+
+  /**
+   * Inserts the given step at the beginning of the
+   * array of provided steps, returning the modified array
+   * @param steps
+   * @param newStep
+   */
+  static prependStep(steps: IStepProps[], newStep: IStepProps): IStepProps[] {
+    const newSteps = [...steps];
+    newSteps.unshift(newStep);
+    return newSteps;
+  }
+
+  deleteStep(UUID: string) {
+    // check if the step being modified is nested
+    const currentStepNested = this.nestedStepsStore.nestedSteps.find((ns) => ns.stepUuid === UUID);
+    if (currentStepNested) {
+      const parentStepIdx = this.findStepIdxWithUUID(
+        currentStepNested.originStepUuid,
+        this.integrationJsonStore.integrationJson.steps
+      );
+
+      // update the original parent step, without the child step
+      const updatedParentStep = StepsService.filterStepWithBranches(
+        this.integrationJsonStore.integrationJson.steps[parentStepIdx],
+        (step: { UUID: string }) => step.UUID !== UUID
+      );
+
+      this.integrationJsonStore.deleteBranchStep(updatedParentStep, parentStepIdx);
+    } else {
+      // `deleteStep` requires the index to be from `integrationJson`, not `nodes`
+      const stepsIndex = this.findStepIdxWithUUID(UUID, this.integrationJsonStore.integrationJson.steps);
+
+      this.visualizationStore.deleteNode(stepsIndex);
+      this.integrationJsonStore.deleteStep(stepsIndex);
+    }
+  }
+
+  /**
+   * Update step parameters.
+   * @param step
+   * @param newValues
+   */
+  updateStepParameters(step: IStepProps, newValues: { [s: string]: unknown } | ArrayLike<unknown>) {
+    let newStep: IStepProps = step;
+    const newStepParameters = newStep.parameters?.slice();
+
+    if (newStepParameters && newStepParameters.length > 0) {
+      Object.entries(newValues).forEach(([key, value]) => {
+        const paramIndex = newStepParameters.findIndex((p) => p.id === key);
+        newStepParameters[paramIndex].value = value;
+      });
+
+      // check if the step being modified is nested
+      if (this.nestedStepsStore.nestedSteps.some((ns) => ns.stepUuid === newStep.UUID)) {
+        // use its path to replace only this part of the original step
+        const currentStepNested = this.nestedStepsStore.nestedSteps.find((ns) => ns.stepUuid === newStep.UUID);
+        if (currentStepNested) {
+          this.integrationJsonStore.replaceBranchStep(newStep, currentStepNested.pathToStep);
+        }
+      } else {
+        const oldStepIdx = this.findStepIdxWithUUID(newStep.UUID, this.integrationJsonStore.integrationJson.steps);
+        this.integrationJsonStore.replaceStep(newStep, oldStepIdx);
+      }
+    } else {
+      return;
+    }
+  }
+
+  /**
+   * Submits current integration steps to the backend and update with received views.
+   */
+  updateViews() {
+    fetchViews(this.integrationJsonStore.integrationJson.steps).then((views) => {
+      this.integrationJsonStore.setViews(views);
+    });
+  }
+
+  /**
+   * Gets a step nested.
+   * @param step
+   */
+  getStepNested(step: IStepProps) {
+    return this.nestedStepsStore.nestedSteps.find((ns) => ns.stepUuid === step.UUID);
+  }
+
+  /**
+   * Appends a selected step to the current step.
+   * @param currentStep
+   * @param selectedStep
+   */
+  handleAppendStep(currentStep: IStepProps, selectedStep: IStepProps) {
+    // fetch parameters and other details
+    fetchStepDetails(selectedStep.id).then((step) => {
+      step.UUID = selectedStep.UUID;
+      const currentStepNested = this.getStepNested(currentStep);
+      if (currentStepNested) {
+        // special handling for branch steps
+        const rootStepIdx = this.findStepIdxWithUUID(currentStepNested.originStepUuid);
+        const stepsCopy = this.integrationJsonStore.integrationJson.steps.slice();
+        const stepCopy = stepsCopy[rootStepIdx];
+        // find path to the branch, for easy modification of its steps
+        const pathToBranch = findPath(stepCopy, currentStepNested.branchUuid, 'branchUuid');
+        let newBranch = getDeepValue(stepCopy, pathToBranch);
+        newBranch.steps = [...newBranch.steps, step];
+        // here we are building a new root step, with a new array of those branch steps
+        const newRootStep = setDeepValue(stepCopy, pathToBranch, newBranch);
+        this.integrationJsonStore.replaceStep(newRootStep, rootStepIdx);
+      } else {
+        this.integrationJsonStore.appendStep(step);
+      }
+    });
+  }
+
+  /**
+   * Prepends a selected step to the current step.
+   * @param currentStep
+   * @param selectedStep
+   */
+  handlePrependStep(currentStep: IStepProps, selectedStep: IStepProps) {
+    // fetch parameters and other details
+    fetchStepDetails(selectedStep.id).then((step) => {
+      step.UUID = selectedStep.UUID;
+      const currentStepNested = this.getStepNested(currentStep);
+      if (currentStepNested) {
+        // special handling for branch steps
+        const rootStepIdx = this.findStepIdxWithUUID(currentStepNested.originStepUuid);
+        const stepsCopy = this.integrationJsonStore.integrationJson.steps.slice();
+        const stepCopy = stepsCopy[rootStepIdx];
+        // find path to the branch, for easy modification of its steps
+        const pathToBranch = findPath(stepCopy, currentStepNested.branchUuid, 'branchUuid');
+        let newBranch = getDeepValue(stepCopy, pathToBranch);
+        newBranch.steps = StepsService.prependStep([...newBranch.steps], step);
+        // here we are building a new root step, with a new array of those branch steps
+        const newRootStep = setDeepValue(stepCopy, pathToBranch, newBranch);
+        this.integrationJsonStore.replaceStep(newRootStep, rootStepIdx);
+      } else {
+        this.integrationJsonStore.appendStep(step);
+      }
+    });
+  }
+
+  /**
+   * Adds a new step onto a placeholder from mini catalog.
+   * @param node
+   * @param stepC
+   */
+  async replacePlaceholderStep(node: IVizStepNodeData, stepC: IStepProps) {
+    // fetch parameters and other details
+    return fetchStepDetails(stepC.id).then((step) => {
+      step.UUID = stepC.UUID;
+      const validation = ValidationService.canStepBeReplaced(node, step);
+
+      if (validation.isValid) {
+        // update the steps, the new node will be created automatically
+        if (node.branchInfo) {
+          if (node.isPlaceholder) {
+            const pathToBranch = findPath(this.integrationJsonStore.integrationJson.steps, node.branchInfo.branchUuid!, 'branchUuid');
+            const newPath = pathToBranch?.concat('steps', '0');
+            this.integrationJsonStore.replaceBranchStep(step, newPath);
+          }
+        } else {
+          this.integrationJsonStore.replaceStep(step);
+        }
+      }
+      return validation;
+    });
+  }
+
+  /**
+   * Replace an existing step through Drag and Drop.
+   * @todo {@link node} is a React Flow related object that should be handled in {@link VisualizationService}, while this does modify the logical step structure. Could we retrieve same info from something else than {@link node}?
+   * @param node
+   * @param currentStep
+   * @param stepC
+   */
+  async handleDropOnExistingStep(node: IVizStepNodeData, currentStep:IStepProps, stepC: IStepProps) {
+    // fetch parameters and other details
+    return fetchStepDetails(stepC.id).then((newStep) => {
+      const validation = ValidationService.canStepBeReplaced(node, newStep);
+      // Replace step
+      if (validation.isValid) {
+        if (node.branchInfo) {
+          const currentStepNested = this.getStepNested(currentStep);
+          if (currentStepNested) {
+            this.integrationJsonStore.replaceBranchStep(newStep, currentStepNested.pathToStep);
+          }
+        } else {
+          const currentIdx = this.findStepIdxWithUUID(currentStep.UUID);
+          this.integrationJsonStore.replaceStep(newStep, currentIdx);
+        }
+      }
+      return validation;
+    });
+  }
+}

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -1,23 +1,23 @@
-import { canStepBeReplaced, prependableStepTypes } from './validationService';
+import { ValidationService } from './validationService';
 import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 
 describe('validationService', () => {
   it('canStepBeReplaced(): should return a boolean to determine if a step can be replaced', () => {
     // start steps
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'START' } } as IVizStepNodeData,
         { type: 'START' } as IStepProps
       ).isValid
     ).toBeTruthy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'START' } } as IVizStepNodeData,
         { type: 'MIDDLE' } as IStepProps
       ).isValid
     ).toBeFalsy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'START' } } as IVizStepNodeData,
         { type: 'END' } as IStepProps
       ).isValid
@@ -25,25 +25,25 @@ describe('validationService', () => {
 
     // middle steps
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'MIDDLE' } } as IVizStepNodeData,
         { type: 'START' } as IStepProps
       ).isValid
     ).toBeFalsy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'MIDDLE' } } as IVizStepNodeData,
         { type: 'MIDDLE' } as IStepProps
       ).isValid
     ).toBeTruthy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'MIDDLE' }, isLastStep: false } as IVizStepNodeData,
         { type: 'END' } as IStepProps
       ).isValid
     ).toBeFalsy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'MIDDLE' }, isLastStep: true } as IVizStepNodeData,
         { type: 'END' } as IStepProps
       ).isValid
@@ -51,19 +51,19 @@ describe('validationService', () => {
 
     // end steps
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'END' } } as IVizStepNodeData,
         { type: 'START' } as IStepProps
       ).isValid
     ).toBeFalsy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'END' }, isLastStep: true } as IVizStepNodeData,
         { type: 'MIDDLE' } as IStepProps
       ).isValid
     ).toBeTruthy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'END' }, isLastStep: true } as IVizStepNodeData,
         { type: 'END' } as IStepProps
       ).isValid
@@ -71,19 +71,19 @@ describe('validationService', () => {
 
     // branch placeholder step
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'START' }, branchInfo: {}, isPlaceholder: true } as IVizStepNodeData,
         { type: 'START' } as IStepProps
       ).isValid
     ).toBeFalsy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         { step: { type: 'START' }, branchInfo: {}, isPlaceholder: true } as IVizStepNodeData,
         { type: 'MIDDLE' } as IStepProps
       ).isValid
     ).toBeTruthy();
     expect(
-      canStepBeReplaced(
+      ValidationService.canStepBeReplaced(
         {
           step: { type: 'START' },
           branchInfo: {},
@@ -95,6 +95,6 @@ describe('validationService', () => {
   });
 
   it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {
-    expect(prependableStepTypes()).toEqual('MIDDLE');
+    expect(ValidationService.prependableStepTypes()).toEqual('MIDDLE');
   });
 });

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -1,112 +1,119 @@
 import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 
 /**
- * Checks kind of steps can be appended onto an existing step.
- * @param existingStepType
+ *  * A collection of business logic to process validation related tasks.
+ *  * @see StepsService
+ *  * @see VisualizationService
  */
-export function appendableStepTypes(existingStepType: string): string {
-  let possibleSteps: string = '';
+export class ValidationService {
+  /**
+   * Checks kind of steps can be appended onto an existing step.
+   * @param existingStepType
+   */
+  static appendableStepTypes(existingStepType: string): string {
+    let possibleSteps: string = '';
 
-  switch (existingStepType) {
-    case 'START':
-    case 'MIDDLE':
-      // cannot append a START step to a START or MIDDLE step
-      possibleSteps = 'MIDDLE,END';
-      break;
-  }
-
-  return possibleSteps;
-}
-
-/**
- * Checks whether a step can replace an existing step.
- * @param existingNode
- * @param proposedStep
- */
-export function canStepBeReplaced(
-  existingNode: IVizStepNodeData,
-  proposedStep: IStepProps
-): { isValid: boolean; message?: string } {
-  let isValid = false;
-  let message = undefined;
-
-  // if step is a placeholder and within a branch,
-  // this requires special handling
-  if (existingNode.isPlaceholder && existingNode.branchInfo) {
-    // placeholders will always be the first step
-    if (proposedStep.type === 'MIDDLE' || proposedStep.type === 'END') {
-      return { isValid: true };
-    } else {
-      return { isValid: false, message: 'Branches must start with a middle or end step.' };
+    switch (existingStepType) {
+      case 'START':
+      case 'MIDDLE':
+        // cannot append a START step to a START or MIDDLE step
+        possibleSteps = 'MIDDLE,END';
+        break;
     }
+
+    return possibleSteps;
   }
 
-  // initial shallow check of step type, where the
-  // existing step is treated as a first class citizen,
-  // regardless if it's a slot or not
-  if (existingNode.step.type === proposedStep.type) {
-    isValid = true;
+  /**
+   * Checks whether a step can replace an existing step.
+   * @param existingNode
+   * @param proposedStep
+   */
+  static canStepBeReplaced(
+    existingNode: IVizStepNodeData,
+    proposedStep: IStepProps
+  ): { isValid: boolean; message?: string } {
+    let isValid = false;
+    let message = undefined;
 
-    return { isValid, message: '' };
-  }
-
-  switch (existingNode.step.type) {
-    case 'START':
-      isValid = proposedStep.type === 'START';
-      message = 'First step must be a start step.';
-      break;
-    case 'MIDDLE':
-    case 'END':
-      // check if it's the last step
-      if (existingNode.isLastStep) {
-        message = 'Last step must be a middle or end step.';
-        isValid = proposedStep.type === 'MIDDLE' || proposedStep.type === 'END';
-      } else if (existingNode.step.type === 'MIDDLE' && proposedStep.type === 'END') {
-        // not the last step, but trying to replace a MIDDLE step with an END step
-        message = 'You cannot replace a middle step with an end step.';
-      } else if (existingNode.step.type === 'MIDDLE' && proposedStep.type === 'START') {
-        // not the last step, but trying to replace a MIDDLE step with a START step
-        message = 'You cannot replace a middle step with a start step.';
+    // if step is a placeholder and within a branch,
+    // this requires special handling
+    if (existingNode.isPlaceholder && existingNode.branchInfo) {
+      // placeholders will always be the first step
+      if (proposedStep.type === 'MIDDLE' || proposedStep.type === 'END') {
+        return { isValid: true };
+      } else {
+        return { isValid: false, message: 'Branches must start with a middle or end step.' };
       }
+    }
 
-      break;
+    // initial shallow check of step type, where the
+    // existing step is treated as a first class citizen,
+    // regardless if it's a slot or not
+    if (existingNode.step.type === proposedStep.type) {
+      isValid = true;
+
+      return { isValid, message: '' };
+    }
+
+    switch (existingNode.step.type) {
+      case 'START':
+        isValid = proposedStep.type === 'START';
+        message = 'First step must be a start step.';
+        break;
+      case 'MIDDLE':
+      case 'END':
+        // check if it's the last step
+        if (existingNode.isLastStep) {
+          message = 'Last step must be a middle or end step.';
+          isValid = proposedStep.type === 'MIDDLE' || proposedStep.type === 'END';
+        } else if (existingNode.step.type === 'MIDDLE' && proposedStep.type === 'END') {
+          // not the last step, but trying to replace a MIDDLE step with an END step
+          message = 'You cannot replace a middle step with an end step.';
+        } else if (existingNode.step.type === 'MIDDLE' && proposedStep.type === 'START') {
+          // not the last step, but trying to replace a MIDDLE step with a START step
+          message = 'You cannot replace a middle step with a start step.';
+        }
+
+        break;
+    }
+
+    return { isValid, message };
   }
 
-  return { isValid, message };
-}
-
-/**
- * Checks kind of steps can be appended onto an existing step.
- * @param _prevStep
- * @param _nextStep
- */
-export function insertableStepTypes(_prevStep?: IStepProps, _nextStep?: IStepProps): string {
-  let possibleSteps: string[] = ['START', 'MIDDLE', 'END'];
-  if (_prevStep) {
-    // inserted step can be MIDDLE or END
-    possibleSteps = possibleSteps.filter((val) => val !== 'START');
+  /**
+   * Checks kind of steps can be appended onto an existing step.
+   * @param _prevStep
+   * @param _nextStep
+   */
+  static insertableStepTypes(_prevStep?: IStepProps, _nextStep?: IStepProps): string {
+    let possibleSteps: string[] = ['START', 'MIDDLE', 'END'];
+    if (_prevStep) {
+      // inserted step can be MIDDLE or END
+      possibleSteps = possibleSteps.filter((val) => val !== 'START');
+    }
+    if (_nextStep) {
+      // inserted step must be MIDDLE
+      possibleSteps = possibleSteps.filter((val) => val !== 'START');
+      possibleSteps = possibleSteps.filter((val) => val !== 'END');
+    }
+    return possibleSteps.join(',');
   }
-  if (_nextStep) {
-    // inserted step must be MIDDLE
-    possibleSteps = possibleSteps.filter((val) => val !== 'START');
-    possibleSteps = possibleSteps.filter((val) => val !== 'END');
+
+  /**
+   * Verifies that the provided name is valid
+   * Regex: [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
+   * @param name
+   */
+  static isNameValidCheck(name: string) {
+    const regexPattern = /^[a-z\d]([-a-z\d]*[a-z\d])?(\.[a-z\d]([-a-z\d]*[a-z\d])?)*$/gm;
+    return regexPattern.test(name);
   }
-  return possibleSteps.join(',');
-}
 
-/**
- * Verifies that the provided name is valid
- * Regex: [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
- * @param name
- */
-export function isNameValidCheck(name: string) {
-  const regexPattern = /^[a-z\d]([-a-z\d]*[a-z\d])?(\.[a-z\d]([-a-z\d]*[a-z\d])?)*$/gm;
-  return regexPattern.test(name);
-}
-
-/**
- * Returns the step types that can be prepended to a step.
- */
-export function prependableStepTypes(): string {
-  return 'MIDDLE';
+  /**
+   * Returns the step types that can be prepended to a step.
+   */
+  static prependableStepTypes(): string {
+    return 'MIDDLE';
+  }
 }

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -1,36 +1,7 @@
-import eipIntegration from '../store/data/branchSteps';
 import branchSteps from '../store/data/branchSteps';
-import nestedBranch from '../store/data/kamelet.nested-branch.steps';
 import nodes from '../store/data/nodes';
 import steps from '../store/data/steps';
-import {
-  buildBranchNodeParams,
-  buildBranchSingleStepEdges,
-  buildEdgeParams,
-  buildEdges,
-  buildNodeDefaultParams,
-  buildNodesFromSteps,
-  containsAddStepPlaceholder,
-  containsBranches,
-  extractNestedSteps,
-  filterNestedSteps,
-  filterStepWithBranches,
-  findNodeIdxWithUUID,
-  findStepIdxWithUUID,
-  flattenSteps,
-  getRandomArbitraryNumber,
-  insertAddStepPlaceholder,
-  insertBranchGroupNode,
-  insertStep,
-  isEndStep,
-  isFirstStepEip,
-  isFirstStepStart,
-  isMiddleStep,
-  isStartStep,
-  prependStep,
-  regenerateUuids,
-  shouldAddEdge,
-} from './visualizationService';
+import { VisualizationService } from './visualizationService';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
 import { MarkerType, Position } from 'reactflow';
@@ -46,7 +17,7 @@ describe('visualizationService', () => {
     const currentStep = steps[3];
     const nodeId = 'node_example-1234';
 
-    expect(buildBranchNodeParams(currentStep, nodeId, 'RIGHT')).toEqual({
+    expect(VisualizationService.buildBranchNodeParams(currentStep, nodeId, 'RIGHT')).toEqual({
       data: {
         kind: currentStep.kind,
         label: truncateString(currentStep.name, 14),
@@ -62,7 +33,7 @@ describe('visualizationService', () => {
     });
 
     // Check that the `sourcePosition` and `targetPosition` change with the layout
-    expect(buildBranchNodeParams(currentStep, nodeId, 'DOWN')).toEqual({
+    expect(VisualizationService.buildBranchNodeParams(currentStep, nodeId, 'DOWN')).toEqual({
       data: {
         kind: currentStep.kind,
         label: truncateString(currentStep.name, 14),
@@ -92,7 +63,7 @@ describe('visualizationService', () => {
     } as IVizStepNode;
     const rootNode = {} as IVizStepNode;
     const rootNodeNext = {} as IVizStepNode;
-    expect(buildBranchSingleStepEdges(node, rootNode, rootNodeNext)).toHaveLength(2);
+    expect(VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)).toHaveLength(2);
   });
 
   /**
@@ -102,7 +73,7 @@ describe('visualizationService', () => {
     const currentStep = nodes[1];
     const previousStep = nodes[0];
 
-    expect(buildEdgeParams(currentStep, previousStep)).toEqual({
+    expect(VisualizationService.buildEdgeParams(currentStep, previousStep)).toEqual({
       arrowHeadType: 'arrowclosed',
       id: 'e-' + currentStep.id + '>' + previousStep.id,
       markerEnd: {
@@ -135,12 +106,12 @@ describe('visualizationService', () => {
       },
     ];
 
-    expect(buildEdges(nodes)).toHaveLength(1);
+    expect(VisualizationService.buildEdges(nodes)).toHaveLength(1);
 
     // let's test that it works for branching too
-    const stepNodes = buildNodesFromSteps(branchSteps, 'RIGHT');
+    const stepNodes = VisualizationService.buildNodesFromSteps(branchSteps, 'RIGHT');
 
-    expect(buildEdges(stepNodes)).toHaveLength(branchSteps.length - 1);
+    expect(VisualizationService.buildEdges(stepNodes)).toHaveLength(branchSteps.length - 1);
   });
 
   /**
@@ -150,7 +121,7 @@ describe('visualizationService', () => {
     const position = { x: 0, y: 0 };
     const step = { name: 'avro-deserialize-action', icon: '', kind: 'Kamelet' } as IStepProps;
 
-    expect(buildNodeDefaultParams(step, 'dummy-id', position)).toEqual({
+    expect(VisualizationService.buildNodeDefaultParams(step, 'dummy-id', position)).toEqual({
       data: {
         branchInfo: undefined,
         icon: step.icon,
@@ -176,7 +147,7 @@ describe('visualizationService', () => {
    * buildNodesFromSteps
    */
   it('buildNodesFromSteps(): should build visualization nodes from an array of steps', () => {
-    const stepNodes = buildNodesFromSteps(steps, 'RIGHT');
+    const stepNodes = VisualizationService.buildNodesFromSteps(steps, 'RIGHT');
     expect(stepNodes[0].data.step.UUID).toBeDefined();
     expect(stepNodes[0].id).toContain(stepNodes[0].data.step.UUID);
   });
@@ -185,7 +156,7 @@ describe('visualizationService', () => {
    * buildNodesFromSteps for integrations with branches
    */
   it.skip('buildNodesFromSteps(): should build visualization nodes from an array of steps with branches', () => {
-    const stepNodes = buildNodesFromSteps(branchSteps, 'RIGHT');
+    const stepNodes = VisualizationService.buildNodesFromSteps(branchSteps, 'RIGHT');
     expect(stepNodes[0].data.step.UUID).toBeDefined();
     expect(stepNodes).toHaveLength(branchSteps.length);
   });
@@ -213,10 +184,10 @@ describe('visualizationService', () => {
       },
     ];
 
-    expect(containsAddStepPlaceholder(nodes)).toBe(true);
+    expect(VisualizationService.containsAddStepPlaceholder(nodes)).toBe(true);
 
     expect(
-      containsAddStepPlaceholder([
+      VisualizationService.containsAddStepPlaceholder([
         {
           data: {
             label: 'avro-deserialize-sink',
@@ -230,99 +201,11 @@ describe('visualizationService', () => {
   });
 
   /**
-   * containsBranches
-   */
-  it('containsBranches(): should determine if a given step contains branches', () => {
-    expect(containsBranches(branchSteps[0])).toBe(false);
-    expect(containsBranches(branchSteps[1])).toBe(true);
-  });
-
-  /**
-   * extractNestedSteps
-   */
-  it('extractNestedSteps(): should create an array of properties for all nested steps', () => {
-    const nested = nestedBranch.slice();
-    expect(extractNestedSteps(nested)).toHaveLength(6);
-  });
-
-  /**
-   * filterNestedSteps
-   */
-  it('filterNestedSteps(): should filter an array of steps given a conditional function', () => {
-    const nestedSteps = [
-      { branches: [{ steps: [{ branches: [{ steps: [{ UUID: 'log-340230' }] }] }] }] },
-    ] as IStepProps[];
-    expect(nestedSteps[0].branches![0].steps[0].branches![0].steps).toHaveLength(1);
-
-    const filtered = filterNestedSteps(nestedSteps, (step) => step.UUID !== 'log-340230');
-    expect(filtered![0].branches![0].steps[0].branches![0].steps).toHaveLength(0);
-  });
-
-  /**
-   * filterStepWithBranches
-   */
-  it('filterStepWithBranches(): should filter the branch steps for a given step and conditional', () => {
-    const step = {
-      branches: [
-        {
-          steps: [
-            {
-              UUID: 'step-one',
-              branches: [{ steps: [{ UUID: 'strawberry' }, { UUID: 'banana' }] }],
-            },
-            { UUID: 'step-two', branches: [{ steps: [{ UUID: 'cherry' }] }] },
-          ],
-        },
-      ],
-    } as IStepProps;
-
-    expect(step.branches![0].steps[0].branches![0].steps).toHaveLength(2);
-
-    const filtered = filterStepWithBranches(
-      step,
-      (step: { UUID: string }) => step.UUID !== 'banana'
-    );
-
-    expect(filtered.branches![0].steps[0].branches![0].steps).toHaveLength(1);
-  });
-
-  /**
    * findNodeIdxWithUUID
    */
   it('findNodeIdxWithUUID(): should find a node from an array of nodes, given a UUID', () => {
-    expect(findNodeIdxWithUUID(nodes[0].data.step.UUID, nodes)).toBe(0);
-    expect(findNodeIdxWithUUID(nodes[1].data.step.UUID, nodes)).toBe(1);
-  });
-
-  /**
-   * findStepIdxWithUUID
-   */
-  it("findStepIdxWithUUID(): should find a step's index, given a particular UUID", () => {
-    expect(findStepIdxWithUUID('caffeine-action-2', steps)).toEqual(2);
-  });
-
-  /**
-   * flattenSteps
-   */
-  it('flattenSteps(): should flatten an array of deeply nested steps', () => {
-    expect(nestedBranch).toHaveLength(4);
-    const deeplyNestedBranchStepUuid = 'set-body-877932';
-    expect(nestedBranch.some((s) => s.UUID === deeplyNestedBranchStepUuid)).toBeFalsy();
-
-    const flattenedSteps = flattenSteps(nestedBranch);
-    expect(flattenedSteps).toHaveLength(10);
-    expect(flattenedSteps.some((s) => s.UUID === deeplyNestedBranchStepUuid)).toBeTruthy();
-  });
-
-  it.skip('getRandomArbitraryNumber(): should get a random arbitrary number', () => {
-    const mGetRandomValues = jest.fn().mockReturnValueOnce(new Uint32Array(10));
-
-    Object.defineProperty(window, 'crypto', {
-      value: { getRandomValues: mGetRandomValues },
-    });
-
-    expect(getRandomArbitraryNumber()).toEqual(new Uint32Array(10));
-    expect(mGetRandomValues).toBeCalledWith(new Uint8Array(1));
+    expect(VisualizationService.findNodeIdxWithUUID(nodes[0].data.step.UUID, nodes)).toBe(0);
+    expect(VisualizationService.findNodeIdxWithUUID(nodes[1].data.step.UUID, nodes)).toBe(1);
   });
 
   /**
@@ -330,7 +213,7 @@ describe('visualizationService', () => {
    */
   it('insertAddStepPlaceholder(): should add an ADD STEP placeholder to the beginning of the array', () => {
     const nodes: IVizStepNode[] = [];
-    insertAddStepPlaceholder(nodes, '', 'START', { nextStepUuid: '' });
+    VisualizationService.insertAddStepPlaceholder(nodes, '', 'START', { nextStepUuid: '' });
     expect(nodes).toHaveLength(1);
   });
 
@@ -339,107 +222,8 @@ describe('visualizationService', () => {
    */
   it.skip('insertBranchGroupNode', () => {
     const nodes: IVizStepNode[] = [];
-    insertBranchGroupNode(nodes, { x: 0, y: 0 }, 150, groupWidth);
+    VisualizationService.insertBranchGroupNode(nodes, { x: 0, y: 0 }, 150, groupWidth);
     expect(nodes).toHaveLength(1);
-  });
-
-  /**
-   * insertStep
-   */
-  it('insertStep(): should insert the provided step at the index specified, in a given array of steps', () => {
-    const steps = [
-      {
-        name: 'strawberry',
-      },
-      {
-        name: 'blueberry',
-      },
-    ] as IStepProps[];
-
-    expect(insertStep(steps, 2, { name: 'peach' } as IStepProps)).toHaveLength(3);
-    // does it insert it at the correct spot?
-    expect(insertStep(steps, 2, { name: 'peach' } as IStepProps)[2]).toEqual({ name: 'peach' });
-  });
-
-  /**
-   * isFirstStepEip
-   */
-  it('isFirstStepEip(): should determine if the provided step is an EIP', () => {
-    const firstBranch = eipIntegration[1].branches![0];
-    expect(isFirstStepEip(eipIntegration)).toBe(false);
-    expect(isFirstStepEip(firstBranch.steps)).toBe(true);
-  });
-
-  /**
-   * isFirstStepStart
-   */
-  it('isFirstStepStart(): should determine if the first step is a START', () => {
-    // first step is a START
-    expect(isFirstStepStart(steps)).toBe(true);
-
-    expect(
-      isFirstStepStart([
-        {
-          id: 'pdf-action',
-          name: 'pdf-action',
-          type: 'MIDDLE',
-          UUID: 'pdf-action-1',
-          group: 'PDF',
-          kind: 'Kamelet',
-          title: 'PDF Action',
-        } as IStepProps,
-      ])
-    ).toBe(false);
-  });
-
-  /**
-   * isEndStep
-   */
-  it('isEndStep(): should determine if the provided step is an END step', () => {
-    expect(isEndStep(eipIntegration[3])).toBe(true);
-    expect(isEndStep(eipIntegration[0])).toBe(false);
-  });
-
-  /**
-   * isMiddleStep
-   */
-  it('isMiddleStep(): should determine if the provided step is a MIDDLE step', () => {
-    expect(isMiddleStep(eipIntegration[1])).toBe(true);
-    expect(isMiddleStep(eipIntegration[0])).toBe(false);
-  });
-
-  /**
-   * isStartStep
-   */
-  it('isStartStep(): should determine if the provided step is a START step', () => {
-    expect(isStartStep(eipIntegration[0])).toBe(true);
-    expect(isStartStep(eipIntegration[1])).toBe(false);
-  });
-
-  /**
-   * prependStep
-   */
-  it('prependStep(): should insert the provided step at the beginning of a given array of steps', () => {
-    const steps = [
-      {
-        name: 'strawberry',
-      },
-      {
-        name: 'blueberry',
-      },
-    ] as IStepProps[];
-
-    expect(prependStep(steps, { name: 'peach' } as IStepProps)).toHaveLength(3);
-    expect(prependStep(steps, { name: 'mango' } as IStepProps)[0]).toEqual({ name: 'mango' });
-  });
-
-  /**
-   * regenerateUuids
-   */
-  it('regenerateUuids(): should regenerate UUIDs for an array of steps', () => {
-    expect(regenerateUuids(steps)[0].UUID).toBeDefined();
-    expect(regenerateUuids(branchSteps)[0].UUID).toBeDefined();
-    expect(regenerateUuids(branchSteps)[1].UUID).toBeDefined();
   });
 
   /**
@@ -460,8 +244,8 @@ describe('visualizationService', () => {
     } as IVizStepNode;
 
     // there is no next node, so it should be false
-    expect(shouldAddEdge(nodeWithoutBranches)).toBeFalsy();
-    expect(shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
+    expect(VisualizationService.shouldAddEdge(nodeWithoutBranches)).toBeFalsy();
+    expect(VisualizationService.shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
 
     const nodeWithBranches = {
       id: 'node-with-branches',
@@ -482,11 +266,11 @@ describe('visualizationService', () => {
     } as IVizStepNode;
 
     // there is no next node, so it should be false
-    expect(shouldAddEdge(nodeWithBranches)).toBeFalsy();
+    expect(VisualizationService.shouldAddEdge(nodeWithBranches)).toBeFalsy();
 
     // it has branches with steps, so it should be false because
     // the steps will connect with the next step later on
-    expect(shouldAddEdge(nodeWithBranches, nextNode)).toBeFalsy();
+    expect(VisualizationService.shouldAddEdge(nodeWithBranches, nextNode)).toBeFalsy();
 
     const nodeWithEmptyBranch = {
       id: 'node-with-empty-branch',
@@ -507,7 +291,7 @@ describe('visualizationService', () => {
     } as IVizStepNode;
 
     // there is no next node, so it should be false
-    expect(shouldAddEdge(nodeWithEmptyBranch)).toBeFalsy();
-    expect(shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
+    expect(VisualizationService.shouldAddEdge(nodeWithEmptyBranch)).toBeFalsy();
+    expect(VisualizationService.shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
   });
 });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,661 +1,512 @@
-import { useIntegrationJsonStore } from '@kaoto/store';
-import {
-  INestedStep,
-  IStepProps,
-  IStepPropsBranch,
-  IVizStepNode,
-  IVizStepNodeDataBranch,
-  IVizStepPropsEdge,
-} from '@kaoto/types';
-import { findPath, truncateString } from '@kaoto/utils';
-import { ElkExtendedEdge, ElkNode } from 'elkjs';
-import { MarkerType, Position } from 'reactflow';
+import {IStepProps, IVizStepNode, IVizStepNodeDataBranch, IVizStepPropsEdge,} from '@kaoto/types';
+import {IIntegrationJsonStore, RFState} from "@kaoto/store";
+import {getRandomArbitraryNumber, truncateString} from '@kaoto/utils';
+import {ElkExtendedEdge, ElkNode} from 'elkjs';
+import {MarkerType, Position} from 'reactflow';
+import {StepsService} from './stepsService';
 
 const ELK = require('elkjs');
 
-// for nodes within a branch
-export function buildBranchNodeParams(
-  step: IStepProps,
-  nodeId: string,
-  layout: string,
-  dataProps?: { [prop: string]: any }
-): IVizStepNode {
-  return {
-    data: {
-      kind: step.kind,
-      label: truncateString(step.name, 14),
-      step,
-      icon: step.icon,
-      ...dataProps,
-    },
-    id: nodeId,
-    position: { x: 0, y: 0 },
-    draggable: false,
-    sourcePosition: layout === 'RIGHT' ? Position.Top : Position.Right,
-    targetPosition: layout === 'RIGHT' ? Position.Bottom : Position.Left,
-    type: 'step',
-  } as IVizStepNode;
-}
+/**
+ * A collection of business logic to process visualization related tasks.
+ * Since Kaoto UI uses React Flow for drawing the diagram in the canvas, the main job to achieve
+ * it is to manage React Flow "nodes" and "edges".
+ * We use ELK to layout steps in the canvas. See {@link getLayoutedElements} for details.
+ * This class focuses on visualization. For handling internal Step model objects, see {@link StepsService}.
+ *  @see IVizStepNode
+ *  @see IVizStepPropsEdge
+ *  @see StepsService
+ */
+export class VisualizationService {
 
-// Builds branch step edges and edges that need to connect branches to prev/next steps
-export function buildBranchSpecialEdges(stepNodes: IVizStepNode[]): IVizStepPropsEdge[] {
-  const specialEdges: IVizStepPropsEdge[] = [];
+  constructor(
+    private integrationJsonStore: IIntegrationJsonStore,
+    private visualizationStore: RFState
+  ) {};
 
-  stepNodes.forEach((node) => {
-    if (node.type === 'group') return;
+  /**
+   * for nodes within a branch
+   * @param step
+   * @param nodeId
+   * @param layout
+   * @param dataProps
+   */
+  static buildBranchNodeParams(
+    step: IStepProps,
+    nodeId: string,
+    layout: string,
+    dataProps?: { [prop: string]: any }
+  ): IVizStepNode {
+    return {
+      data: {
+        kind: step.kind,
+        label: truncateString(step.name, 14),
+        step,
+        icon: step.icon,
+        ...dataProps,
+      },
+      id: nodeId,
+      position: { x: 0, y: 0 },
+      draggable: false,
+      sourcePosition: layout === 'RIGHT' ? Position.Top : Position.Right,
+      targetPosition: layout === 'RIGHT' ? Position.Bottom : Position.Left,
+      type: 'step',
+    } as IVizStepNode;
+  }
 
-    const parentNodeIndex = findNodeIdxWithUUID(node.data.branchInfo?.parentUuid, stepNodes);
-    const ogNodeNextIndex = findNodeIdxWithUUID(
-      node.data.branchInfo?.branchParentNextUuid,
-      stepNodes
-    );
+  //
+  /**
+   * Builds branch step edges and edges that need to connect branches to prev/next steps
+   * @param stepNodes
+   */
+  buildBranchSpecialEdges(stepNodes: IVizStepNode[]): IVizStepPropsEdge[] {
+    const specialEdges: IVizStepPropsEdge[] = [];
 
-    if (node.data.branchInfo) {
-      // handle all "normal" steps within a branch
-      if (
-        node.data.branchInfo.branchStep &&
-        !node.data.isLastStep &&
-        !node.data.isPlaceholder &&
-        !containsBranches(node.data.step)
-      ) {
-        const branchStepNextIdx = findNodeIdxWithUUID(node.data.nextStepUuid, stepNodes);
-        if (stepNodes[branchStepNextIdx]) {
-          specialEdges.push(buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert'));
+    stepNodes.forEach((node) => {
+      if (node.type === 'group') return;
+
+      const parentNodeIndex = VisualizationService.findNodeIdxWithUUID(node.data.branchInfo?.parentUuid, stepNodes);
+      const ogNodeNextIndex = VisualizationService.findNodeIdxWithUUID(
+        node.data.branchInfo?.branchParentNextUuid,
+        stepNodes
+      );
+
+      if (node.data.branchInfo) {
+        // handle all "normal" steps within a branch
+        if (
+          node.data.branchInfo.branchStep &&
+          !node.data.isLastStep &&
+          !node.data.isPlaceholder &&
+          !StepsService.containsBranches(node.data.step)
+        ) {
+          const branchStepNextIdx = VisualizationService.findNodeIdxWithUUID(node.data.nextStepUuid, stepNodes);
+          if (stepNodes[branchStepNextIdx]) {
+            specialEdges.push(VisualizationService.buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert'));
+          }
+        }
+
+        // handle special first step, needs to be connected to its immediate parent
+        if (node.data.isFirstStep) {
+          const ogNodeStep = stepNodes[parentNodeIndex];
+          let edgeProps = VisualizationService.buildEdgeParams(ogNodeStep, node, 'default');
+
+          if (node.data.branchInfo?.branchIdentifier)
+            edgeProps.label = node.data.branchInfo?.branchIdentifier;
+
+          specialEdges.push(edgeProps);
+        }
+
+        // handle placeholder steps within a branch
+        if (node.data.branchInfo?.branchStep && node.data.isPlaceholder) {
+          specialEdges.push(
+            ...VisualizationService.buildBranchSingleStepEdges(
+              node,
+              stepNodes[parentNodeIndex],
+              stepNodes[ogNodeNextIndex]
+            )
+          );
+        }
+
+        // handle special last steps
+        if (node.data.isLastStep && !StepsService.isEndStep(node.data.step)) {
+          const nextStep = stepNodes[ogNodeNextIndex];
+
+          if (nextStep) {
+            // it needs to merge back
+            specialEdges.push(VisualizationService.buildEdgeParams(node, nextStep, 'default'));
+          }
         }
       }
+    });
 
-      // handle special first step, needs to be connected to its immediate parent
-      if (node.data.isFirstStep) {
-        const ogNodeStep = stepNodes[parentNodeIndex];
-        let edgeProps = buildEdgeParams(ogNodeStep, node, 'default');
+    return specialEdges;
+  }
 
-        if (node.data.branchInfo?.branchIdentifier)
-          edgeProps.label = node.data.branchInfo?.branchIdentifier;
+  /**
+   * Builds edges for branches with only a single step
+   * i.e. for placeholders within a branch
+   * @param node
+   * @param rootNode
+   * @param rootNextNode
+   */
+  static buildBranchSingleStepEdges(
+    node: IVizStepNode,
+    rootNode: IVizStepNode,
+    rootNextNode: IVizStepNode
+  ): IVizStepPropsEdge[] {
+    const branchPlaceholderEdges: IVizStepPropsEdge[] = [];
+    let edgeProps = VisualizationService.buildEdgeParams(rootNode, node, 'default');
 
-        specialEdges.push(edgeProps);
-      }
+    if (node.data.branchInfo?.branchIdentifier)
+      edgeProps.label = node.data.branchInfo?.branchIdentifier;
 
-      // handle placeholder steps within a branch
-      if (node.data.branchInfo?.branchStep && node.data.isPlaceholder) {
-        specialEdges.push(
-          ...buildBranchSingleStepEdges(
+    branchPlaceholderEdges.push(edgeProps);
+
+    if (rootNextNode) {
+      branchPlaceholderEdges.push(VisualizationService.buildEdgeParams(node, rootNextNode, 'default'));
+    }
+
+    return branchPlaceholderEdges;
+  }
+
+  /**
+   * @param sourceStep
+   * @param targetStep
+   * @param type
+   */
+  static buildEdgeParams(
+    sourceStep: IVizStepNode,
+    targetStep: IVizStepNode,
+    type?: string
+  ): IVizStepPropsEdge {
+    return {
+      arrowHeadType: 'arrowclosed',
+      id: `e-${sourceStep.id}>${targetStep.id}`,
+      markerEnd: {
+        type: MarkerType.Arrow,
+      },
+      source: sourceStep.id,
+      target: targetStep.id,
+      type: type ?? 'default',
+    };
+  }
+
+  static buildEdges(nodes: IVizStepNode[]): IVizStepPropsEdge[] {
+    const stepEdges: IVizStepPropsEdge[] = [];
+
+    // for every node except for placeholders and the last step, add an edge
+    if (nodes.length === 1) {
+      return stepEdges;
+    }
+
+    nodes.forEach((node) => {
+      const nextNodeIdx = VisualizationService.findNodeIdxWithUUID(node.data.nextStepUuid, nodes);
+
+      if (VisualizationService.shouldAddEdge(node, nodes[nextNodeIdx])) {
+        stepEdges.push(
+          VisualizationService.buildEdgeParams(
             node,
-            stepNodes[parentNodeIndex],
-            stepNodes[ogNodeNextIndex]
+            nodes[nextNodeIdx],
+            node.data.branchInfo || node.data.step.branches ? 'default' : 'insert'
           )
         );
       }
+    });
 
-      // handle special last steps
-      if (node.data.isLastStep && !isEndStep(node.data.step)) {
-        const nextStep = stepNodes[ogNodeNextIndex];
-
-        if (nextStep) {
-          // it needs to merge back
-          specialEdges.push(buildEdgeParams(node, nextStep, 'default'));
-        }
-      }
-    }
-  });
-
-  return specialEdges;
-}
-
-/**
- * Builds edges for branches with only a single step
- * i.e. for placeholders within a branch
- * @param node
- * @param rootNode
- * @param rootNextNode
- */
-export function buildBranchSingleStepEdges(
-  node: IVizStepNode,
-  rootNode: IVizStepNode,
-  rootNextNode: IVizStepNode
-): IVizStepPropsEdge[] {
-  const branchPlaceholderEdges: IVizStepPropsEdge[] = [];
-  let edgeProps = buildEdgeParams(rootNode, node, 'default');
-
-  if (node.data.branchInfo?.branchIdentifier)
-    edgeProps.label = node.data.branchInfo?.branchIdentifier;
-
-  branchPlaceholderEdges.push(edgeProps);
-
-  if (rootNextNode) {
-    branchPlaceholderEdges.push(buildEdgeParams(node, rootNextNode, 'default'));
-  }
-
-  return branchPlaceholderEdges;
-}
-
-export function buildEdgeParams(
-  sourceStep: IVizStepNode,
-  targetStep: IVizStepNode,
-  type?: string
-): IVizStepPropsEdge {
-  return {
-    arrowHeadType: 'arrowclosed',
-    id: `e-${sourceStep.id}>${targetStep.id}`,
-    markerEnd: {
-      type: MarkerType.Arrow,
-    },
-    source: sourceStep.id,
-    target: targetStep.id,
-    type: type ?? 'default',
-  };
-}
-
-export function buildEdges(nodes: IVizStepNode[]): IVizStepPropsEdge[] {
-  const stepEdges: IVizStepPropsEdge[] = [];
-
-  // for every node except for placeholders and the last step, add an edge
-  if (nodes.length === 1) {
     return stepEdges;
   }
 
-  nodes.forEach((node) => {
-    const nextNodeIdx = findNodeIdxWithUUID(node.data.nextStepUuid, nodes);
-
-    if (shouldAddEdge(node, nodes[nextNodeIdx])) {
-      stepEdges.push(
-        buildEdgeParams(
-          node,
-          nodes[nextNodeIdx],
-          node.data.branchInfo || node.data.step.branches ? 'default' : 'insert'
-        )
-      );
-    }
-  });
-
-  return stepEdges;
-}
-
-export function buildNodeDefaultParams(
-  step: IStepProps,
-  newId: string,
-  props?: { [prop: string]: any },
-  branchInfo?: IVizStepNodeDataBranch
-): IVizStepNode {
-  return {
-    data: {
-      branchInfo,
-      icon: step.icon,
-      kind: step.kind,
-      label: truncateString(step.name, 14),
-      step,
-      isPlaceholder: false,
-      ...props,
-    },
-    draggable: false,
-    id: newId,
-    position: { x: 0, y: 0 },
-    type: 'step',
-    width: 80,
-    height: 80,
-    ...props,
-  } as IVizStepNode;
-}
-
-/**
- * Creates an array for the Visualization from the Step model.
- * Contains UI-specific metadata (e.g. position).
- * Data is stored in the `nodes` hook.
- */
-export function buildNodesFromSteps(
-  steps: IStepProps[],
-  layout: string,
-  props?: { [prop: string]: any },
-  branchInfo?: IVizStepNodeDataBranch
-): IVizStepNode[] {
-  let stepNodes: IVizStepNode[] = [];
-  let id = 0;
-  let getId = (uuid: string) => `node_${id++}-${uuid}-${getRandomArbitraryNumber()}`;
-
-  // if no steps or first step isn't START or an EIP, create a dummy placeholder step
-  if (
-    (steps.length === 0 && !branchInfo) ||
-    (!isFirstStepStart(steps) && !isFirstStepEip(steps) && !branchInfo)
-  ) {
-    insertAddStepPlaceholder(stepNodes, getId(''), 'START', {
-      nextStepUuid: steps[0]?.UUID,
-    });
-  }
-
-  // build EIP placeholder
-  if (branchInfo && steps.length === 0 && !isFirstStepStart(steps)) {
-    insertAddStepPlaceholder(stepNodes, getId(''), 'MIDDLE', {
-      branchInfo,
-      nextStepUuid: steps[0]?.UUID,
-    });
-  }
-
-  steps.forEach((step, index) => {
-    let currentStep: IVizStepNode;
-
-    // build the default parameters for a node
-    if (branchInfo) {
-      // we are within a branch
-      currentStep = buildBranchNodeParams(step, getId(step.UUID), layout, {
+  static buildNodeDefaultParams(
+    step: IStepProps,
+    newId: string,
+    props?: { [prop: string]: any },
+    branchInfo?: IVizStepNodeDataBranch
+  ): IVizStepNode {
+    return {
+      data: {
         branchInfo,
-        isFirstStep: index === 0,
-        isLastStep: index === steps.length - 1 && !step.branches?.length,
-        nextStepUuid: steps[index + 1]?.UUID,
+        icon: step.icon,
+        kind: step.kind,
+        label: truncateString(step.name, 14),
+        step,
+        isPlaceholder: false,
         ...props,
-      });
-      stepNodes.push(currentStep);
-    } else {
-      currentStep = buildNodeDefaultParams(step, getId(step.UUID), {
-        isLastStep: index === steps.length - 1,
-        nextStepUuid: steps[index + 1]?.UUID,
-        ...props,
-      });
-      stepNodes.push(currentStep);
-    }
-
-    // recursively build nodes for branch steps
-    if (step.branches && step.maxBranches !== 0) {
-      step.branches.forEach((branch) => {
-        stepNodes = stepNodes.concat(
-          buildNodesFromSteps(branch.steps, layout, props, {
-            branchIdentifier: branch.identifier,
-
-            // branchParentUuid is the parent for a first branch step,
-            // and grandparent for n branch step
-            branchParentUuid: branchInfo?.branchParentUuid ?? steps[index].UUID,
-            branchParentNextUuid: branchInfo?.branchParentNextUuid ?? steps[index + 1]?.UUID,
-            branchStep: true,
-            branchUuid: branch.branchUuid,
-
-            // parentUuid is always the parent of the branch step, no matter how nested
-            parentUuid: steps[index].UUID,
-          })
-        );
-      });
-    }
-  });
-
-  return stepNodes;
-}
-
-/**
- * Checks if an array of nodes contains an ADD A STEP placeholder step
- * @param stepNodes
- */
-export function containsAddStepPlaceholder(stepNodes: IVizStepNode[]): boolean {
-  return stepNodes.length > 0 && stepNodes[0].data.label === 'ADD A STEP';
-}
-
-/**
- * Checks if a Step contains branches
- * @param step
- */
-export function containsBranches(step: IStepProps): boolean {
-  let containsBranching = false;
-  if (step.branches) {
-    containsBranching = true;
+      },
+      draggable: false,
+      id: newId,
+      position: { x: 0, y: 0 },
+      type: 'step',
+      width: 80,
+      height: 80,
+      ...props,
+    } as IVizStepNode;
   }
-  return containsBranching;
-}
 
-/**
- * Given an array of Steps, return an array containing *only*
- * the steps which are nested
- * @param steps
- */
-export function extractNestedSteps(steps: IStepProps[]) {
-  let tempSteps = steps.slice();
-  let nestedSteps: INestedStep[] = [];
+  /**
+   * Creates an array for the Visualization from the Step model.
+   * Contains UI-specific metadata (e.g. position).
+   * Data is stored in the `nodes` hook.
+   */
+  static buildNodesFromSteps(
+    steps: IStepProps[],
+    layout: string,
+    props?: { [prop: string]: any },
+    branchInfo?: IVizStepNodeDataBranch
+  ): IVizStepNode[] {
+    let stepNodes: IVizStepNode[] = [];
+    let id = 0;
+    let getId = (uuid: string) => `node_${id++}-${uuid}-${getRandomArbitraryNumber()}`;
 
-  const loopOverSteps = (steps: IStepProps[], originalStepUuid?: string, branchUuid?: string) => {
-    steps.forEach((step) => {
-      if (originalStepUuid) {
-        // this is a nested step
-        nestedSteps.push({
-          branchUuid,
-          stepUuid: step.UUID,
-          originStepUuid: originalStepUuid,
-          pathToStep: findPath(tempSteps, step.UUID, 'UUID'),
-        } as INestedStep);
+    // if no steps or first step isn't START or an EIP, create a dummy placeholder step
+    if (
+      (steps.length === 0 && !branchInfo) ||
+      (!StepsService.isFirstStepStart(steps) && !StepsService.isFirstStepEip(steps) && !branchInfo)
+    ) {
+      VisualizationService.insertAddStepPlaceholder(stepNodes, getId(''), 'START', {
+        nextStepUuid: steps[0]?.UUID,
+      });
+    }
+
+    // build EIP placeholder
+    if (branchInfo && steps.length === 0 && !StepsService.isFirstStepStart(steps)) {
+      VisualizationService.insertAddStepPlaceholder(stepNodes, getId(''), 'MIDDLE', {
+        branchInfo,
+        nextStepUuid: steps[0]?.UUID,
+      });
+    }
+
+    steps.forEach((step, index) => {
+      let currentStep: IVizStepNode;
+
+      // build the default parameters for a node
+      if (branchInfo) {
+        // we are within a branch
+        currentStep = VisualizationService.buildBranchNodeParams(step, getId(step.UUID), layout, {
+          branchInfo,
+          isFirstStep: index === 0,
+          isLastStep: index === steps.length - 1 && !step.branches?.length,
+          nextStepUuid: steps[index + 1]?.UUID,
+          ...props,
+        });
+        stepNodes.push(currentStep);
+      } else {
+        currentStep = VisualizationService.buildNodeDefaultParams(step, getId(step.UUID), {
+          isLastStep: index === steps.length - 1,
+          nextStepUuid: steps[index + 1]?.UUID,
+          ...props,
+        });
+        stepNodes.push(currentStep);
       }
 
-      if (step.branches) {
+      // recursively build nodes for branch steps
+      if (step.branches && step.maxBranches !== 0) {
         step.branches.forEach((branch) => {
-          // it contains nested steps; we will need to store the branch info
-          // and the path to it, for each of those steps
-          return loopOverSteps(branch.steps, step.UUID, branch.branchUuid);
+          stepNodes = stepNodes.concat(
+            VisualizationService.buildNodesFromSteps(branch.steps, layout, props, {
+              branchIdentifier: branch.identifier,
+
+              // branchParentUuid is the parent for a first branch step,
+              // and grandparent for n branch step
+              branchParentUuid: branchInfo?.branchParentUuid ?? steps[index].UUID,
+              branchParentNextUuid: branchInfo?.branchParentNextUuid ?? steps[index + 1]?.UUID,
+              branchStep: true,
+              branchUuid: branch.branchUuid,
+
+              // parentUuid is always the parent of the branch step, no matter how nested
+              parentUuid: steps[index].UUID,
+            })
+          );
         });
       }
     });
-  };
 
-  loopOverSteps(tempSteps);
-
-  return nestedSteps;
-}
-
-/**
- * Given an array of steps and a function with a condition,
- * return a new filtered array
- * @param steps
- * @param predicate
- */
-export function filterNestedSteps(steps: IStepProps[], predicate: (step: IStepProps) => boolean) {
-  return !steps
-    ? null
-    : steps.reduce((list: IStepProps[], step: IStepProps) => {
-        let clone: IStepProps | null = null;
-
-        if (predicate(step) && steps.some((s) => s.UUID === step.UUID)) {
-          // clone the step if it matches the condition and isn't a nested step
-          clone = Object.assign({}, step);
-        }
-
-        // overwrite the branch if one of its steps contains a match
-        if (clone && clone.branches) {
-          clone.branches.forEach((branch, idx) => {
-            const filteredBranchSteps = filterNestedSteps(branch.steps, predicate);
-            if (filteredBranchSteps && clone?.branches) {
-              clone.branches[idx].steps = filteredBranchSteps;
-            }
-          });
-        }
-
-        // if there's a cloned step, push it to the output list
-        clone && list.push(clone);
-        return list;
-      }, []);
-}
-
-/**
- * Returns a Step index when provided with the `UUID`.
- * `UUID` is originally set using the Step UUID.
- * @param UUID
- * @param steps
- */
-export function findStepIdxWithUUID(UUID: string, steps?: IStepProps[]): number {
-  // optional steps allows for dependency injection in testing
-  if (!steps) {
-    return useIntegrationJsonStore
-      .getState()
-      .integrationJson.steps.map((s) => s.UUID)
-      .indexOf(UUID);
-  } else {
-    return steps.map((s) => s.UUID).indexOf(UUID);
+    return stepNodes;
   }
-}
 
-/**
- * Given a step and a function with a condition,
- * return a new step with filtered branch steps
- * @param step
- * @param predicate
- */
-export function filterStepWithBranches(step: IStepProps, predicate: (step: IStepProps) => boolean) {
-  const stepCopy: IStepProps = { ...step };
-  const loopOverBranches = (branches: IStepPropsBranch[]) => {
-    if (step.branches?.length === 0) return;
-    branches.forEach((branch, idx) => {
-      const branchCopy = { ...branch };
-      if (stepCopy.branches && stepCopy.branches[idx].steps) {
-        const filtered = filterNestedSteps(branchCopy.steps, predicate);
-        if (filtered) stepCopy.branches[idx].steps = filtered;
-      }
-    });
-  };
+  /**
+   * Checks if an array of nodes contains an ADD A STEP placeholder step
+   * @param stepNodes
+   */
+  static containsAddStepPlaceholder(stepNodes: IVizStepNode[]): boolean {
+    return stepNodes.length > 0 && stepNodes[0].data.label === 'ADD A STEP';
+  }
 
-  if (stepCopy.branches) loopOverBranches(stepCopy.branches);
+  /**
+   * Returns a Node index when provided with the `UUID`.
+   * @param UUID
+   * @param nodes
+   */
+  static findNodeIdxWithUUID(UUID: string, nodes: IVizStepNode[]) {
+    return nodes.map((n) => n.data.step.UUID).indexOf(UUID);
+  }
 
-  return stepCopy;
-}
+  /**
+   * Accepts an array of React Flow nodes and edges,
+   * build a new ELK layout graph with them
+   * @param nodes
+   * @param edges
+   * @param direction
+   */
+  static async getLayoutedElements(
+    nodes: IVizStepNode[],
+    edges: IVizStepPropsEdge[],
+    direction: string
+  ) {
+    const DEFAULT_WIDTH_HEIGHT = 80;
+    const isHorizontal = direction === 'RIGHT';
 
-/**
- * Returns a Node index when provided with the `UUID`.
- * @param UUID
- * @param nodes
- */
-export function findNodeIdxWithUUID(UUID: string, nodes: IVizStepNode[]) {
-  return nodes.map((n) => n.data.step.UUID).indexOf(UUID);
-}
+    const elk = new ELK({
+      defaultLayoutOptions: {
+        'elk.algorithm': 'layered',
+        'elk.direction': direction,
 
-/**
- * Flattens a deeply nested array of Steps and their respective
- * branches, and their Steps, into a single array.
- * Typically used for quickly fetching a Step.
- */
-export function flattenSteps(steps: IStepProps[]): IStepProps[] {
-  let children: IStepProps[] = [];
-  const flattenMembers = steps.map((s) => {
-    if (s.branches && s.branches.length) {
-      s.branches.forEach((b) => {
-        children = [...children, ...b.steps];
-      });
-    }
-    return s;
-  });
+        // vertical spacing of nodes
+        'elk.spacing.nodeNode': DEFAULT_WIDTH_HEIGHT / 2,
 
-  return flattenMembers.concat(children.length ? flattenSteps(children) : children);
-}
+        // ensures balanced, linear graph from beginning to end
+        'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
 
-/**
- * Accepts an array of React Flow nodes and edges,
- * build a new ELK layout graph with them
- * @param nodes
- * @param edges
- * @param direction
- */
-export async function getLayoutedElements(
-  nodes: IVizStepNode[],
-  edges: IVizStepPropsEdge[],
-  direction: string
-) {
-  const DEFAULT_WIDTH_HEIGHT = 80;
-  const isHorizontal = direction === 'RIGHT';
+        // *between handles horizontal spacing
+        'elk.layered.spacing.nodeNodeBetweenLayers': DEFAULT_WIDTH_HEIGHT,
+        'elk.layered.spacing.edgeEdgeBetweenLayers': DEFAULT_WIDTH_HEIGHT * 1.5,
+        'spacing.componentComponent': '70',
+        spacing: '75',
 
-  const elk = new ELK({
-    defaultLayoutOptions: {
-      'elk.algorithm': 'layered',
-      'elk.direction': direction,
-
-      // vertical spacing of nodes
-      'elk.spacing.nodeNode': DEFAULT_WIDTH_HEIGHT / 2,
-
-      // ensures balanced, linear graph from beginning to end
-      'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-
-      // *between handles horizontal spacing
-      'elk.layered.spacing.nodeNodeBetweenLayers': DEFAULT_WIDTH_HEIGHT,
-      'elk.layered.spacing.edgeEdgeBetweenLayers': DEFAULT_WIDTH_HEIGHT * 1.5,
-      'spacing.componentComponent': '70',
-      spacing: '75',
-
-      // ensures correct order of nodes (particularly important for branches)
-      'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
-    },
-  });
-
-  const elkNodes: ElkNode[] = [];
-  const elkEdges: ElkExtendedEdge[] = [];
-
-  nodes.forEach((flowNode) => {
-    elkNodes.push({
-      id: flowNode.id,
-      width: flowNode.width ?? DEFAULT_WIDTH_HEIGHT,
-      height: flowNode.height ?? DEFAULT_WIDTH_HEIGHT,
-    });
-  });
-
-  edges.forEach((flowEdge) => {
-    elkEdges.push({
-      id: flowEdge.id,
-      targets: [flowEdge.target],
-      sources: [flowEdge.source],
-    });
-  });
-
-  const newGraph = await elk.layout({
-    id: 'root',
-    portConstraints: 'FIXED_ORDER',
-    children: elkNodes,
-    edges: elkEdges,
-  });
-
-  nodes.forEach((flowNode) => {
-    const node = newGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
-    if (node?.x && node?.y && node?.width && node?.height) {
-      flowNode.position = {
-        x: node.x - node.width / 2,
-        y: node.y - node.height / 2,
-      };
-
-      flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
-      flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
-    }
-    return flowNode;
-  });
-
-  return { layoutedNodes: nodes, layoutedEdges: edges };
-}
-
-export function getRandomArbitraryNumber(): number {
-  const crypto = window.crypto;
-  return Math.floor(crypto?.getRandomValues(new Uint32Array(1))[0]);
-}
-
-export function insertAddStepPlaceholder(
-  stepNodes: IVizStepNode[],
-  id: string,
-  type: string,
-  props: { [prop: string]: any }
-) {
-  return stepNodes.unshift({
-    data: {
-      label: 'ADD A STEP',
-      step: {
-        maxBranches: 0,
-        minBranches: 0,
-        name: '',
-        type: type,
-        UUID: `placeholder-${getRandomArbitraryNumber()}`,
+        // ensures correct order of nodes (particularly important for branches)
+        'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
       },
-      isPlaceholder: true,
-      ...props,
-    },
-    id,
-    draggable: false,
-    position: { x: 0, y: 0 },
-    type: 'step',
-    width: 80,
-    height: 80,
-  } as IVizStepNode);
-}
+    });
 
-export function insertBranchGroupNode(
-  stepNodes: Partial<IVizStepNode>[],
-  position: { x: number; y: number },
-  groupHeight: number,
-  groupWidth: number,
-  props?: { [prop: string]: any }
-) {
-  return stepNodes.unshift({
-    id: getRandomArbitraryNumber().toString(),
-    type: 'group',
-    position,
-    data: {
-      ...props,
-    },
-    className: 'light',
-    draggable: true,
-    style: {
-      border: 'dashed 1px rgba(37, 150, 190, 0.8)',
-      width: groupWidth,
-      height: groupHeight,
-      backgroundColor: 'rgba(37, 150, 190, 0.1)',
-    },
-  });
-}
+    const elkNodes: ElkNode[] = [];
+    const elkEdges: ElkExtendedEdge[] = [];
 
-/**
- * Insert the given step at the specified index of
- * an array of provided steps
- * @param steps
- * @param insertIndex
- * @param newStep
- */
-export function insertStep(
-  steps: IStepProps[],
-  insertIndex: number,
-  newStep: IStepProps
-): IStepProps[] {
-  return [
-    // part of array before the index
-    ...steps.slice(0, insertIndex),
-    // inserted item
-    newStep,
-    // part of array after the index
-    ...steps.slice(insertIndex),
-  ];
-}
-
-export function isEndStep(step: IStepProps): boolean {
-  return step.type === 'END';
-}
-
-export function isFirstStepEip(steps: IStepProps[]): boolean {
-  return steps.length > 0 && steps[0].kind === 'EIP';
-}
-
-export function isFirstStepStart(steps: IStepProps[]): boolean {
-  return steps.length > 0 && steps[0].type === 'START';
-}
-
-export function isMiddleStep(step: IStepProps): boolean {
-  return step.type === 'MIDDLE';
-}
-
-export function isStartStep(step: IStepProps): boolean {
-  return step.type === 'START';
-}
-
-/**
- * Inserts the given step at the beginning of the
- * array of provided steps, returning the modified array
- * @param steps
- * @param newStep
- */
-export function prependStep(steps: IStepProps[], newStep: IStepProps): IStepProps[] {
-  const newSteps = [...steps];
-  newSteps.unshift(newStep);
-  return newSteps;
-}
-
-/**
- * Regenerate a UUID for a list of Steps
- * Every time there is a change to steps or their positioning in the Steps array,
- * their UUIDs need to be regenerated
- * @param steps
- * @param branchSteps
- */
-export function regenerateUuids(steps: IStepProps[], branchSteps: boolean = false): IStepProps[] {
-  let newSteps = steps.slice();
-
-  newSteps.forEach((step, idx) => {
-    step.UUID = `${step.name}-${idx}`;
-    if (branchSteps) step.UUID = `${step.name}-${idx}-${getRandomArbitraryNumber()}`;
-    if (step.branches) {
-      step.branches.forEach((branch) => {
-        branch.branchUuid = `b-${idx}-${getRandomArbitraryNumber()}`;
-        return newSteps.concat(regenerateUuids(branch.steps, true));
+    nodes.forEach((flowNode) => {
+      elkNodes.push({
+        id: flowNode.id,
+        width: flowNode.width ?? DEFAULT_WIDTH_HEIGHT,
+        height: flowNode.height ?? DEFAULT_WIDTH_HEIGHT,
       });
-    }
-  });
-  return newSteps;
-}
+    });
 
-/**
- * Given a node, determines if an edge should be created for it
- * @param node
- * @param nextNode
- */
-export function shouldAddEdge(node: IVizStepNode, nextNode?: IVizStepNode): boolean {
-  return node.data.step && nextNode && !containsBranches(node.data.step);
+    edges.forEach((flowEdge) => {
+      elkEdges.push({
+        id: flowEdge.id,
+        targets: [flowEdge.target],
+        sources: [flowEdge.source],
+      });
+    });
+
+    const newGraph = await elk.layout({
+      id: 'root',
+      portConstraints: 'FIXED_ORDER',
+      children: elkNodes,
+      edges: elkEdges,
+    });
+
+    nodes.forEach((flowNode) => {
+      const node = newGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
+      if (node?.x && node?.y && node?.width && node?.height) {
+        flowNode.position = {
+          x: node.x - node.width / 2,
+          y: node.y - node.height / 2,
+        };
+
+        flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
+        flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
+      }
+      return flowNode;
+    });
+
+    return { layoutedNodes: nodes, layoutedEdges: edges };
+  }
+
+  static insertAddStepPlaceholder(
+    stepNodes: IVizStepNode[],
+    id: string,
+    type: string,
+    props: { [prop: string]: any }
+  ) {
+    return stepNodes.unshift({
+      data: {
+        label: 'ADD A STEP',
+        step: {
+          maxBranches: 0,
+          minBranches: 0,
+          name: '',
+          type: type,
+          UUID: `placeholder-${getRandomArbitraryNumber()}`,
+        },
+        isPlaceholder: true,
+        ...props,
+      },
+      id,
+      draggable: false,
+      position: { x: 0, y: 0 },
+      type: 'step',
+      width: 80,
+      height: 80,
+    } as IVizStepNode);
+  }
+
+  static insertBranchGroupNode(
+    stepNodes: Partial<IVizStepNode>[],
+    position: { x: number; y: number },
+    groupHeight: number,
+    groupWidth: number,
+    props?: { [prop: string]: any }
+  ) {
+    return stepNodes.unshift({
+      id: getRandomArbitraryNumber().toString(),
+      type: 'group',
+      position,
+      data: {
+        ...props,
+      },
+      className: 'light',
+      draggable: true,
+      style: {
+        border: 'dashed 1px rgba(37, 150, 190, 0.8)',
+        width: groupWidth,
+        height: groupHeight,
+        backgroundColor: 'rgba(37, 150, 190, 0.1)',
+      },
+    });
+  }
+
+  /**
+   * Given a node, determines if an edge should be created for it
+   * @param node
+   * @param nextNode
+   */
+  static shouldAddEdge(node: IVizStepNode, nextNode?: IVizStepNode): boolean {
+    return node.data.step && nextNode && !StepsService.containsBranches(node.data.step);
+  }
+
+  /**
+   * Builds Reaat Flow nodes and edges from current integration JSON.
+   * @param handleDeleteStep
+   */
+  buildNodesAndEdges(handleDeleteStep: (uuid: string) => void) {
+    const steps = this.integrationJsonStore.integrationJson.steps;
+    const layout = this.visualizationStore.layout;
+    // build all nodes
+    const stepNodes = VisualizationService.buildNodesFromSteps(steps, layout, {
+      handleDeleteStep
+    });
+
+    // build edges only for main nodes
+    const filteredNodes = stepNodes.filter((node) => !node.data.branchInfo?.branchStep);
+    let stepEdges: IVizStepPropsEdge[] = VisualizationService.buildEdges(filteredNodes);
+
+    // build edges for branch nodes
+    const branchSpecialEdges: IVizStepPropsEdge[] = this.buildBranchSpecialEdges(stepNodes);
+
+    stepEdges = stepEdges.concat(...branchSpecialEdges);
+
+    return { stepNodes, stepEdges };
+  }
+
+  /**
+   * Redraw integration diagram on the canvas. If {@link rebuildNodes} is true,
+   * It rebuilds the nodes and edges from integration JSON store and re-layout the diagram.
+   * Otherwise it only performs re-layout.
+   * @param handleDeleteStep
+   * @param rebuildNodes
+   */
+  async redrawDiagram(handleDeleteStep: (uuid: string) => void, rebuildNodes: boolean) {
+    let stepNodes = this.visualizationStore.nodes;
+    let stepEdges = this.visualizationStore.edges;
+    if (rebuildNodes) {
+      const ne = this.buildNodesAndEdges(handleDeleteStep);
+      stepNodes = ne.stepNodes;
+      stepEdges = ne.stepEdges
+    }
+    VisualizationService.getLayoutedElements(stepNodes, stepEdges, this.visualizationStore.layout)
+      .then((res) => {
+        const { layoutedNodes, layoutedEdges } = res;
+        this.visualizationStore.setNodes(layoutedNodes);
+        this.visualizationStore.setEdges(layoutedEdges);
+      })
+  }
+
 }

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -3,7 +3,7 @@ import { useIntegrationSourceStore } from './integrationSourceStore';
 import { useNestedStepsStore } from './nestedStepsStore';
 import { useSettingsStore } from './settingsStore';
 import { useVisualizationStore } from './visualizationStore';
-import { extractNestedSteps, insertStep, regenerateUuids } from '@kaoto/services';
+import { StepsService } from '@kaoto/services';
 import { IIntegration, IStepProps, IViewProps } from '@kaoto/types';
 import { setDeepValue } from '@kaoto/utils';
 import isEqual from 'lodash.isequal';
@@ -11,7 +11,7 @@ import { mountStoreDevtool } from 'simple-zustand-devtools';
 import { temporal } from 'zundo';
 import { create } from 'zustand';
 
-interface IIntegrationJsonStore {
+export interface IIntegrationJsonStore {
   appendStep: (newStep: IStepProps) => void;
   deleteBranchStep: (newStep: IStepProps, originalStepIndex: number) => void;
   deleteIntegration: () => void;
@@ -61,9 +61,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
         // replacing the origin parent of a deeply nested step
         newSteps[originalStepIndex] = newStep;
 
-        const stepsWithNewUuids = regenerateUuids(newSteps);
+        const stepsWithNewUuids = StepsService.regenerateUuids(newSteps);
         const { updateSteps } = useNestedStepsStore.getState();
-        updateSteps(extractNestedSteps(stepsWithNewUuids));
+        updateSteps(StepsService.extractNestedSteps(stepsWithNewUuids));
 
         return set((state) => ({
           integrationJson: {
@@ -75,9 +75,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
       deleteStep: (stepIdx) => {
         let stepsCopy = get().integrationJson.steps.slice();
         const updatedSteps = stepsCopy.filter((_step: IStepProps, idx: number) => idx !== stepIdx);
-        const stepsWithNewUuids = regenerateUuids(updatedSteps);
+        const stepsWithNewUuids = StepsService.regenerateUuids(updatedSteps);
         const updateSteps = useNestedStepsStore.getState().updateSteps;
-        updateSteps(extractNestedSteps(stepsWithNewUuids));
+        updateSteps(StepsService.extractNestedSteps(stepsWithNewUuids));
         set((state) => ({
           integrationJson: {
             ...state.integrationJson,
@@ -95,9 +95,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
       },
       insertStep: (newStep, insertIndex) => {
         let steps = get().integrationJson.steps.slice();
-        const stepsWithNewUuids = regenerateUuids(insertStep(steps, insertIndex, newStep));
+        const stepsWithNewUuids = StepsService.regenerateUuids(StepsService.insertStep(steps, insertIndex, newStep));
         const updateSteps = useNestedStepsStore.getState().updateSteps;
-        updateSteps(extractNestedSteps(stepsWithNewUuids));
+        updateSteps(StepsService.extractNestedSteps(stepsWithNewUuids));
 
         set((state) => ({
           integrationJson: {
@@ -110,9 +110,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
         let stepsCopy = get().integrationJson.steps.slice();
         stepsCopy = setDeepValue(stepsCopy, pathToOldStep, newStep);
 
-        const stepsWithNewUuids = regenerateUuids(stepsCopy);
+        const stepsWithNewUuids = StepsService.regenerateUuids(stepsCopy);
         const { updateSteps } = useNestedStepsStore.getState();
-        updateSteps(extractNestedSteps(stepsWithNewUuids));
+        updateSteps(StepsService.extractNestedSteps(stepsWithNewUuids));
 
         return set((state) => ({
           integrationJson: {
@@ -131,9 +131,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           stepsCopy[oldStepIndex] = newStep;
         }
 
-        const stepsWithNewUuids = regenerateUuids(stepsCopy);
+        const stepsWithNewUuids = StepsService.regenerateUuids(stepsCopy);
         const { updateSteps } = useNestedStepsStore.getState();
-        updateSteps(extractNestedSteps(stepsWithNewUuids));
+        updateSteps(StepsService.extractNestedSteps(stepsWithNewUuids));
 
         return set((state) => ({
           integrationJson: {
@@ -147,9 +147,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
       },
       updateIntegration: (newInt: IIntegration) => {
         let newIntegration = { ...get().integrationJson, ...newInt };
-        const uuidSteps = regenerateUuids(newIntegration.steps);
+        const uuidSteps = StepsService.regenerateUuids(newIntegration.steps);
         const updateSteps = useNestedStepsStore.getState().updateSteps;
-        updateSteps(extractNestedSteps(uuidSteps));
+        updateSteps(StepsService.extractNestedSteps(uuidSteps));
 
         return set({ integrationJson: { ...newIntegration, steps: uuidSteps } });
       },

--- a/src/store/nestedStepsStore.tsx
+++ b/src/store/nestedStepsStore.tsx
@@ -1,7 +1,7 @@
 import { INestedStep } from '@kaoto/types';
 import { create } from 'zustand';
 
-interface INestedStepStore {
+export interface INestedStepStore {
   addStep: (newStep: INestedStep) => void;
   clearNestedSteps: () => void;
   deleteStep: (stepUuid: string) => void;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import {useEffect, useRef} from 'react';
 
 export function accessibleRouteChangeHandler() {
   return window.setTimeout(() => {
@@ -143,4 +143,9 @@ export function unbindUndoRedo(callback: (event: KeyboardEvent) => void) {
 }
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function getRandomArbitraryNumber(): number {
+  const crypto = window.crypto;
+  return Math.floor(crypto?.getRandomValues(new Uint32Array(1))[0]);
 }

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
-import { findPath, getDeepValue, setDeepValue } from './index';
-import { filterNestedSteps } from '@kaoto/services';
+import {findPath, getDeepValue, getRandomArbitraryNumber, setDeepValue} from './index';
+import { StepsService } from '@kaoto/services';
 
 describe('utils', () => {
   it('findPath(): should find the path from a deeply nested object, given a value', () => {
@@ -24,7 +24,7 @@ describe('utils', () => {
     const nestedBranchCopy = nestedBranch.slice();
     expect(nestedBranchCopy[1].branches![0].steps[0].branches![0].steps).toHaveLength(1);
 
-    const filteredNestedBranch = filterNestedSteps(
+    const filteredNestedBranch = StepsService.filterNestedSteps(
       nestedBranchCopy,
       (step) => step.UUID !== 'log-340230'
     );
@@ -62,4 +62,16 @@ describe('utils', () => {
       { a: [{ bar: { c: 6 }, baz: { d: 2 } }], x: { '0': { y: { z: 5 } } } },
     ]);
   });
+
+  it.skip('getRandomArbitraryNumber(): should get a random arbitrary number', () => {
+    const mGetRandomValues = jest.fn().mockReturnValueOnce(new Uint32Array(10));
+
+    Object.defineProperty(window, 'crypto', {
+      value: { getRandomValues: mGetRandomValues },
+    });
+
+    expect(getRandomArbitraryNumber()).toEqual(new Uint32Array(10));
+    expect(mGetRandomValues).toBeCalledWith(new Uint8Array(1));
+  });
+
 });


### PR DESCRIPTION
* From now on the componets are expected to only initialize the stores and forward them directly to the services. In This way the store details, which often touches the business logic, are isolated from components and encapsulated into services
  * In this changeset, only Visualization.tsx and VisualizationStep.tsx are addressed. More will be expected later
* Turns services into classes and let them hold references to the stores, mainly for reducing the arguments on business logic methods invoked from components, therefore it helps more to decouple business logic from components. Also the related business logic routines are bundled together into a same namespace of class, which makes it easier to see where the method is declared and for what purpose.
* Splitted StepsService from VisualizationService, trying to isolate the logical model handling (e.g. IStepProps) from pure visualization handling (React Flow nodes and edges) as much as possible