### PR TITLE
feat(viz): highlight connected branch nodes

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -20,7 +20,7 @@
 .stepNode {
     align-items: center;
     background: var(--pf-global--BackgroundColor--100);
-    border: 2px solid rgb(0, 136, 206);
+    border: 2px solid var(--pf-global--BorderColor--100);
     border-radius: 50%;
     display: block;
     font-family: Ubuntu, serif;
@@ -30,6 +30,10 @@
     padding: 10px;
     text-align: center;
     width: 80px;
+}
+
+.stepNode__Active {
+    border: 2px solid rgb(0, 136, 206);
 }
 
 .stepNode__Add {

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -26,6 +26,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
   const showBranchesTab = VisualizationService.showBranchesTab(data);
   const showStepsTab = VisualizationService.showStepsTab(data);
+  const supportsBranching = StepsService.supportsBranching(data.step);
 
   const { addAlert } = useAlert() || {};
 
@@ -94,8 +95,24 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     <>
       {!data.isPlaceholder ? (
         <div
-          className={`stepNode`}
+          className={
+            `stepNode` +
+            `${VisualizationService.shouldHighlightNode(
+              visualizationStore.hoverStepUuid,
+              data.branchInfo?.branchParentUuid ?? data.step.UUID
+            )}`
+          }
           onDrop={onDropReplace}
+          onMouseEnter={() => {
+            if (data.branchInfo || supportsBranching) {
+              visualizationStore.setHoverStepUuid(
+                data.branchInfo?.branchParentUuid ?? data.step.UUID
+              );
+            } else {
+              visualizationStore.setHoverStepUuid(data.step.UUID);
+            }
+          }}
+          onMouseLeave={() => visualizationStore.setHoverStepUuid('')}
           data-testid={`viz-step-${data.step.name}`}
         >
           {/* PREPEND STEP BUTTON */}
@@ -260,6 +277,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
                 <div>click on a node to add a step.</div>
               </div>
             )}
+
             {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             {(!StepsService.isStartStep(data.step) || data.branchInfo) && (
               <Handle

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -317,6 +317,18 @@ describe('visualizationService', () => {
     expect(VisualizationService.shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
   });
 
+  it('shouldHighlightNode(): determines if node should be highlighted', () => {
+    const something = 'something';
+    const nothing = undefined;
+    expect(VisualizationService.shouldHighlightNode('example', 'example')).toEqual(
+      ' stepNode__Active'
+    );
+    expect(VisualizationService.shouldHighlightNode(something, nothing ?? 'example')).toEqual('');
+    expect(VisualizationService.shouldHighlightNode(something, nothing ?? something)).toEqual(
+      ' stepNode__Active'
+    );
+  });
+
   it('showAppendStepButton(): given a node, should determine whether to show an append step button for it', () => {
     // it cannot be an END step, it must be the last step in the array,
     // OR it must support branching & contain at least one step

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -536,6 +536,14 @@ export class VisualizationService {
     return node.data.step && nextNode && !StepsService.containsBranches(node.data.step);
   }
 
+  static shouldHighlightNode(hoverUuid: string, stepUuid: string) {
+    if (hoverUuid === stepUuid) {
+      return ' stepNode__Active';
+    } else {
+      return '';
+    }
+  }
+
   /**
    * Determines whether to show a button for appending a step or inserting a branch
    * @param nodeData

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -16,11 +16,13 @@ export type RFState = {
   deleteNode: (nodeIndex: number) => void;
   nodes: IVizStepNode[];
   edges: IVizStepPropsEdge[];
+  hoverStepUuid: string;
   layout: string;
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
   onConnect: OnConnect;
   setEdges: (newEdges: IVizStepPropsEdge[]) => void;
+  setHoverStepUuid: (stepUuid: string) => void;
   setLayout: (newLayout: string) => void;
   setNodes: (newNodes: IVizStepNode[]) => void;
   /**
@@ -38,6 +40,7 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
     set((state) => ({
       nodes: [...state.nodes.filter((_n, idx) => idx !== nodeIndex)],
     })),
+  hoverStepUuid: '',
   layout: 'RIGHT', // e.g. RIGHT, DOWN
   onNodesChange: (changes: NodeChange[]) =>
     set((state) => ({
@@ -56,6 +59,7 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
     set({
       edges: [...newEdges],
     }),
+  setHoverStepUuid: (stepUuid: string) => set({ hoverStepUuid: stepUuid }),
   setLayout: (newLayout: string) => set({ layout: newLayout }),
   setNodes: (newNodes: IVizStepNode[]) =>
     set({


### PR DESCRIPTION
This PR adds the enhancement to show which steps are part of a branch. All nodes will now have a grey border that will turn blue on hover. For nodes/steps that contain branching, it will highlight the step and its child steps. Resolves https://github.com/KaotoIO/kaoto-ui/issues/1133.

## Screenshots

![Kapture 2023-02-22 at 17 19 37](https://user-images.githubusercontent.com/3844502/220707755-c119d608-f9b0-45b8-aea0-0d1fa5be5a9a.gif)
