### PR TITLE
feat(viz): add node hint on empty state

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -106,6 +106,30 @@
     border-radius: 50%;
 }
 
+/* SHOWN FOR EMPTY STATE PLACEHOLDERS */
+.nodeHintArrow {
+    margin-right: 6px;
+    font-size: 16px;
+    font-weight: 900;
+    position: relative;
+    top: 6px;
+}
+
+.nodeHintWrapper {
+    position: absolute;
+    top: -34px;
+    left: 50px;
+    font-size: 11px;
+    font-weight: 400;
+    text-align: left;
+    line-height: 1.1;
+    color: #999;
+    width: 120px;
+    display: flex;
+    align-items: flex-end;
+    pointer-events: none;
+}
+
 .react-flow__minimap.visualization__minimap {
     right: 50px;
 }

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -253,6 +253,13 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             onDrop={onDropNew}
             data-testid={'viz-step-slot'}
           >
+            {/* PLACEHOLDER HINT FOR EMPTY STATE */}
+            {VisualizationService.isFirstAndOnlyNode(data) && (
+              <div className={'nodeHintWrapper'} data-testid={'placeholderHint'}>
+                <div className={'nodeHintArrow'}>⤹</div>
+                <div>click on a node to add a step.</div>
+              </div>
+            )}
             {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             {(!StepsService.isStartStep(data.step) || data.branchInfo) && (
               <Handle

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -3,7 +3,13 @@ import nodes from '../store/data/nodes';
 import steps from '../store/data/steps';
 import { VisualizationService } from './visualizationService';
 import { useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
-import { IStepProps, IStepPropsBranch, IVizStepNode, IVizStepNodeData } from '@kaoto/types';
+import {
+  IStepProps,
+  IStepPropsBranch,
+  IVizStepNode,
+  IVizStepNodeData,
+  IVizStepNodeDataBranch,
+} from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
 import { MarkerType, Position } from 'reactflow';
 
@@ -227,6 +233,19 @@ describe('visualizationService', () => {
     const nodes: IVizStepNode[] = [];
     VisualizationService.insertBranchGroupNode(nodes, { x: 0, y: 0 }, 150, groupWidth);
     expect(nodes).toHaveLength(1);
+  });
+
+  it('isFirstAndOnlyNode()', () => {
+    const nodeData: IVizStepNodeData = { label: '', step: {} as IStepProps };
+    expect(VisualizationService.isFirstAndOnlyNode(nodeData)).toBeTruthy();
+    expect(
+      VisualizationService.isFirstAndOnlyNode({
+        ...nodeData,
+        branchInfo: {} as IVizStepNodeDataBranch,
+        nextStepUuid: 'some-next-step',
+        previousStepUuid: 'some-previous-step',
+      })
+    ).toBeFalsy();
   });
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -493,6 +493,15 @@ export class VisualizationService {
   }
 
   /**
+   * Determines if a node is the first and only node.
+   * NOTE: Applies to both placeholders and normal steps.
+   * @param stepNodeData
+   */
+  static isFirstAndOnlyNode(stepNodeData: IVizStepNodeData): boolean {
+    return !stepNodeData.nextStepUuid && !stepNodeData.previousStepUuid && !stepNodeData.branchInfo;
+  }
+
+  /**
    * Redraw integration diagram on the canvas. If {@link rebuildNodes} is true,
    * It rebuilds the nodes and edges from integration JSON store and re-layout the diagram.
    * Otherwise, it only performs re-layout.


### PR DESCRIPTION
This PR adds a hint for Kaoto empty state. Relates to #226, but doesn't resolve it as this is somewhat of a short-term workaround.

## Changes
- Add node hint `<div>` for Kaoto placeholder nodes
- Add validation for checking that it's the first and only node
- Add test for validation 

## Screenshots

On empty state:

![Screen Shot 2023-02-21 at 1 21 10 pm](https://user-images.githubusercontent.com/3844502/220356024-0600e590-9b80-4ea9-9fee-5fa137528a2d.png)

Showing that the hint doesn't show for other placeholder nodes:

![Screen Shot 2023-02-21 at 1 15 06 pm](https://user-images.githubusercontent.com/3844502/220356255-c55fd5d9-3cc8-47c0-875d-4163efd8b22b.png)
