### PR TITLE
chore(catalog): Extract info below Step Catalog title

### DIFF
--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -24,9 +24,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
-  Tooltip,
 } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useEffect, useRef, useState } from 'react';
 
@@ -96,10 +94,8 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
       <DrawerHead>
         <h3 className={'pf-c-title pf-m-2xl'}>
           Step Catalog&nbsp;&nbsp;
-          <Tooltip content={<span>Try dragging a step onto a circle in the canvas</span>}>
-            <InfoCircleIcon className={'catalog__help'} />
-          </Tooltip>
         </h3>
+        <span>Try dragging a step onto a circle in the canvas</span>
         <DrawerActions>
           <DrawerCloseButton onClick={handleClose} />
         </DrawerActions>


### PR DESCRIPTION
It seems like having the initial instructions about how to start an integration inside of an info button is not clear enough.
![image](https://user-images.githubusercontent.com/16512618/218161303-2d7707cb-73ea-45a6-8705-07f2b6f73b15.png)

This commit extracts that sentence and places it directly below the Step Catalog title with the aim of being more explicit.
![image](https://user-images.githubusercontent.com/16512618/218161406-c2899f82-12f2-4479-92d1-b452404c9623.png)
