### PR TITLE
Place the tooltips in code editor to top

### DIFF
--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -149,7 +149,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       data-testid={'sourceCode--clearButton'}
       onClick={clearAction}
       isVisible={sourceCode !== ''}
-      tooltipProps={{ content: 'Clear', position: 'right' }}
+      tooltipProps={{ content: 'Clear', position: 'top' }}
     />
   );
 
@@ -161,7 +161,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       data-testid={'sourceCode--undoButton'}
       onClick={undoAction}
       isVisible={sourceCode !== ''}
-      tooltipProps={{ content: 'Undo change', position: 'right' }}
+      tooltipProps={{ content: 'Undo change', position: 'top' }}
     />
   );
 
@@ -173,7 +173,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       data-testid={'sourceCode--redoButton'}
       onClick={redoAction}
       isVisible={sourceCode !== ''}
-      tooltipProps={{ content: 'Redo change', position: 'right' }}
+      tooltipProps={{ content: 'Redo change', position: 'top' }}
     />
   );
 
@@ -184,7 +184,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
       aria-label="Apply the code"
       data-testid={'sourceCode--applyButton'}
       onClick={updateModelFromTheEditor}
-      tooltipProps={{ content: 'Sync your code', position: 'right' }}
+      tooltipProps={{ content: 'Sync your code', position: 'top' }}
       isVisible={sourceCode !== '' && props.mode === CodeEditorMode.FREE_EDIT}
     />
   );
@@ -206,7 +206,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
         onCodeChange={syncChanges}
         language={Language.yaml}
         onEditorDidMount={handleEditorDidMount}
-        toolTipPosition="right"
+        toolTipPosition="top"
         customControls={[UndoButton, RedoButton, ClearButton, UpdateButton]}
         isCopyEnabled
         isDarkTheme={!settings.editorIsLightMode}


### PR DESCRIPTION
The current - right placement of the tooltip was causing sometimes issues. Do you think that placing the tooltips to the top makes sense?

Recordings with right placement:
![Peek 2023-02-17 13-36](https://user-images.githubusercontent.com/4180208/219656235-94bce867-1920-4fa1-93dd-56dd2a40e591.gif)

top placement:
![Peek 2023-02-17 13-38](https://user-images.githubusercontent.com/4180208/219656251-6b33948b-53cd-41db-8634-3bc84d61731a.gif)
