### PR TITLE
fix(steps): Hide the details panel upon clicking on a selected step

### DIFF
--- a/src/__mocks__/steps.ts
+++ b/src/__mocks__/steps.ts
@@ -1,0 +1,73 @@
+import { MarkerType, Position } from 'reactflow';
+
+export const stepsStub = {
+  nodes: [
+    {
+      data: {
+        icon: 'data:image/svg+xml;base64,',
+        kind: 'Kamelet',
+        label: 'timer-source',
+        step: {
+          name: 'timer-source',
+          type: 'START',
+          id: 'timer-source',
+          kind: 'Kamelet',
+          icon: 'data:image/svg+xml;base64,',
+          title: 'Timer Source',
+          description: 'Produces periodic messages with a custom payload.',
+          group: 'Timer',
+          parameters: [],
+          required: [],
+          branches: null,
+          minBranches: 0,
+          maxBranches: 0,
+          UUID: 'timer-source-0'
+        },
+        isPlaceholder: false,
+        isLastStep: true
+      },
+      draggable: false,
+      id: 'node_0-timer-source-0-4076175505',
+      position: {
+        x: -28,
+        y: -28
+      },
+      type: 'step',
+      width: 80,
+      height: 80,
+      isLastStep: true,
+      targetPosition: Position.Left,
+      sourcePosition: Position.Right,
+      selected: true
+    }
+  ],
+  edges: [],
+  layout: MarkerType.Arrow
+}
+
+export const integrationJSONStub = {
+  dsl: 'KameletBinding',
+  metadata: {
+    name: 'integration',
+    namespace: 'default'
+  },
+  steps: [
+    {
+      name: 'timer-source',
+      type: 'START',
+      id: 'timer-source',
+      kind: 'Kamelet',
+      icon: 'data:image/svg+xml;base64,',
+      title: 'Timer Source',
+      description: 'Produces periodic messages with a custom payload.',
+      group: 'Timer',
+      parameters: [],
+      required: [],
+      branches: null,
+      minBranches: 0,
+      maxBranches: 0,
+      UUID: 'timer-source-0'
+    }
+  ],
+  params: []
+}

--- a/src/components/KaotoDrawer.tsx
+++ b/src/components/KaotoDrawer.tsx
@@ -41,6 +41,7 @@ export const KaotoDrawer = ({
   panelContent,
   position,
   style,
+  ...rest
 }: IKaotoDrawer) => {
   const consoleDrawerRef = useRef<HTMLSpanElement | null>(null);
 
@@ -65,7 +66,7 @@ export const KaotoDrawer = ({
   );
 
   return (
-    <Drawer id={id} isExpanded={isExpanded} onExpand={onExpand} position={position} style={style}>
+    <Drawer id={id} isExpanded={isExpanded} onExpand={onExpand} position={position} style={style} {...rest}>
       <DrawerContent panelContent={panelContentWrapper} className={'panelCustom'}>
         <DrawerContentBody>{children}</DrawerContentBody>
       </DrawerContent>

--- a/src/components/Visualization.test.tsx
+++ b/src/components/Visualization.test.tsx
@@ -1,7 +1,8 @@
+import { IIntegrationJsonStore, RFState, useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AlertProvider } from '../layout';
+import { integrationJSONStub, stepsStub } from '../__mocks__/steps';
 import { Visualization } from './Visualization';
-import { screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
 
 beforeAll(() => {
   // Setup ResizeObserver and offset* properties
@@ -40,5 +41,26 @@ describe('Visualization.tsx', () => {
     );
     const element = screen.getByTestId('react-flow-wrapper');
     expect(element).toBeInTheDocument();
+  });
+
+  test('should expands the details panel upon clicking on a step', async () => {
+    useVisualizationStore.setState(stepsStub as unknown as RFState);
+    useIntegrationJsonStore.setState(integrationJSONStub as unknown as IIntegrationJsonStore);
+
+    const wrapper = render(
+      <AlertProvider>
+        <Visualization />
+      </AlertProvider>
+    );
+
+    const stepIcon = wrapper.getByTestId('viz-step-timer-source').querySelector('.stepNode__Icon.stepNode__clickable') as HTMLDivElement;
+
+    fireEvent.click(stepIcon);
+
+    const drawer = wrapper.container.querySelector('#right-resize-panel');
+
+    await waitFor(() => {
+      expect(drawer?.getAttribute('data-expanded')).toEqual('true');
+    });
   });
 });

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -117,7 +117,15 @@ const Visualization = () => {
       const step = stepsService.findStepWithUUID(node.data.step.UUID);
       if (step) setSelectedStep(step);
 
+      /** If the details panel is collapsed, we expanded for the user */
       if (!isPanelExpanded) setIsPanelExpanded(true);
+
+      /**
+       * If the details panel is already expanded and the step it's already
+       * selected, we collapse it for the user */
+      if (isPanelExpanded && selectedStep.UUID === node.data.step.UUID) {
+        setIsPanelExpanded(false);
+      }
     }
   };
 
@@ -138,6 +146,7 @@ const Visualization = () => {
       {/* RIGHT DRAWER: STEP DETAIL & EXTENSIONS */}
       <KaotoDrawer
         isExpanded={isPanelExpanded}
+        data-expanded={isPanelExpanded}
         isResizable={true}
         panelContent={
           <VisualizationStepViews


### PR DESCRIPTION
At the moment, clicking on a step shows the Step Details panel.

With this commit, clicking once again will hide the Step Details panel.

Please see the attached screencast:

[Screencast from 2023-02-10 18-29-41.webm](https://user-images.githubusercontent.com/16512618/218157292-1593fb36-a766-4bf7-9e1e-534b7e3e0475.webm)

fixes [#543](https://github.com/KaotoIO/kaoto-ui/issues/543)