### PR TITLE
feat(viz): visual cue for selected step

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -32,8 +32,12 @@
     width: 80px;
 }
 
-.stepNode__Active {
+.stepNode__Hover {
     border: 2px solid rgb(0, 136, 206);
+}
+
+.stepNode__Selected {
+    border: 3px solid rgb(0, 136, 206);
 }
 
 .stepNode__Add {

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -113,7 +113,6 @@ const Visualization = () => {
     // here we check if it's a node or edge
     // workaround for https://github.com/wbkd/react-flow/issues/2202
     if (!e.target.classList.contains('stepNode__clickable')) return;
-    e.preventDefault();
 
     if (!node.data.isPlaceholder) {
       const step = stepsService.findStepWithUUID(node.data.step.UUID);

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -81,6 +81,7 @@ const Visualization = () => {
     if (!UUID) return;
 
     setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '' });
+    visualizationStore.setSelectedStepUuid('');
     if (isPanelExpanded) setIsPanelExpanded(false);
 
     stepsService.deleteStep(UUID);
@@ -88,6 +89,7 @@ const Visualization = () => {
 
   const onClosePanelClick = () => {
     setIsPanelExpanded(false);
+    visualizationStore.setSelectedStepUuid('');
   };
 
   /**
@@ -104,17 +106,21 @@ const Visualization = () => {
 
   /**
    * Called when a React Flow node is clicked
-   * @param _e
+   * @param e
    * @param node
    */
-  const onNodeClick = (_e: any, node: IVizStepNode) => {
+  const onNodeClick = (e: any, node: IVizStepNode) => {
     // here we check if it's a node or edge
     // workaround for https://github.com/wbkd/react-flow/issues/2202
-    if (!_e.target.classList.contains('stepNode__clickable')) return;
+    if (!e.target.classList.contains('stepNode__clickable')) return;
+    e.preventDefault();
 
     if (!node.data.isPlaceholder) {
       const step = stepsService.findStepWithUUID(node.data.step.UUID);
-      if (step) setSelectedStep(step);
+      if (step) {
+        setSelectedStep(step);
+        visualizationStore.setSelectedStepUuid(step.UUID);
+      }
 
       /** If the details panel is collapsed, we expanded for the user */
       if (!isPanelExpanded) setIsPanelExpanded(true);
@@ -124,6 +130,7 @@ const Visualization = () => {
        * selected, we collapse it for the user */
       if (isPanelExpanded && selectedStep.UUID === node.data.step.UUID) {
         setIsPanelExpanded(false);
+        visualizationStore.setSelectedStepUuid('');
       }
     }
   };

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -91,18 +91,27 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     });
   };
 
+  const getSelectedClass = (): string => {
+    return VisualizationService.getNodeClass(
+      visualizationStore.selectedStepUuid,
+      data.step.UUID,
+      ' stepNode__Selected'
+    );
+  };
+
+  const getHoverClass = (): string => {
+    return VisualizationService.getNodeClass(
+      visualizationStore.hoverStepUuid,
+      data.branchInfo?.branchParentUuid ?? data.step.UUID,
+      ' stepNode__Hover'
+    );
+  };
+
   return (
     <>
       {!data.isPlaceholder ? (
         <div
-          className={
-            `stepNode` +
-            `${VisualizationService.shouldHighlightNode(
-              visualizationStore.hoverStepUuid,
-              data.branchInfo?.branchParentUuid ?? data.step.UUID
-            )}` +
-            `${visualizationStore.selectedStepUuid === data.step.UUID ? ' stepNode__Selected' : ''}`
-          }
+          className={`stepNode` + getSelectedClass() + getHoverClass()}
           onDrop={onDropReplace}
           onMouseEnter={() => {
             if (data.branchInfo || supportsBranching) {

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -100,7 +100,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             `${VisualizationService.shouldHighlightNode(
               visualizationStore.hoverStepUuid,
               data.branchInfo?.branchParentUuid ?? data.step.UUID
-            )}`
+            )}` +
+            `${visualizationStore.selectedStepUuid === data.step.UUID ? ' stepNode__Selected' : ''}`
           }
           onDrop={onDropReplace}
           onMouseEnter={() => {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -34,7 +34,7 @@ const routes: AppRouteConfig[] = [
     exact: true,
     label: 'Dashboard',
     path: '/',
-    title: 'Kaoto | Main Dashboard',
+    title: 'Kaoto',
   },
 ];
 

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -217,6 +217,20 @@ describe('visualizationService', () => {
     expect(VisualizationService.findNodeIdxWithUUID(nodes[1].data.step.UUID, nodes)).toBe(1);
   });
 
+  it('getNodeClass(): given two strings to compare and a class name, returns the class name if they match', () => {
+    const something = 'something';
+    const nothing = undefined;
+    expect(VisualizationService.getNodeClass('example', 'example', ' stepNode__Hover')).toEqual(
+      ' stepNode__Hover'
+    );
+    expect(
+      VisualizationService.getNodeClass(something, nothing ?? 'example', ' stepNode__Hover')
+    ).toEqual('');
+    expect(
+      VisualizationService.getNodeClass(something, nothing ?? something, ' stepNode__Hover')
+    ).toEqual(' stepNode__Hover');
+  });
+
   /**
    * insertAddStepPlaceholder
    */
@@ -315,18 +329,6 @@ describe('visualizationService', () => {
     // there is no next node, so it should be false
     expect(VisualizationService.shouldAddEdge(nodeWithEmptyBranch)).toBeFalsy();
     expect(VisualizationService.shouldAddEdge(nodeWithoutBranches, nextNode)).toBeTruthy();
-  });
-
-  it('shouldHighlightNode(): determines if node should be highlighted', () => {
-    const something = 'something';
-    const nothing = undefined;
-    expect(VisualizationService.shouldHighlightNode('example', 'example')).toEqual(
-      ' stepNode__Hover'
-    );
-    expect(VisualizationService.shouldHighlightNode(something, nothing ?? 'example')).toEqual('');
-    expect(VisualizationService.shouldHighlightNode(something, nothing ?? something)).toEqual(
-      ' stepNode__Hover'
-    );
   });
 
   it('showAppendStepButton(): given a node, should determine whether to show an append step button for it', () => {

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -321,11 +321,11 @@ describe('visualizationService', () => {
     const something = 'something';
     const nothing = undefined;
     expect(VisualizationService.shouldHighlightNode('example', 'example')).toEqual(
-      ' stepNode__Active'
+      ' stepNode__Hover'
     );
     expect(VisualizationService.shouldHighlightNode(something, nothing ?? 'example')).toEqual('');
     expect(VisualizationService.shouldHighlightNode(something, nothing ?? something)).toEqual(
-      ' stepNode__Active'
+      ' stepNode__Hover'
     );
   });
 

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -441,6 +441,20 @@ export class VisualizationService {
     return { layoutedNodes: nodes, layoutedEdges: edges };
   }
 
+  /**
+   * Accepts two UUIDs to compare, and a class name to use if they match
+   * @param firstUuid
+   * @param secondUuid
+   * @param className
+   */
+  static getNodeClass(firstUuid: string, secondUuid: string, className: string): string {
+    if (firstUuid === secondUuid) {
+      return className;
+    } else {
+      return '';
+    }
+  }
+
   static insertAddStepPlaceholder(
     stepNodes: IVizStepNode[],
     id: string,
@@ -534,14 +548,6 @@ export class VisualizationService {
    */
   static shouldAddEdge(node: IVizStepNode, nextNode?: IVizStepNode): boolean {
     return node.data.step && nextNode && !StepsService.containsBranches(node.data.step);
-  }
-
-  static shouldHighlightNode(hoverUuid: string, stepUuid: string) {
-    if (hoverUuid === stepUuid) {
-      return ' stepNode__Hover';
-    } else {
-      return '';
-    }
   }
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -538,7 +538,7 @@ export class VisualizationService {
 
   static shouldHighlightNode(hoverUuid: string, stepUuid: string) {
     if (hoverUuid === stepUuid) {
-      return ' stepNode__Active';
+      return ' stepNode__Hover';
     } else {
       return '';
     }

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -21,8 +21,10 @@ export type RFState = {
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
   onConnect: OnConnect;
+  selectedStepUuid: string;
   setEdges: (newEdges: IVizStepPropsEdge[]) => void;
   setHoverStepUuid: (stepUuid: string) => void;
+  setSelectedStepUuid: (stepUuid: string) => void;
   setLayout: (newLayout: string) => void;
   setNodes: (newNodes: IVizStepNode[]) => void;
   /**
@@ -55,11 +57,13 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
       edges: addEdge(connection, state.edges),
     }));
   },
+  selectedStepUuid: '',
   setEdges: (newEdges: IVizStepPropsEdge[]) =>
     set({
       edges: [...newEdges],
     }),
   setHoverStepUuid: (stepUuid: string) => set({ hoverStepUuid: stepUuid }),
+  setSelectedStepUuid: (stepUuid: string) => set({ selectedStepUuid: stepUuid }),
   setLayout: (newLayout: string) => set({ layout: newLayout }),
   setNodes: (newNodes: IVizStepNode[]) =>
     set({


### PR DESCRIPTION
This PR adds a visual cue for showing the selected step.
Resolves #827

## Changes
- Add CSS class for selected step
- Rename CSS class for hover step for clarity
- Add selected step UUID & method for setting it to `visualizationStore` store, to avoid storing entire step there, but allowing access from custom React Flow node component
- Remove `selectedStepUuid` on closing step detail view panel & also on delete step
- Consolidate hover and selected step class fetching into a single reusable function
- Add tests for the above function
- For fun, rename Kaoto title to plain `Kaoto` instead of `Kaoto | Main Dashboard`

## Screenshots

Example with one step:

![Screen Shot 2023-02-23 at 11 07 58 am](https://user-images.githubusercontent.com/3844502/220905647-ff5684a2-578d-4a00-b06e-1107ffcc2fd8.png)

Example with branch parent step:

![Screen Shot 2023-02-23 at 11 21 32 am](https://user-images.githubusercontent.com/3844502/220905711-f7ea51d5-7793-43e3-a641-eb9d40a3554e.png)

Example with nested step:

![Screen Shot 2023-02-23 at 11 10 07 am](https://user-images.githubusercontent.com/3844502/220905774-0a241fb8-cfcc-4c97-9ff2-a6c72806a3e8.png)

Example with hover and selected step:

![Screen Shot 2023-02-23 at 12 13 28 pm](https://user-images.githubusercontent.com/3844502/220905276-939c20c2-691e-42e2-a0b2-395efbc39608.png)
