### PR TITLE
feat(branching): disable steps for steps with at least one branch

### DIFF
--- a/src/components/MiniCatalog.stories.tsx
+++ b/src/components/MiniCatalog.stories.tsx
@@ -21,4 +21,33 @@ const Template: ComponentStory<typeof MiniCatalog> = (args) => {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  disableBranchesTab: false,
+  disableStepsTab: false,
+};
+
+export const DisableStepsTab = Template.bind({});
+DisableStepsTab.args = {
+  disableBranchesTab: false,
+  disableStepsTab: true,
+};
+
+export const DisableBranchesTab = Template.bind({});
+DisableBranchesTab.args = {
+  disableBranchesTab: true,
+  disableStepsTab: false,
+};
+
+export const DisableBranchesTabTooltip = Template.bind({});
+DisableBranchesTabTooltip.args = {
+  disableBranchesTab: true,
+  disableBranchesTabMsg: "This step doesn't support branching.",
+  disableStepsTab: false,
+};
+
+export const DisableStepsTabTooltip = Template.bind({});
+DisableStepsTabTooltip.args = {
+  disableBranchesTab: false,
+  disableStepsTab: true,
+  disableStepsTabMsg: "You can't add a step between a step and a branch.",
+};

--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -1,5 +1,4 @@
 import { fetchCatalogSteps } from '@kaoto/api';
-import { StepsService } from '@kaoto/services';
 import { useSettingsStore } from '@kaoto/store';
 import { IStepProps, IStepQueryParams } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
@@ -27,6 +26,10 @@ import { createRef, ReactNode, useEffect, useRef, useState } from 'react';
 
 export interface IMiniCatalog {
   children?: ReactNode;
+  disableBranchesTab?: boolean;
+  disableBranchesTabMsg?: string;
+  disableStepsTab?: boolean;
+  disableStepsTabMsg?: string;
   handleSelectStep?: (selectedStep: any) => void;
   queryParams?: IStepQueryParams;
   step?: IStepProps;
@@ -36,11 +39,12 @@ export interface IMiniCatalog {
 export const MiniCatalog = (props: IMiniCatalog) => {
   const [catalogData, setCatalogData] = useState<IStepProps[]>(props.steps ?? []);
   const [query, setQuery] = useState(``);
-  const [activeTabKey, setActiveTabKey] = useState();
+  const [activeTabKey, setActiveTabKey] = useState(props.disableStepsTab ? 1 : 0);
   const dsl = useSettingsStore((state) => state.settings.dsl.name);
   const typesAllowedArray = props.queryParams?.type?.split(',');
   const [isSelected, setIsSelected] = useState(typesAllowedArray ? typesAllowedArray[0] : 'MIDDLE');
-  const tooltipRef = createRef();
+  const branchTooltipRef = createRef();
+  const stepTooltipRef = createRef();
 
   const { addAlert } = useAlert() || {};
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -104,7 +108,19 @@ export const MiniCatalog = (props: IMiniCatalog) => {
   return (
     <section data-testid={'miniCatalog'} className={'nodrag'}>
       <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox={false}>
-        <Tab eventKey={0} title={<TabTitleText>Steps</TabTitleText>}>
+        <Tab
+          eventKey={0}
+          title={<TabTitleText>Steps</TabTitleText>}
+          isAriaDisabled={props.disableStepsTab}
+          ref={stepTooltipRef}
+        >
+          {props.disableStepsTab && props.disableStepsTabMsg && (
+            <Tooltip
+              content={props.disableStepsTabMsg}
+              reference={stepTooltipRef}
+              position={'top'}
+            />
+          )}
           <Toolbar id={'toolbar'} style={{ background: 'transparent' }}>
             <ToolbarContent>
               {
@@ -189,14 +205,14 @@ export const MiniCatalog = (props: IMiniCatalog) => {
         <Tab
           eventKey={1}
           title={<TabTitleText>Branches</TabTitleText>}
-          isAriaDisabled={!StepsService.supportsBranching(props.step)}
-          ref={tooltipRef}
+          isAriaDisabled={props.disableBranchesTab}
+          ref={branchTooltipRef}
         >
-          {!StepsService.supportsBranching(props.step) && (
+          {props.disableBranchesTab && props.disableBranchesTabMsg && (
             <Tooltip
-              content="This step does not support branching."
-              reference={tooltipRef}
-              position="right"
+              content={props.disableBranchesTabMsg}
+              reference={branchTooltipRef}
+              position="top"
             />
           )}
           <div style={{ padding: '50px' }}>{props.children}</div>

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -1,6 +1,6 @@
 import './CustomEdge.css';
 import { BranchBuilder, MiniCatalog } from '@kaoto/components';
-import { StepsService, ValidationService } from '@kaoto/services';
+import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { Popover } from '@patternfly/react-core';
@@ -110,6 +110,10 @@ const PlusButtonEdge = ({
             bodyContent={
               <MiniCatalog
                 children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+                disableBranchesTab={!VisualizationService.showBranchesTab(sourceNode?.data)}
+                disableBranchesTabMsg={"This step doesn't support branching."}
+                disableStepsTab={!VisualizationService.showStepsTab(sourceNode?.data)}
+                disableStepsTabMsg={"You can't add a step between a step and a branch."}
                 handleSelectStep={onMiniCatalogClickInsert}
                 queryParams={{
                   type: ValidationService.insertableStepTypes(

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -100,10 +100,13 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {visualizationService.showPrependStepButton(data) && (
             <Popover
               appendTo={() => document.body}
-              aria-label="Search for a step"
+              aria-label="Add a step"
               bodyContent={
                 <MiniCatalog
                   children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+                  disableBranchesTab={true}
+                  disableBranchesTabMsg={"You can't add a branch from here."}
+                  disableStepsTab={!VisualizationService.showStepsTab(data)}
                   handleSelectStep={onMiniCatalogClickPrepend}
                   queryParams={{
                     dsl: currentDSL,
@@ -177,6 +180,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               bodyContent={
                 <MiniCatalog
                   children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+                  disableBranchesTab={!VisualizationService.showBranchesTab(data)}
+                  disableBranchesTabMsg={"This step doesn't support branching."}
+                  disableStepsTab={!VisualizationService.showStepsTab(data)}
+                  disableStepsTabMsg={"You can't add a step between a step and a branch."}
                   handleSelectStep={onMiniCatalogClickAppend}
                   queryParams={{
                     dsl: currentDSL,
@@ -208,10 +215,13 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
       ) : (
         <Popover
           appendTo={() => document.body}
-          aria-label="Search for a step"
+          aria-label="Add a step"
           bodyContent={
             <MiniCatalog
               children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+              disableBranchesTab={!VisualizationService.showBranchesTab(data)}
+              disableBranchesTabMsg={"This step doesn't support branching."}
+              disableStepsTab={!VisualizationService.showStepsTab(data)}
               handleSelectStep={onMiniCatalogClickAdd}
               queryParams={{
                 dsl: currentDSL,

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -422,4 +422,54 @@ describe('visualizationService', () => {
       })
     ).toBeTruthy();
   });
+
+  it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
+    const step: IVizStepNodeData = {
+      label: '',
+      step: {} as IStepProps,
+    };
+
+    expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
+    // has branches but not branch support
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        step: { ...step.step, branches: [] },
+      })
+    ).toBeFalsy();
+
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        step: { ...step.step, branches: [], minBranches: 0, maxBranches: -1 },
+      })
+    ).toBeTruthy();
+  });
+
+  it('showStepsTab(): given node data, should determine whether to show the steps tab in mini catalog', () => {
+    const step: IVizStepNodeData = {
+      label: '',
+      step: {} as IStepProps,
+    };
+
+    // contains no branches
+    expect(VisualizationService.showStepsTab(step)).toBeTruthy();
+
+    // contains branches, has no next step, should show steps tab
+    expect(
+      VisualizationService.showStepsTab({
+        ...step,
+        step: { ...step.step, branches: [{} as IStepPropsBranch] },
+      })
+    ).toBeTruthy();
+
+    // contains branches, has a next step, should not show steps tab
+    expect(
+      VisualizationService.showStepsTab({
+        ...step,
+        step: { ...step.step, branches: [{} as IStepPropsBranch] },
+        nextStepUuid: 'some-dummy-node-uuid',
+      })
+    ).toBeFalsy();
+  });
 });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -89,7 +89,6 @@ export class VisualizationService {
     return branchPlaceholderEdges;
   }
 
-  //
   /**
    * Builds branch step edges and edges that need to connect branches to prev/next steps
    * @param stepNodes
@@ -564,5 +563,22 @@ export class VisualizationService {
     } else if (!StepsService.isEndStep(nodeData.step) && nodeData.isFirstStep) {
       return true;
     }
+  }
+
+  /**
+   * Determines whether to show the Branches tab in the mini catalog
+   * @param nodeData
+   */
+  static showBranchesTab(nodeData: IVizStepNodeData): boolean {
+    return StepsService.supportsBranching(nodeData.step);
+  }
+
+  /**
+   * Determines whether to show the Steps tab in the mini catalog
+   * @param nodeData
+   */
+  static showStepsTab(nodeData: IVizStepNodeData): boolean {
+    if (StepsService.containsBranches(nodeData.step) && !nodeData.nextStepUuid) return true;
+    return !StepsService.containsBranches(nodeData.step);
   }
 }


### PR DESCRIPTION
This PR disables the Steps tab for steps that already contain at least one branch. Resolves #1263.

## Changes
- Add support to pass custom tooltip text and a boolean to disable specific tabs to the `MiniCatalog`
- Move call to `StepsService` out of MiniCatalog component
- Update `MiniCatalog` stories
- Change `"cannot"` to `"can't"` for consistent messaging across tooltips
- Change tooltip position for disabled Branch tab from `right` to `top`, same as for a disabled `Steps` tab

## Screenshots

![Screen Shot 2023-02-17 at 2 44 40 pm](https://user-images.githubusercontent.com/3844502/219689744-0ab731c2-7566-406d-9eaf-f7571400a6ed.png)

![Screen Shot 2023-02-17 at 3 03 23 pm](https://user-images.githubusercontent.com/3844502/219690892-6ac90d8b-fedd-487a-bf45-1bff9045a166.png)

