### PR TITLE
fix(steps-catalog): Remove extra X from the Search box

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,3 +21,12 @@ code {
 .pf-u-screen-reader {
   display: none;
 }
+
+/*
+  clears the extra 'X' for Google Chrome, Microsoft Edge (Chromium)
+  from the Step Catalogs's Search box
+*/
+#stepSearch input[type="search"]::-webkit-search-decoration,
+#stepSearch input[type="search"]::-webkit-search-cancel-button,
+#stepSearch input[type="search"]::-webkit-search-results-button,
+#stepSearch input[type="search"]::-webkit-search-results-decoration { display: none; }


### PR DESCRIPTION
### Context
Chromium-based browsers add an X automatically to clear input of search type.

This is usually beneficial but in our case, it causes rendering an extra X since the Search component already provides one out of the box.

This commit hides the native X in favor of the Search component one.

### Before
![image](https://user-images.githubusercontent.com/16512618/218164768-f6a08e62-4797-4f55-b4fc-ab3725c74720.png)

### After
![image](https://user-images.githubusercontent.com/16512618/218164867-220a13b4-e33a-4616-b0f9-ea41989ef9ec.png)

fixes [1097](https://github.com/KaotoIO/kaoto-ui/issues/1097)