### PR TITLE
Add E2E catalog actions tests

### DIFF
--- a/cypress/e2e/7-catalog_actions/catalog_actions.js
+++ b/cypress/e2e/7-catalog_actions/catalog_actions.js
@@ -1,0 +1,87 @@
+describe('Test for catalog actions', () => {
+
+    beforeEach(() => {
+        let url = Cypress.config().baseUrl;
+        cy.visit(url);
+
+        // Upload the initial state (EipAction.yaml)
+        cy.get('[data-testid="toolbar-show-code-btn"]').click();
+        cy.get('[data-testid="sourceCode--clearButton"]').should('be.visible').click({ force: true });
+        cy.get('.pf-c-code-editor__main').should('be.visible');
+        cy.get('.pf-c-code-editor__main > input').attachFile('EipAction.yaml');
+        cy.get('[data-testid="sourceCode--applyButton"]').click();
+    });
+
+    // Try replace the digitalocean step with the timer-source step
+    it("User drags and drops an invalid step onto a nested branch step", () => {
+        const dataTransfer = new DataTransfer();
+        // open catalog
+        cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
+        // select timer-source step
+        cy.get('#stepSearch').type('timer-source');
+        // drag timer-source step from catalog
+        cy.get('[data-testid="catalog-step-timer-source"]').trigger('dragstart', {
+            dataTransfer,
+        });
+        // drop aggregate step from catalog over nested digitalocean step
+        cy.get('[data-testid="viz-step-digitalocean"]').trigger('drop', {
+            dataTransfer,
+        });
+
+        // CHECK digitalocean step is visible
+        cy.get('[data-testid="viz-step-digitalocean"]').should('be.visible');
+        // CHECK aggregation step was not created
+        cy.get('[data-testid="viz-step-timer-source"]').should('not.exist');
+        // CHECK alert box is visible and contains error message
+        cy.get('[data-testid="alert-box-replace-unsuccessful"]').should('be.visible');
+        cy.get('[data-testid="alert-box-replace-unsuccessful"]').should('contain', 'You cannot replace a middle step with a start step.');
+    });
+
+    // Replace the digitalocean step with the delay step with the big catalog
+    it("User replaces a placeholder step via drag & drop from the big catalog", () => {
+        const dataTransfer = new DataTransfer();
+        // open catalog
+        cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
+        // select actions category
+        cy.get('[data-testid="catalog-step-actions"]').click();
+        // select delay step
+        cy.get('#stepSearch').type('delay');
+        // drag delay step from catalog
+        cy.get('[data-testid="catalog-step-delay"]').trigger('dragstart', {
+            dataTransfer,
+        });
+        // drop aggregate step from catalog over nested digitalocean step
+        cy.get('[data-testid="viz-step-digitalocean"]').trigger('drop', {
+            dataTransfer,
+        });
+
+        // CHECK digitalocean step was replaced
+        cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
+        // CHECK delay step was created
+        cy.get('[data-testid="viz-step-delay"]').should('be.visible');
+    });
+
+    // Replace the digitalocean step with the delay step with the mini catalog (Delete and Insert)
+    it("User replaces a placeholder step using the mini catalog (Delete and Insert)", () => {
+        // delete digitalocean step
+        cy.get('[data-testid="viz-step-digitalocean"]').trigger('mouseover');
+        cy.get(
+            '[data-testid="viz-step-digitalocean"] > [data-testid="configurationTab__deleteBtn"]'
+        ).click({ force: true });
+        // prepend step before set-header step
+        cy.get(
+            '[data-testid="viz-step-set-header"] > [data-testid="stepNode__prependStep-btn"]'
+        ).click();
+        cy.get('[data-testid="miniCatalog"]').should('be.visible');
+        // search delay step
+        cy.get('.pf-c-text-input-group__text-input').type('delay');
+        // select delay step
+        cy.get('[data-testid="miniCatalog__stepItem--delay"]').click();
+
+        // CHECK digitalocean step was replaced
+        cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
+        // CHECK delay step was created
+        cy.get('[data-testid="viz-step-delay"]').should('be.visible');
+    });
+
+});

--- a/cypress/fixtures/EipAction.yaml
+++ b/cypress/fixtures/EipAction.yaml
@@ -1,0 +1,61 @@
+apiVersion: camel.apache.org/v1alpha1
+kind: Kamelet
+metadata:
+  annotations:
+    camel.apache.org/kamelet.icon: cherry
+  labels:
+    camel.apache.org/kamelet.type: action
+  name: eip-action
+spec:
+  definition:
+    title: EIP Kamelet
+    description: Used to test all EIP we implement
+    properties: {}
+  dependencies:
+    - camel:core
+    - camel:kamelet
+  template:
+    from:
+      uri: kamelet:source
+      steps:
+        - loop:
+            constant: "3"
+            copy: true
+            steps:
+              - delay:
+                  expression:
+                    simple: ${body}
+                  async-delayed: true
+        - choice:
+            when:
+              - simple: "{{?foo}}"
+                steps:
+                  - to:
+                      uri: digitalocean:null
+                  - set-header:
+                      name: bar
+                      simple: foo
+              - simple: "{{?bar}}"
+                steps:
+                  - delay: {}
+                  - marshal:
+                      json:
+                        library: Gson
+              - simple: "{{?baz}}"
+                steps:
+                  - choice:
+                      when: []
+                  - log:
+                      message: test
+                      logging-level: INFO
+                      log-name: yaml
+            otherwise:
+              steps:
+                - pipeline:
+                    steps:
+                      - aggregate: {}
+        - filter:
+            simple: "{{?foo}}"
+            steps: []
+        - to:
+            uri: kamelet:sink

--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -122,6 +122,7 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
                 <ToggleGroup aria-label={'Icon variant toggle group'}>
                   <ToggleGroupItem
                     text={'start'}
+                    data-testid={`catalog-step-start`}
                     aria-label={'sources button'}
                     buttonId={'START'}
                     isSelected={isSelected === 'START'}
@@ -129,6 +130,7 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
                   />
                   <ToggleGroupItem
                     icon={'actions'}
+                    data-testid={`catalog-step-actions`}
                     aria-label={'actions button'}
                     buttonId={'MIDDLE'}
                     isSelected={isSelected === 'MIDDLE'}
@@ -136,6 +138,7 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
                   />
                   <ToggleGroupItem
                     text={'end'}
+                    data-testid={`catalog-step-end`}
                     aria-label={'sinks button'}
                     buttonId={'END'}
                     isSelected={isSelected === 'END'}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -40,6 +40,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
         addAlert &&
         addAlert({
           title: 'Add Step Unsuccessful',
+          dataTestId: 'alert-box-add-unsuccessful',
           variant: AlertVariant.danger,
           description: validation.message ?? 'Something went wrong, please try again later.',
         });
@@ -85,6 +86,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
         addAlert &&
         addAlert({
           title: 'Replace Step Unsuccessful',
+          dataTestId: 'alert-box-replace-unsuccessful',
           variant: AlertVariant.danger,
           description: validation.message ?? 'Something went wrong, please try again later.',
         });


### PR DESCRIPTION
Hi @kahboom, @tplevko 

Kindly ask you to take a look at the new tests:

I have tried to cover the following scenarios:

Catalog actions:

-  User drags and drops an invalid step onto a nested branch step (i.e. a start step when branches should start with action steps)
-  User replaces a placeholder step via drag & drop from the big catalog
-  User replaces a placeholder step using the mini catalog*

If you have any recommendations or if I misunderstood something (not skilled in cypress actually), feel free to write it here, thanks!

Related to:
- [Issue-1297](https://github.com/KaotoIO/kaoto-ui/issues/1297)