### PR TITLE
feat(branching): adds ability to build branches in canvas

### DIFF
--- a/src/components/BranchBuilder.tsx
+++ b/src/components/BranchBuilder.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@patternfly/react-core';
+
+interface IBranchBuilder {
+  handleAddBranch: () => void;
+}
+
+const BranchBuilder = ({ handleAddBranch }: IBranchBuilder) => {
+  return (
+    <>
+      <Button variant={'primary'} onClick={handleAddBranch}>
+        Add a Branch
+      </Button>
+    </>
+  );
+};
+
+export { BranchBuilder };

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -1,4 +1,5 @@
 import { fetchCatalogSteps } from '@kaoto/api';
+import { StepsService } from '@kaoto/services';
 import { useSettingsStore } from '@kaoto/store';
 import { IStepProps, IStepQueryParams } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
@@ -11,30 +12,42 @@ import {
   GridItem,
   InputGroup,
   SearchInput,
+  Tabs,
+  Tab,
+  TabTitleText,
   ToggleGroup,
   ToggleGroupItem,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { useEffect, useRef, useState } from 'react';
+import { createRef, ReactNode, useEffect, useRef, useState } from 'react';
 
 export interface IMiniCatalog {
+  children?: ReactNode;
   handleSelectStep?: (selectedStep: any) => void;
   queryParams?: IStepQueryParams;
+  step?: IStepProps;
   steps?: IStepProps[];
 }
 
 export const MiniCatalog = (props: IMiniCatalog) => {
   const [catalogData, setCatalogData] = useState<IStepProps[]>(props.steps ?? []);
   const [query, setQuery] = useState(``);
+  const [activeTabKey, setActiveTabKey] = useState();
   const dsl = useSettingsStore((state) => state.settings.dsl.name);
   const typesAllowedArray = props.queryParams?.type?.split(',');
   const [isSelected, setIsSelected] = useState(typesAllowedArray ? typesAllowedArray[0] : 'MIDDLE');
+  const tooltipRef = createRef();
 
   const { addAlert } = useAlert() || {};
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const handleTabClick = (_e: any, tabIndex: any) => {
+    setActiveTabKey(tabIndex);
+  };
 
   /**
    * Sort & fetch all Steps for the Catalog
@@ -90,86 +103,105 @@ export const MiniCatalog = (props: IMiniCatalog) => {
 
   return (
     <section data-testid={'miniCatalog'} className={'nodrag'}>
-      <Toolbar id={'toolbar'} style={{ background: 'transparent' }}>
-        <ToolbarContent>
-          {
-            <>
-              <ToolbarItem className={'miniCatalog__search'}>
-                <InputGroup>
-                  <SearchInput
-                    name={'stepSearch'}
-                    id={'stepSearch'}
-                    type={'search'}
-                    placeholder={'search for a step...'}
-                    data-testid={'miniCatalog__search--input'}
-                    aria-label={'search for a step'}
-                    value={query}
-                    onChange={changeSearch}
-                    ref={searchInputRef}
-                  />
-                </InputGroup>
-              </ToolbarItem>
-              <ToolbarItem style={{ width: '100%' }}>
-                <ToggleGroup aria-label={'Icon variant toggle group'} style={{ width: '100%' }}>
-                  <ToggleGroupItem
-                    text={'start'}
-                    aria-label={'sources button'}
-                    buttonId={'START'}
-                    isDisabled={!typesAllowedArray?.includes('START')}
-                    isSelected={isSelected === 'START'}
-                    onChange={handleItemClick}
-                  />
-                  <ToggleGroupItem
-                    icon={'actions'}
-                    aria-label={'actions button'}
-                    buttonId={'MIDDLE'}
-                    isDisabled={!typesAllowedArray?.includes('MIDDLE')}
-                    isSelected={isSelected === 'MIDDLE'}
-                    onChange={handleItemClick}
-                  />
-                  <ToggleGroupItem
-                    text={'end'}
-                    aria-label={'sinks button'}
-                    buttonId={'END'}
-                    isDisabled={!typesAllowedArray?.includes('END')}
-                    isSelected={isSelected === 'END'}
-                    onChange={handleItemClick}
-                  />
-                </ToggleGroup>
-              </ToolbarItem>
-            </>
-          }
-        </ToolbarContent>
-      </Toolbar>
-      <Gallery hasGutter={false} className={'miniCatalog__gallery'}>
-        {catalogData &&
-          search(catalogData).map((step, idx) => {
-            return (
-              <Button
-                key={idx}
-                variant={'tertiary'}
-                onClick={() => {
-                  handleSelectStep(step);
-                }}
-                className={'miniCatalog__stepItem'}
-                data-testid={`miniCatalog__stepItem--${step.name}`}
-              >
-                <Grid md={6} className={'miniCatalog__stepItem__grid'}>
-                  <GridItem span={3}>
-                    <Bullseye>
-                      <img
-                        src={step.icon}
-                        className={'miniCatalog__stepImage'}
-                        alt={'Step Image'}
+      <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
+        <Tab eventKey={0} title={<TabTitleText>Steps</TabTitleText>}>
+          <Toolbar id={'toolbar'} style={{ background: 'transparent' }}>
+            <ToolbarContent>
+              {
+                <>
+                  <ToolbarItem>
+                    <InputGroup>
+                      <SearchInput
+                        name={'stepSearch'}
+                        id={'stepSearch'}
+                        type={'search'}
+                        placeholder={'search for a step...'}
+                        data-testid={'miniCatalog__search--input'}
+                        aria-label={'search for a step'}
+                        value={query}
+                        onChange={changeSearch}
+                        ref={searchInputRef}
                       />
-                    </Bullseye>
-                  </GridItem>
-                  <GridItem span={9}>{truncateString(step.name, 25)}</GridItem>
-                </Grid>
-              </Button>
-            );
-          })}
-      </Gallery>
+                    </InputGroup>
+                  </ToolbarItem>
+                  <ToolbarItem>
+                    <ToggleGroup aria-label={'Icon variant toggle group'} style={{ width: '100%' }}>
+                      <ToggleGroupItem
+                        text={'start'}
+                        aria-label={'sources button'}
+                        buttonId={'START'}
+                        isDisabled={!typesAllowedArray?.includes('START')}
+                        isSelected={isSelected === 'START'}
+                        onChange={handleItemClick}
+                      />
+                      <ToggleGroupItem
+                        icon={'actions'}
+                        aria-label={'actions button'}
+                        buttonId={'MIDDLE'}
+                        isDisabled={!typesAllowedArray?.includes('MIDDLE')}
+                        isSelected={isSelected === 'MIDDLE'}
+                        onChange={handleItemClick}
+                      />
+                      <ToggleGroupItem
+                        text={'end'}
+                        aria-label={'sinks button'}
+                        buttonId={'END'}
+                        isDisabled={!typesAllowedArray?.includes('END')}
+                        isSelected={isSelected === 'END'}
+                        onChange={handleItemClick}
+                      />
+                    </ToggleGroup>
+                  </ToolbarItem>
+                </>
+              }
+            </ToolbarContent>
+          </Toolbar>
+          <Gallery hasGutter={false} className={'miniCatalog__gallery'}>
+            {catalogData &&
+              search(catalogData).map((step, idx) => {
+                return (
+                  <Button
+                    key={idx}
+                    variant={'tertiary'}
+                    onClick={() => {
+                      handleSelectStep(step);
+                    }}
+                    className={'miniCatalog__stepItem'}
+                    data-testid={`miniCatalog__stepItem--${step.name}`}
+                  >
+                    <Grid md={6} className={'miniCatalog__stepItem__grid'}>
+                      <GridItem span={3}>
+                        <Bullseye>
+                          <img
+                            src={step.icon}
+                            className={'miniCatalog__stepImage'}
+                            alt={'Step Image'}
+                          />
+                        </Bullseye>
+                      </GridItem>
+                      <GridItem span={9}>{truncateString(step.name, 25)}</GridItem>
+                    </Grid>
+                  </Button>
+                );
+              })}
+          </Gallery>
+        </Tab>
+        <Tab
+          eventKey={1}
+          title={<TabTitleText>Branches</TabTitleText>}
+          isAriaDisabled={!StepsService.supportsBranching(props.step)}
+          ref={tooltipRef}
+        >
+          {!StepsService.supportsBranching(props.step) && (
+            <Tooltip
+              content="This step does not support branching."
+              reference={tooltipRef}
+              position="right"
+            />
+          )}
+          <div style={{ padding: '50px' }}>{props.children}</div>
+        </Tab>
+      </Tabs>
     </section>
   );
 };

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -1,7 +1,7 @@
 import './PlusButtonEdge.css';
-import { MiniCatalog } from '@kaoto/components';
+import { BranchBuilder, MiniCatalog } from '@kaoto/components';
 import { StepsService, ValidationService } from '@kaoto/services';
-import {useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore} from '@kaoto/store';
+import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { Popover } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
@@ -55,10 +55,16 @@ const PlusButtonEdge = ({
     targetPosition,
   });
 
+  const handleAddBranch = () => {
+    stepsService.addBranch(sourceNode?.data.step, { branchUuid: '', identifier: '', steps: [] });
+  };
+
   const onMiniCatalogClickInsert = (selectedStep: IStepProps) => {
     if (targetNode?.data.branchInfo) {
       const rootStepIdx = stepsService.findStepIdxWithUUID(targetNode?.data.branchInfo.parentUuid);
-      const currentStepNested = nestedStepsStore.nestedSteps.map((ns) => ns.stepUuid === targetNode?.data.step.UUID);
+      const currentStepNested = nestedStepsStore.nestedSteps.map(
+        (ns) => ns.stepUuid === targetNode?.data.step.UUID
+      );
 
       if (currentStepNested) {
         // 1. make a copy of the steps, get the root step
@@ -103,14 +109,20 @@ const PlusButtonEdge = ({
             aria-label="Search for a step"
             bodyContent={
               <MiniCatalog
+                children={<BranchBuilder handleAddBranch={handleAddBranch} />}
                 handleSelectStep={onMiniCatalogClickInsert}
                 queryParams={{
-                  type: ValidationService.insertableStepTypes(sourceNode?.data.step, targetNode?.data.step),
+                  type: ValidationService.insertableStepTypes(
+                    sourceNode?.data.step,
+                    targetNode?.data.step
+                  ),
                 }}
+                step={sourceNode?.data.step}
               />
             }
             enableFlip={true}
             flipBehavior={['top-start', 'left-start']}
+            hasAutoWidth
             hideOnOutsideClick={true}
             position={'right-start'}
           >

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,7 +1,7 @@
 import { BranchBuilder } from './BranchBuilder';
 import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
-import { StepsService, ValidationService } from '@kaoto/services';
+import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
 import {
   useIntegrationJsonStore,
   useNestedStepsStore,
@@ -94,7 +94,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           data-testid={`viz-step-${data.step.name}`}
         >
           {/* PREPEND STEP BUTTON */}
-          {!endStep && data.isFirstStep && (
+          {VisualizationService.showPrependStepButton(data, endStep) && (
             <Popover
               appendTo={() => document.body}
               aria-label="Search for a step"
@@ -166,7 +166,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* ADD/APPEND STEP BUTTON */}
-          {!endStep && data.isLastStep && (
+          {VisualizationService.showAppendStepButton(data, endStep) && (
             <Popover
               appendTo={() => document.body}
               aria-label="Search for a step"

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,3 +1,4 @@
+import { BranchBuilder } from './BranchBuilder';
 import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
 import { StepsService, ValidationService } from '@kaoto/services';
@@ -29,16 +30,15 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     stepsService.handleAppendStep(data.step, selectedStep);
   };
   const replacePlaceholderStep = (stepC: IStepProps) => {
-    stepsService.replacePlaceholderStep(data, stepC)
-      .then((validation) => {
-        !validation?.isValid &&
+    stepsService.replacePlaceholderStep(data, stepC).then((validation) => {
+      !validation?.isValid &&
         addAlert &&
         addAlert({
           title: 'Add Step Unsuccessful',
           variant: AlertVariant.danger,
           description: validation.message ?? 'Something went wrong, please try again later.',
         });
-      });
+    });
   };
   const onMiniCatalogClickAdd = (stepC: IStepProps) => {
     replacePlaceholderStep(stepC);
@@ -46,6 +46,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
   const onMiniCatalogClickPrepend = (selectedStep: IStepProps): void => {
     stepsService.handlePrependStep(data.step, selectedStep);
+  };
+
+  const handleAddBranch = () => {
+    stepsService.addBranch(data.step, { branchUuid: '', identifier: '', steps: [] });
   };
 
   const handleTrashClick = () => {
@@ -70,16 +74,15 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
     const dataJSON = event.dataTransfer.getData('text');
     const stepC: IStepProps = JSON.parse(dataJSON);
-    stepsService.handleDropOnExistingStep(data, data.step, stepC)
-      .then((validation) => {
-        !validation.isValid &&
+    stepsService.handleDropOnExistingStep(data, data.step, stepC).then((validation) => {
+      !validation.isValid &&
         addAlert &&
         addAlert({
           title: 'Replace Step Unsuccessful',
           variant: AlertVariant.danger,
           description: validation.message ?? 'Something went wrong, please try again later.',
         });
-      })
+    });
   };
 
   return (
@@ -97,19 +100,21 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               aria-label="Search for a step"
               bodyContent={
                 <MiniCatalog
+                  children={<BranchBuilder handleAddBranch={handleAddBranch} />}
                   handleSelectStep={onMiniCatalogClickPrepend}
                   queryParams={{
                     dsl: currentDSL,
                     type: ValidationService.prependableStepTypes(),
                   }}
+                  step={data.step}
                 />
               }
               className={'miniCatalog__popover'}
               data-testid={'miniCatalog__popover'}
-              enableFlip={true}
-              flipBehavior={['top-start', 'left-start']}
+              hasAutoWidth
               hideOnOutsideClick={true}
               position={'left-start'}
+              showClose={false}
             >
               <button
                 className="stepNode__Prepend plusButton nodrag"
@@ -165,19 +170,23 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               aria-label="Search for a step"
               bodyContent={
                 <MiniCatalog
+                  children={<BranchBuilder handleAddBranch={handleAddBranch} />}
                   handleSelectStep={onMiniCatalogClickAppend}
                   queryParams={{
                     dsl: currentDSL,
                     type: ValidationService.appendableStepTypes(data.step.type),
                   }}
+                  step={data.step}
                 />
               }
               className={'miniCatalog__popover'}
               data-testid={'miniCatalog__popover'}
               enableFlip={true}
               flipBehavior={['top-start', 'left-start']}
+              hasAutoWidth
               hideOnOutsideClick={true}
               position={'right-start'}
+              showClose={false}
             >
               <button
                 className="stepNode__Add plusButton nodrag"
@@ -194,19 +203,21 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           aria-label="Search for a step"
           bodyContent={
             <MiniCatalog
+              children={<BranchBuilder handleAddBranch={handleAddBranch} />}
               handleSelectStep={onMiniCatalogClickAdd}
               queryParams={{
                 dsl: currentDSL,
                 type: data.step.type,
               }}
+              step={data.step}
             />
           }
           className={'miniCatalog__popover'}
           data-testid={'miniCatalog__popover'}
-          enableFlip={true}
-          flipBehavior={['top-start', 'left-start']}
+          hasAutoWidth
           hideOnOutsideClick={true}
-          position={'right-start'}
+          position={'auto'}
+          showClose={false}
         >
           <div
             className={'stepNode stepNode__Slot stepNode__clickable'}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -111,6 +111,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               }
               className={'miniCatalog__popover'}
               data-testid={'miniCatalog__popover'}
+              enableFlip={true}
+              flipBehavior={['top-start', 'left-start']}
               hasAutoWidth
               hideOnOutsideClick={true}
               position={'left-start'}
@@ -214,10 +216,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           }
           className={'miniCatalog__popover'}
           data-testid={'miniCatalog__popover'}
+          enableFlip={true}
+          flipBehavior={['top-start', 'left-start']}
           hasAutoWidth
           hideOnOutsideClick={true}
-          position={'auto'}
-          showClose={false}
+          position={'right-start'}
         >
           <div
             className={'stepNode stepNode__Slot stepNode__clickable'}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AppearanceModal';
+export * from './BranchBuilder';
 export * from './Catalog';
 export * from './ConfirmationModal';
 export * from './Console';

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -1,12 +1,11 @@
 import branchSteps from '../store/data/branchSteps';
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
 import steps from '../store/data/steps';
+import { StepsService } from './stepsService';
+import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
-import { StepsService } from "./stepsService";
-import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from "@kaoto/store";
 
 describe('stepsService', () => {
-
   const stepsService = new StepsService(
     useIntegrationJsonStore.getState(),
     useNestedStepsStore.getState(),
@@ -38,7 +37,10 @@ describe('stepsService', () => {
     ] as IStepProps[];
     expect(nestedSteps[0].branches![0].steps[0].branches![0].steps).toHaveLength(1);
 
-    const filtered = StepsService.filterNestedSteps(nestedSteps, (step) => step.UUID !== 'log-340230');
+    const filtered = StepsService.filterNestedSteps(
+      nestedSteps,
+      (step) => step.UUID !== 'log-340230'
+    );
     expect(filtered![0].branches![0].steps[0].branches![0].steps).toHaveLength(0);
   });
 
@@ -105,7 +107,9 @@ describe('stepsService', () => {
 
     expect(StepsService.insertStep(steps, 2, { name: 'peach' } as IStepProps)).toHaveLength(3);
     // does it insert it at the correct spot?
-    expect(StepsService.insertStep(steps, 2, { name: 'peach' } as IStepProps)[2]).toEqual({ name: 'peach' });
+    expect(StepsService.insertStep(steps, 2, { name: 'peach' } as IStepProps)[2]).toEqual({
+      name: 'peach',
+    });
   });
 
   /**
@@ -177,7 +181,9 @@ describe('stepsService', () => {
     ] as IStepProps[];
 
     expect(StepsService.prependStep(steps, { name: 'peach' } as IStepProps)).toHaveLength(3);
-    expect(StepsService.prependStep(steps, { name: 'mango' } as IStepProps)[0]).toEqual({ name: 'mango' });
+    expect(StepsService.prependStep(steps, { name: 'mango' } as IStepProps)[0]).toEqual({
+      name: 'mango',
+    });
   });
 
   /**
@@ -189,4 +195,15 @@ describe('stepsService', () => {
     expect(StepsService.regenerateUuids(branchSteps)[1].UUID).toBeDefined();
   });
 
+  it('supportsBranching(): should determine if the provided step supports branching', () => {
+    expect(
+      StepsService.supportsBranching({
+        UUID: 'with-branches',
+        minBranches: 0,
+        maxBranches: -1,
+      } as IStepProps)
+    ).toBeTruthy();
+
+    expect(StepsService.supportsBranching({ UUID: 'no-branches' } as IStepProps)).toBeFalsy();
+  });
 });

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -2,7 +2,7 @@ import branchSteps from '../store/data/branchSteps';
 import nodes from '../store/data/nodes';
 import steps from '../store/data/steps';
 import { VisualizationService } from './visualizationService';
-import { IStepProps, IVizStepNode } from '@kaoto/types';
+import { IStepProps, IStepPropsBranch, IVizStepNode, IVizStepNodeData } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
 import { MarkerType, Position } from 'reactflow';
 
@@ -63,7 +63,9 @@ describe('visualizationService', () => {
     } as IVizStepNode;
     const rootNode = {} as IVizStepNode;
     const rootNodeNext = {} as IVizStepNode;
-    expect(VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)).toHaveLength(2);
+    expect(
+      VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)
+    ).toHaveLength(2);
   });
 
   /**
@@ -293,5 +295,72 @@ describe('visualizationService', () => {
     // there is no next node, so it should be false
     expect(VisualizationService.shouldAddEdge(nodeWithEmptyBranch)).toBeFalsy();
     expect(VisualizationService.shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
+  });
+
+  it('showAppendStepButton(): given a node, should determine whether to show an append step button for it', () => {
+    // it cannot be an end step, AND it must either be the last step or have a branch
+    const stepWithNoBranch: IVizStepNodeData = {
+      label: '',
+      isLastStep: true,
+      step: {} as IStepProps,
+    };
+
+    // is the last step, is an end step, no branch
+    expect(VisualizationService.showAppendStepButton(stepWithNoBranch, true)).toBeFalsy();
+
+    // is the last step, is not an end step, no branch
+    expect(VisualizationService.showAppendStepButton(stepWithNoBranch, false)).toBeTruthy();
+
+    const lastStepWithBranch: IVizStepNodeData = {
+      label: '',
+      isLastStep: true,
+      step: {
+        branches: [] as IStepPropsBranch[],
+        maxBranches: -1,
+        minBranches: 0,
+      } as IStepProps,
+    };
+
+    // is last step, is an end step, has branches
+    expect(VisualizationService.showAppendStepButton(lastStepWithBranch, true)).toBeFalsy();
+
+    // is last step, is not an end step, has branches
+    expect(VisualizationService.showAppendStepButton(lastStepWithBranch, false)).toBeTruthy();
+
+    // is not the last step, is not an end step, has branches
+    expect(
+      VisualizationService.showAppendStepButton(
+        {
+          ...lastStepWithBranch,
+          isLastStep: false,
+        },
+        false
+      )
+    ).toBeTruthy();
+  });
+
+  it('showPrependStepButton(): given a node, should determine whether to show a prepend step button for it', () => {
+    // it cannot be an end step, and it must be a first step
+    const node: IVizStepNodeData = {
+      label: '',
+      isFirstStep: true,
+      step: {} as IStepProps,
+    };
+
+    // is a first step, is an end step
+    expect(VisualizationService.showPrependStepButton(node, true)).toBeFalsy();
+
+    // is a first step, is not an end step
+    expect(VisualizationService.showPrependStepButton(node, false)).toBeTruthy();
+
+    // is not a first step, is not an end step
+    expect(
+      VisualizationService.showPrependStepButton({ ...node, isFirstStep: false }, false)
+    ).toBeFalsy();
+
+    // is not a first step, is an end step
+    expect(
+      VisualizationService.showPrependStepButton({ ...node, isFirstStep: false }, true)
+    ).toBeFalsy();
   });
 });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,6 +1,12 @@
 import { StepsService } from './stepsService';
 import { IIntegrationJsonStore, RFState } from '@kaoto/store';
-import { IStepProps, IVizStepNode, IVizStepNodeDataBranch, IVizStepPropsEdge } from '@kaoto/types';
+import {
+  IStepProps,
+  IVizStepNode,
+  IVizStepNodeData,
+  IVizStepNodeDataBranch,
+  IVizStepPropsEdge,
+} from '@kaoto/types';
 import { getRandomArbitraryNumber, truncateString } from '@kaoto/utils';
 import { ElkExtendedEdge, ElkNode } from 'elkjs';
 import { MarkerType, Position } from 'reactflow';
@@ -470,7 +476,7 @@ export class VisualizationService {
   }
 
   /**
-   * Builds Reaat Flow nodes and edges from current integration JSON.
+   * Builds React Flow nodes and edges from current integration JSON.
    * @param handleDeleteStep
    */
   buildNodesAndEdges(handleDeleteStep: (uuid: string) => void) {
@@ -494,9 +500,27 @@ export class VisualizationService {
   }
 
   /**
+   * Determines whether to show a button for appending a step or inserting a branch
+   * @param nodeData
+   * @param isEndStep
+   */
+  static showAppendStepButton(nodeData: IVizStepNodeData, isEndStep: boolean) {
+    return !isEndStep && (nodeData.isLastStep || nodeData.step.branches);
+  }
+
+  /**
+   * Determines whether to show a button for prepending a step
+   * @param nodeData
+   * @param isEndStep
+   */
+  static showPrependStepButton(nodeData: IVizStepNodeData, isEndStep: boolean) {
+    return !isEndStep && nodeData.isFirstStep;
+  }
+
+  /**
    * Redraw integration diagram on the canvas. If {@link rebuildNodes} is true,
    * It rebuilds the nodes and edges from integration JSON store and re-layout the diagram.
-   * Otherwise it only performs re-layout.
+   * Otherwise, it only performs re-layout.
    * @param handleDeleteStep
    * @param rebuildNodes
    */

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,9 +1,9 @@
-import {IStepProps, IVizStepNode, IVizStepNodeDataBranch, IVizStepPropsEdge,} from '@kaoto/types';
-import {IIntegrationJsonStore, RFState} from "@kaoto/store";
-import {getRandomArbitraryNumber, truncateString} from '@kaoto/utils';
-import {ElkExtendedEdge, ElkNode} from 'elkjs';
-import {MarkerType, Position} from 'reactflow';
-import {StepsService} from './stepsService';
+import { StepsService } from './stepsService';
+import { IIntegrationJsonStore, RFState } from '@kaoto/store';
+import { IStepProps, IVizStepNode, IVizStepNodeDataBranch, IVizStepPropsEdge } from '@kaoto/types';
+import { getRandomArbitraryNumber, truncateString } from '@kaoto/utils';
+import { ElkExtendedEdge, ElkNode } from 'elkjs';
+import { MarkerType, Position } from 'reactflow';
 
 const ELK = require('elkjs');
 
@@ -18,11 +18,10 @@ const ELK = require('elkjs');
  *  @see StepsService
  */
 export class VisualizationService {
-
   constructor(
     private integrationJsonStore: IIntegrationJsonStore,
     private visualizationStore: RFState
-  ) {};
+  ) {}
 
   /**
    * for nodes within a branch
@@ -65,7 +64,10 @@ export class VisualizationService {
     stepNodes.forEach((node) => {
       if (node.type === 'group') return;
 
-      const parentNodeIndex = VisualizationService.findNodeIdxWithUUID(node.data.branchInfo?.parentUuid, stepNodes);
+      const parentNodeIndex = VisualizationService.findNodeIdxWithUUID(
+        node.data.branchInfo?.parentUuid,
+        stepNodes
+      );
       const ogNodeNextIndex = VisualizationService.findNodeIdxWithUUID(
         node.data.branchInfo?.branchParentNextUuid,
         stepNodes
@@ -79,9 +81,14 @@ export class VisualizationService {
           !node.data.isPlaceholder &&
           !StepsService.containsBranches(node.data.step)
         ) {
-          const branchStepNextIdx = VisualizationService.findNodeIdxWithUUID(node.data.nextStepUuid, stepNodes);
+          const branchStepNextIdx = VisualizationService.findNodeIdxWithUUID(
+            node.data.nextStepUuid,
+            stepNodes
+          );
           if (stepNodes[branchStepNextIdx]) {
-            specialEdges.push(VisualizationService.buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert'));
+            specialEdges.push(
+              VisualizationService.buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert')
+            );
           }
         }
 
@@ -143,7 +150,9 @@ export class VisualizationService {
     branchPlaceholderEdges.push(edgeProps);
 
     if (rootNextNode) {
-      branchPlaceholderEdges.push(VisualizationService.buildEdgeParams(node, rootNextNode, 'default'));
+      branchPlaceholderEdges.push(
+        VisualizationService.buildEdgeParams(node, rootNextNode, 'default')
+      );
     }
 
     return branchPlaceholderEdges;
@@ -410,8 +419,6 @@ export class VisualizationService {
       data: {
         label: 'ADD A STEP',
         step: {
-          maxBranches: 0,
-          minBranches: 0,
           name: '',
           type: type,
           UUID: `placeholder-${getRandomArbitraryNumber()}`,
@@ -471,7 +478,7 @@ export class VisualizationService {
     const layout = this.visualizationStore.layout;
     // build all nodes
     const stepNodes = VisualizationService.buildNodesFromSteps(steps, layout, {
-      handleDeleteStep
+      handleDeleteStep,
     });
 
     // build edges only for main nodes
@@ -499,14 +506,16 @@ export class VisualizationService {
     if (rebuildNodes) {
       const ne = this.buildNodesAndEdges(handleDeleteStep);
       stepNodes = ne.stepNodes;
-      stepEdges = ne.stepEdges
+      stepEdges = ne.stepEdges;
     }
-    VisualizationService.getLayoutedElements(stepNodes, stepEdges, this.visualizationStore.layout)
-      .then((res) => {
-        const { layoutedNodes, layoutedEdges } = res;
-        this.visualizationStore.setNodes(layoutedNodes);
-        this.visualizationStore.setEdges(layoutedEdges);
-      })
+    VisualizationService.getLayoutedElements(
+      stepNodes,
+      stepEdges,
+      this.visualizationStore.layout
+    ).then((res) => {
+      const { layoutedNodes, layoutedEdges } = res;
+      this.visualizationStore.setNodes(layoutedNodes);
+      this.visualizationStore.setEdges(layoutedEdges);
+    });
   }
-
 }


### PR DESCRIPTION
## Description
This PR adds the ability to build branches in the canvas, and improves the usability of the mini catalog. Resolves #786.

**NOTE:** This PR does not address deleting branches from the canvas, so I've created #1240 for this. It also does not address some other minor issues such as 1) branches can be built without identifiers (and where if we allowed identifiers they might be overridden by the backend), and 2) branches can be built in the incorrect order (i.e. otherwise, when).

## Changes
- Add tabs to mini catalog
- Add `BranchBuilder` component and button
- Add check for whether step supports branching
- Add handling for adding a branch
- Enhancements: Make mini catalog auto-width, remove close button

## Screenshots

### Before

![Screen Shot 2023-02-10 at 12 11 58 pm](https://user-images.githubusercontent.com/3844502/218282879-448abdee-4da5-4b45-a95f-600a4d446e65.png)

### After

<img width="897" alt="Screen Shot 2023-02-10 at 10 29 53 pm" src="https://user-images.githubusercontent.com/3844502/218283334-fbd4b6e9-ebe4-4c51-be1c-5673d1757b77.png">

When branches are not supported:

<img width="703" alt="Screen Shot 2023-02-11 at 8 24 05 pm" src="https://user-images.githubusercontent.com/3844502/218282894-3e9f5e7d-81df-44b9-b729-56c9cb38effd.png">

When branches are supported:

<img width="696" alt="Screen Shot 2023-02-11 at 8 24 31 pm" src="https://user-images.githubusercontent.com/3844502/218282897-c565772a-4eef-41a7-95aa-5498346b6ef3.png">

It's not the nicest, but once we resolve the issue with the identifiers and the conditions, we can turn this into a form for new branches and can show what sort of available/possible branches exist for this step (like a mini catalog for branches). This could be an opportunity for providing step extensions in the canvas (kind of similar idea to #1160).

With new branch:

<img width="596" alt="Screen Shot 2023-02-11 at 8 28 45 pm" src="https://user-images.githubusercontent.com/3844502/218282903-90e193a3-826d-4ed6-a4b8-ca975a81198f.png">
