### PR TITLE
fix: Use "action" instead of "middle" for consistency

### DIFF
--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -43,7 +43,7 @@ export class ValidationService {
       if (proposedStep.type === 'MIDDLE' || proposedStep.type === 'END') {
         return { isValid: true };
       } else {
-        return { isValid: false, message: 'Branches must start with a middle or end step.' };
+        return { isValid: false, message: 'Branches must start with an action or end step.' };
       }
     }
 


### PR DESCRIPTION
Fixes #1262 

![image](https://user-images.githubusercontent.com/726590/220598705-53f4fa8a-3c79-4bcd-8dc0-31536fd927ab.png)
