### PR TITLE
feat(viz): add tooltip helper for adding steps/branches

### DIFF
--- a/src/components/DeleteButtonEdge.tsx
+++ b/src/components/DeleteButtonEdge.tsx
@@ -3,7 +3,7 @@ import { OrangeExclamationTriangleIcon } from './Icons';
 import { StepsService } from '@kaoto/services';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IVizStepNode } from '@kaoto/types';
-import { Button, Popover } from '@patternfly/react-core';
+import { Button, Popover, Tooltip } from '@patternfly/react-core';
 import { MinusIcon } from '@patternfly/react-icons';
 import { getBezierPath, Position, useReactFlow } from 'reactflow';
 
@@ -104,9 +104,11 @@ const DeleteButtonEdge = ({
             hideOnOutsideClick={true}
             position={'right-start'}
           >
-            <button className="deleteButton" data-testid={'stepNode__insertStep-btn'}>
-              <MinusIcon />
-            </button>
+            <Tooltip content={'Delete branch'}>
+              <button className="deleteButton" data-testid={'stepNode__deleteBranch-btn'}>
+                <MinusIcon />
+              </button>
+            </Tooltip>
           </Popover>
         </span>
       </foreignObject>

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -3,7 +3,7 @@ import { BranchBuilder, MiniCatalog } from '@kaoto/components';
 import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
-import { Popover } from '@patternfly/react-core';
+import { Popover, Tooltip } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { getBezierPath, Position, useReactFlow } from 'reactflow';
 
@@ -45,6 +45,8 @@ const PlusButtonEdge = ({
   const visualizationStore = useVisualizationStore();
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
   const currentIdx = stepsService.findStepIdxWithUUID(targetNode?.data.step.UUID);
+  const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data);
+  const showStepsTab = VisualizationService.showStepsTab(sourceNode?.data);
 
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({
     sourceX,
@@ -110,9 +112,9 @@ const PlusButtonEdge = ({
             bodyContent={
               <MiniCatalog
                 children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-                disableBranchesTab={!VisualizationService.showBranchesTab(sourceNode?.data)}
+                disableBranchesTab={!showBranchesTab}
                 disableBranchesTabMsg={"This step doesn't support branching."}
-                disableStepsTab={!VisualizationService.showStepsTab(sourceNode?.data)}
+                disableStepsTab={!showStepsTab}
                 disableStepsTabMsg={"You can't add a step between a step and a branch."}
                 handleSelectStep={onMiniCatalogClickInsert}
                 queryParams={{
@@ -130,9 +132,13 @@ const PlusButtonEdge = ({
             hideOnOutsideClick={true}
             position={'right-start'}
           >
-            <button className="plusButton" data-testid={'stepNode__insertStep-btn'}>
-              <PlusIcon />
-            </button>
+            <Tooltip
+              content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
+            >
+              <button className="plusButton" data-testid={'stepNode__insertStep-btn'}>
+                <PlusIcon />
+              </button>
+            </Tooltip>
           </Popover>
         </span>
       </foreignObject>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -9,7 +9,7 @@ import {
   useVisualizationStore,
 } from '@kaoto/store';
 import { IStepProps, IVizStepNodeData } from '@kaoto/types';
-import { AlertVariant, Popover } from '@patternfly/react-core';
+import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
@@ -24,6 +24,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const integrationJsonStore = useIntegrationJsonStore();
   const visualizationService = new VisualizationService(integrationJsonStore, visualizationStore);
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
+  const showBranchesTab = VisualizationService.showBranchesTab(data);
+  const showStepsTab = VisualizationService.showStepsTab(data);
 
   const { addAlert } = useAlert() || {};
 
@@ -106,7 +108,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
                   children={<BranchBuilder handleAddBranch={handleAddBranch} />}
                   disableBranchesTab={true}
                   disableBranchesTabMsg={"You can't add a branch from here."}
-                  disableStepsTab={!VisualizationService.showStepsTab(data)}
+                  disableStepsTab={!showStepsTab}
                   handleSelectStep={onMiniCatalogClickPrepend}
                   queryParams={{
                     dsl: currentDSL,
@@ -124,12 +126,14 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               position={'left-start'}
               showClose={false}
             >
-              <button
-                className="stepNode__Prepend plusButton nodrag"
-                data-testid={'stepNode__prependStep-btn'}
-              >
-                <PlusIcon />
-              </button>
+              <Tooltip content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}>
+                <button
+                  className="stepNode__Prepend plusButton nodrag"
+                  data-testid={'stepNode__prependStep-btn'}
+                >
+                  <PlusIcon />
+                </button>
+              </Tooltip>
             </Popover>
           )}
 
@@ -180,9 +184,9 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               bodyContent={
                 <MiniCatalog
                   children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-                  disableBranchesTab={!VisualizationService.showBranchesTab(data)}
+                  disableBranchesTab={!showBranchesTab}
                   disableBranchesTabMsg={"This step doesn't support branching."}
-                  disableStepsTab={!VisualizationService.showStepsTab(data)}
+                  disableStepsTab={!showStepsTab}
                   disableStepsTabMsg={"You can't add a step between a step and a branch."}
                   handleSelectStep={onMiniCatalogClickAppend}
                   queryParams={{
@@ -201,12 +205,16 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               position={'right-start'}
               showClose={false}
             >
-              <button
-                className="stepNode__Add plusButton nodrag"
-                data-testid={'stepNode__appendStep-btn'}
+              <Tooltip
+                content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
               >
-                <PlusIcon />
-              </button>
+                <button
+                  className="stepNode__Add plusButton nodrag"
+                  data-testid={'stepNode__appendStep-btn'}
+                >
+                  <PlusIcon />
+                </button>
+              </Tooltip>
             </Popover>
           ) : (
             <></>
@@ -219,9 +227,9 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           bodyContent={
             <MiniCatalog
               children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-              disableBranchesTab={!VisualizationService.showBranchesTab(data)}
+              disableBranchesTab={!showBranchesTab}
               disableBranchesTabMsg={"This step doesn't support branching."}
-              disableStepsTab={!VisualizationService.showStepsTab(data)}
+              disableStepsTab={!showStepsTab}
               handleSelectStep={onMiniCatalogClickAdd}
               queryParams={{
                 dsl: currentDSL,

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -149,13 +149,15 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* DELETE STEP BUTTON */}
-          <button
-            className="stepNode__Delete trashButton nodrag"
-            data-testid={'configurationTab__deleteBtn'}
-            onClick={handleTrashClick}
-          >
-            <MinusIcon />
-          </button>
+          <Tooltip content={'Delete step'}>
+            <button
+              className="stepNode__Delete trashButton nodrag"
+              data-testid={'configurationTab__deleteBtn'}
+              onClick={handleTrashClick}
+            >
+              <MinusIcon />
+            </button>
+          </Tooltip>
 
           {/* VISUAL REPRESENTATION OF STEP WITH ICON */}
           <div className={'stepNode__Icon stepNode__clickable'}>

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -94,6 +94,13 @@ describe('validationService', () => {
     ).toBeTruthy();
   });
 
+  it('getPlusButtonTooltipMsg(): should return the tooltip message for the plus button to add a step or branch', () => {
+    expect(ValidationService.getPlusButtonTooltipMsg(true, true)).toBe('Add a step or branch');
+    expect(ValidationService.getPlusButtonTooltipMsg(true, false)).toBe('Add a branch');
+    expect(ValidationService.getPlusButtonTooltipMsg(false, true)).toBe('Add a step');
+    expect(ValidationService.getPlusButtonTooltipMsg(false, false)).toBe('');
+  });
+
   it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {
     expect(ValidationService.prependableStepTypes()).toEqual('MIDDLE');
   });

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -81,6 +81,18 @@ export class ValidationService {
     return { isValid, message };
   }
 
+  static getPlusButtonTooltipMsg(showBranchesTab: boolean, showStepsTab: boolean): string {
+    if (showStepsTab && showBranchesTab) {
+      return 'Add a step or branch';
+    } else if (showBranchesTab) {
+      return 'Add a branch';
+    } else if (showStepsTab) {
+      return 'Add a step';
+    } else {
+      return '';
+    }
+  }
+
   /**
    * Checks kind of steps can be appended onto an existing step.
    * @param _prevStep

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -81,6 +81,12 @@ export class ValidationService {
     return { isValid, message };
   }
 
+  /**
+   * Get the message to display in a tooltip
+   * for the button to add a step or branch
+   * @param showBranchesTab
+   * @param showStepsTab
+   */
   static getPlusButtonTooltipMsg(showBranchesTab: boolean, showStepsTab: boolean): string {
     if (showStepsTab && showBranchesTab) {
       return 'Add a step or branch';


### PR DESCRIPTION
This PR adds tooltips to the add/insert step/branch buttons on the canvas. Closes #1159.

## Changes
- Add a helper method that determines the content for the tooltip based on whether branch or step tab is shown in the mini catalog
- Add a static tooltip for deleting steps and, separately, branches
- Add a test for the helper method

## Screenshots

Adding a step:

![Add a step](https://user-images.githubusercontent.com/3844502/220167026-d8c23be3-b35b-4878-97c9-a211efb1c817.png)

Adding a branch:

![Add a branch](https://user-images.githubusercontent.com/3844502/220167074-f0847796-0311-48c5-9cfd-45f5aefa540e.png)

Adding a step or branch:

![Add a step or branch](https://user-images.githubusercontent.com/3844502/220167062-0c021602-539e-4c41-972a-0574193fe0f1.png)

Appending a step:

![Append a step](https://user-images.githubusercontent.com/3844502/220167036-37756718-7c95-4d54-bd86-8e1709074355.png)

![Append a step](https://user-images.githubusercontent.com/3844502/220167047-8c497221-99a0-4bf9-a5b0-fb1a621139f5.png)

Deleting a step:

![Delete a step](https://user-images.githubusercontent.com/3844502/220167083-bff3bdea-2c2d-4ff5-b61a-7e2a4621d546.png)

Deleting a branch:

![Delete a branch](https://user-images.githubusercontent.com/3844502/220167101-c591090e-1d08-4fad-a12e-025c8cdb2f4e.png)
