### PR TITLE
feat(settings): change default DSL to Camel Route

### DIFF
--- a/src/store/deploymentStore.tsx
+++ b/src/store/deploymentStore.tsx
@@ -1,3 +1,4 @@
+import { initDsl, initialSettings } from './settingsStore';
 import { IDeployment } from '@kaoto/types';
 import { create } from 'zustand';
 
@@ -10,10 +11,10 @@ const initialDeployment: IDeployment = {
   crd: '',
   date: '',
   errors: [],
-  name: 'integration',
-  namespace: 'default',
+  name: initialSettings.name,
+  namespace: initialSettings.namespace,
   status: 'Stopped',
-  type: 'KameletBinding',
+  type: initDsl.name,
 };
 
 export const useDeploymentStore = create<IDeploymentStore>((set) => ({

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -1,7 +1,7 @@
 import { useDeploymentStore } from './deploymentStore';
 import { useIntegrationSourceStore } from './integrationSourceStore';
 import { useNestedStepsStore } from './nestedStepsStore';
-import { useSettingsStore } from './settingsStore';
+import { initDsl, initialSettings, useSettingsStore } from './settingsStore';
 import { useVisualizationStore } from './visualizationStore';
 import { StepsService } from '@kaoto/services';
 import { IIntegration, IStepProps, IViewProps } from '@kaoto/types';
@@ -30,8 +30,8 @@ export interface IIntegrationJsonStore {
 const initialState = {
   branchSteps: {},
   integrationJson: {
-    dsl: 'KameletBinding',
-    metadata: { name: 'integration', namespace: 'default' },
+    dsl: initDsl.name,
+    metadata: { name: initialSettings.name, namespace: initialSettings.namespace },
     steps: [],
     params: [],
   },

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -9,17 +9,17 @@ interface ISettingsStore {
   setSettings: (vals?: Partial<ISettings>) => void;
 }
 
-const initDsl: IDsl = {
-  deployable: 'true',
+export const initDsl: IDsl = {
+  deployable: 'false',
   description: '',
   input: '',
   output: '',
   stepKinds: '',
-  name: 'KameletBinding',
-  validationSchema: '/v1/capabilities/KameletBinding/schema',
+  name: 'Camel Route',
+  validationSchema: '/v1/capabilities/Camel%20Route/schema',
 };
 
-const initialSettings: ISettings = {
+export const initialSettings: ISettings = {
   description: '',
   dsl: initDsl,
   icon: svg,


### PR DESCRIPTION
This PR changes the default DSL to `Camel Route`
Resolves #1310 , also fixes #1302 

## Changes
- Change initial DSL to `Camel Route`
- Change to use same initial settings across all stores

## Screenshots

Here showing that:
- The initial DSL is `Camel Route`
- Then reproducing the steps from #1302 to show it no longer happens
- Finally, showing that when you switch to `KameletBinding` it also updates the code editor with no issues

![Camel Route default DSL](https://user-images.githubusercontent.com/3844502/220922632-6bbf3f8c-f05c-4e7a-a3e6-351ce50973b7.gif)