### PR TITLE
feat(branching): add support for min/max branches

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0.5%
+        base: auto

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -207,12 +207,16 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {VisualizationService.showAppendStepButton(data, endStep) ? (
             <Popover
               appendTo={() => document.body}
-              aria-label="Search for a step"
+              aria-label="Add a step or branch"
               bodyContent={
                 <MiniCatalog
                   children={<BranchBuilder handleAddBranch={handleAddBranch} />}
                   disableBranchesTab={!showBranchesTab}
-                  disableBranchesTabMsg={"This step doesn't support branching."}
+                  disableBranchesTabMsg={ValidationService.getBranchTabTooltipMsg(
+                    supportsBranching,
+                    data.step.maxBranches,
+                    data.step.branches?.length
+                  )}
                   disableStepsTab={!showStepsTab}
                   disableStepsTabMsg={"You can't add a step between a step and a branch."}
                   handleSelectStep={onMiniCatalogClickAppend}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -102,7 +102,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const getHoverClass = (): string => {
     return VisualizationService.getNodeClass(
       visualizationStore.hoverStepUuid,
-      data.branchInfo?.branchParentUuid ?? data.step.UUID,
+      data.branchInfo?.rootStepUuid ?? data.step.UUID,
       ' stepNode__Hover'
     );
   };
@@ -115,9 +115,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           onDrop={onDropReplace}
           onMouseEnter={() => {
             if (data.branchInfo || supportsBranching) {
-              visualizationStore.setHoverStepUuid(
-                data.branchInfo?.branchParentUuid ?? data.step.UUID
-              );
+              visualizationStore.setHoverStepUuid(data.branchInfo?.rootStepUuid ?? data.step.UUID);
             } else {
               visualizationStore.setHoverStepUuid(data.step.UUID);
             }

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -2,3 +2,17 @@
 
 Services in this directory implement relevant business logic between the presentation layer (stateless components) and application logic (stateful components).
 
+### contentService
+Contains methods pertaining to content rendered in the UI, such as a tooltips, popovers, modals, or other text. Likely relevant for i18n. Example methods: `getTooltipMsg`
+
+### stepsService
+Contains methods pertaining to Steps, where we might modify the business model through a copy of it. Example methods: `insertStep`, `regenerateUuids`
+
+### utilityService
+Contains methods pertaining to common, cross-cutting utilities that may or may not contain business logic. Example methods: `formatDateTime`, `getDeepValue`
+
+### validationService
+Contains methods pertaining to validation of Steps. These methods ensure that the Step does what you expect it to do. Example methods: `isFirstStep`, `reachedMinBranches`
+
+### visualizationService
+Contains methods pertaining to any mutations for the canvas or visualization. This is where you build nodes, find nodes, etc. Example methods: `buildNodesAndEdges`

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -128,7 +128,7 @@ describe('validationService', () => {
 
   it('reachedMinBranches(): given a step, should determine whether the threshold for min branches has been reached', () => {
     expect(ValidationService.reachedMinBranches(1, 2)).toBeFalsy();
-    expect(ValidationService.reachedMinBranches(2, -1)).toBeFalsy();
+    expect(ValidationService.reachedMinBranches(2, 2)).toBeFalsy();
     expect(ValidationService.reachedMinBranches(3, 2)).toBeTruthy();
   });
 });

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -94,6 +94,16 @@ describe('validationService', () => {
     ).toBeTruthy();
   });
 
+  it('getBranchTooltipMsg(): should return tooltip message for a disabled branch tab', () => {
+    expect(ValidationService.getBranchTabTooltipMsg(false, 0, 0)).toBe(
+      "This step doesn't support branching"
+    );
+    expect(ValidationService.getBranchTabTooltipMsg(true, 5, 5)).toBe(
+      'Max number of branches reached'
+    );
+    expect(ValidationService.getBranchTabTooltipMsg(true, 5, 1)).toBe('');
+  });
+
   it('getPlusButtonTooltipMsg(): should return the tooltip message for the plus button to add a step or branch', () => {
     expect(ValidationService.getPlusButtonTooltipMsg(true, true)).toBe('Add a step or branch');
     expect(ValidationService.getPlusButtonTooltipMsg(true, false)).toBe('Add a branch');
@@ -103,5 +113,22 @@ describe('validationService', () => {
 
   it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {
     expect(ValidationService.prependableStepTypes()).toEqual('MIDDLE');
+  });
+
+  it('reachedMaxBranches(): given a step, should determine whether the max number of branches has been reached', () => {
+    // below max
+    expect(ValidationService.reachedMaxBranches(1, 2)).toBeFalsy();
+
+    // at max
+    expect(ValidationService.reachedMaxBranches(2, 2)).toBeTruthy();
+
+    // infinite
+    expect(ValidationService.reachedMaxBranches(4, -1)).toBeFalsy();
+  });
+
+  it('reachedMinBranches(): given a step, should determine whether the threshold for min branches has been reached', () => {
+    expect(ValidationService.reachedMinBranches(1, 2)).toBeFalsy();
+    expect(ValidationService.reachedMinBranches(2, -1)).toBeFalsy();
+    expect(ValidationService.reachedMinBranches(3, 2)).toBeTruthy();
   });
 });

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -43,7 +43,7 @@ export class ValidationService {
       if (proposedStep.type === 'MIDDLE' || proposedStep.type === 'END') {
         return { isValid: true };
       } else {
-        return { isValid: false, message: 'Branches must start with an action or end step.' };
+        return { isValid: false, message: 'Branches must start with an action or end step' };
       }
     }
 
@@ -59,26 +59,47 @@ export class ValidationService {
     switch (existingNode.step.type) {
       case 'START':
         isValid = proposedStep.type === 'START';
-        message = 'First step must be a start step.';
+        message = 'First step must be a start step';
         break;
       case 'MIDDLE':
       case 'END':
         // check if it's the last step
         if (existingNode.isLastStep) {
-          message = 'Last step must be a middle or end step.';
+          message = 'Last step must be a middle or end step';
           isValid = proposedStep.type === 'MIDDLE' || proposedStep.type === 'END';
         } else if (existingNode.step.type === 'MIDDLE' && proposedStep.type === 'END') {
           // not the last step, but trying to replace a MIDDLE step with an END step
-          message = 'You cannot replace a middle step with an end step.';
+          message = 'You cannot replace a middle step with an end step';
         } else if (existingNode.step.type === 'MIDDLE' && proposedStep.type === 'START') {
           // not the last step, but trying to replace a MIDDLE step with a START step
-          message = 'You cannot replace a middle step with a start step.';
+          message = 'You cannot replace a middle step with a start step';
         }
 
         break;
     }
 
     return { isValid, message };
+  }
+
+  /**
+   * Get the message to display in a tooltip when
+   * the branches tab is disabled in the mini catalog
+   * @param supportsBranching
+   * @param maxBranches
+   * @param branchesLength
+   */
+  static getBranchTabTooltipMsg(
+    supportsBranching: boolean,
+    maxBranches: number,
+    branchesLength: number | undefined
+  ): string {
+    if (!supportsBranching) {
+      return "This step doesn't support branching";
+    } else if (branchesLength === maxBranches) {
+      return 'Max number of branches reached';
+    } else {
+      return '';
+    }
   }
 
   /**
@@ -133,5 +154,24 @@ export class ValidationService {
    */
   static prependableStepTypes(): string {
     return 'MIDDLE';
+  }
+
+  /**
+   * Determines if the maximum number of branches has been reached
+   * @param branchLength
+   * @param maxBranches
+   */
+  static reachedMaxBranches(branchLength: number, maxBranches: number): boolean {
+    return branchLength === maxBranches;
+  }
+
+  /**
+   * Determines whether the number of minimum
+   * branches has been reached (gone above the minimum)
+   * @param branchLength
+   * @param minBranches
+   */
+  static reachedMinBranches(branchLength: number, minBranches: number): boolean {
+    return branchLength >= minBranches + 1;
   }
 }

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -383,6 +383,23 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
+  it('showDeleteBranchEdge()', () => {
+    expect(
+      VisualizationService.showDeleteBranchEdge({
+        branches: [{}] as IStepPropsBranch[],
+        minBranches: 2,
+        maxBranches: -1,
+      } as IStepProps)
+    ).toBeFalsy();
+    expect(
+      VisualizationService.showDeleteBranchEdge({
+        branches: [{}, {}, {}] as IStepPropsBranch[],
+        minBranches: 2,
+        maxBranches: -1,
+      } as IStepProps)
+    ).toBeTruthy();
+  });
+
   it('showPrependStepButton(): given a node, should determine whether to show a prepend step button for it', () => {
     const vizStoreState = useVisualizationStore.getState();
     useVisualizationStore.setState({

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -383,7 +383,43 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
-  it('showDeleteBranchEdge()', () => {
+  it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
+    const step: IVizStepNodeData = {
+      label: '',
+      step: {} as IStepProps,
+    };
+
+    expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
+    // has branches but not branch support
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        step: { ...step.step, branches: [] },
+      })
+    ).toBeFalsy();
+
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        step: { ...step.step, branches: [], minBranches: 0, maxBranches: -1 },
+      })
+    ).toBeTruthy();
+
+    // if step has maximum number of branches already
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        step: {
+          ...step.step,
+          branches: [{}, {}] as IStepPropsBranch[],
+          minBranches: 0,
+          maxBranches: 2,
+        },
+      })
+    ).toBeFalsy();
+  });
+
+  it('showDeleteBranchEdge(): given a step, should determine whether to show the ability to delete branches', () => {
     expect(
       VisualizationService.showDeleteBranchEdge({
         branches: [{}] as IStepPropsBranch[],
@@ -391,6 +427,7 @@ describe('visualizationService', () => {
         maxBranches: -1,
       } as IStepProps)
     ).toBeFalsy();
+
     expect(
       VisualizationService.showDeleteBranchEdge({
         branches: [{}, {}, {}] as IStepPropsBranch[],
@@ -469,29 +506,6 @@ describe('visualizationService', () => {
         isFirstStep: false,
         previousStepUuid: 'step-one',
         step: { ...node.step, type: 'MIDDLE' } as IStepProps,
-      })
-    ).toBeTruthy();
-  });
-
-  it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
-    const step: IVizStepNodeData = {
-      label: '',
-      step: {} as IStepProps,
-    };
-
-    expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
-    // has branches but not branch support
-    expect(
-      VisualizationService.showBranchesTab({
-        ...step,
-        step: { ...step.step, branches: [] },
-      })
-    ).toBeFalsy();
-
-    expect(
-      VisualizationService.showBranchesTab({
-        ...step,
-        step: { ...step.step, branches: [], minBranches: 0, maxBranches: -1 },
       })
     ).toBeTruthy();
   });

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -419,24 +419,6 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
-  it('showDeleteBranchEdge(): given a step, should determine whether to show the ability to delete branches', () => {
-    expect(
-      VisualizationService.showDeleteBranchEdge({
-        branches: [{}] as IStepPropsBranch[],
-        minBranches: 2,
-        maxBranches: -1,
-      } as IStepProps)
-    ).toBeFalsy();
-
-    expect(
-      VisualizationService.showDeleteBranchEdge({
-        branches: [{}, {}, {}] as IStepPropsBranch[],
-        minBranches: 2,
-        maxBranches: -1,
-      } as IStepProps)
-    ).toBeTruthy();
-  });
-
   it('showPrependStepButton(): given a node, should determine whether to show a prepend step button for it', () => {
     const vizStoreState = useVisualizationStore.getState();
     useVisualizationStore.setState({

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,4 +1,5 @@
 import { StepsService } from './stepsService';
+import { ValidationService } from './validationService';
 import { IIntegrationJsonStore, RFState } from '@kaoto/store';
 import {
   IStepProps,
@@ -132,8 +133,9 @@ export class VisualizationService {
         // handle special first step, needs to be connected to its immediate parent
         if (node.data.isFirstStep) {
           const parentStepNode: IVizStepNode = stepNodes[parentNodeIndex];
-          const showDeleteEdge = VisualizationService.showDeleteBranchEdge(
-            parentStepNode.data.step
+          const showDeleteEdge = ValidationService.reachedMinBranches(
+            parentStepNode.data.step.branches.length,
+            parentStepNode.data.step.minBranches
           );
           let edgeProps = VisualizationService.buildEdgeParams(
             parentStepNode,
@@ -150,8 +152,9 @@ export class VisualizationService {
         // handle placeholder steps within a branch
         if (node.data.branchInfo?.branchStep && node.data.isPlaceholder) {
           const parentStepNode: IVizStepNode = stepNodes[parentNodeIndex];
-          const showDeleteEdge = VisualizationService.showDeleteBranchEdge(
-            parentStepNode.data.step
+          const showDeleteEdge = ValidationService.reachedMinBranches(
+            parentStepNode.data.step.branches.length,
+            parentStepNode.data.step.minBranches
           );
 
           specialEdges.push(
@@ -577,17 +580,13 @@ export class VisualizationService {
     const supportsBranching = !!(nodeData.step.minBranches || nodeData.step.maxBranches);
     if (isEndStep && !supportsBranching) return false;
     if (supportsBranching && nodeData.step.branches && nodeData.step.branches.length > 0) {
-      return true;
+      // check if max branches reached
+      return ValidationService.reachedMaxBranches(
+        nodeData.step.branches.length,
+        nodeData.step.maxBranches
+      );
+      // return true;
     } else return !!(nodeData.isLastStep && !isEndStep);
-  }
-
-  /**
-   * Given a step, determines whether to show the edge to
-   * delete a branch, based on the required number of branches.
-   * @param step
-   */
-  static showDeleteBranchEdge(step: IStepProps): boolean {
-    return step.branches!.length > step.minBranches;
   }
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -617,7 +617,10 @@ export class VisualizationService {
    * @param nodeData
    */
   static showBranchesTab(nodeData: IVizStepNodeData): boolean {
-    return StepsService.supportsBranching(nodeData.step);
+    return (
+      StepsService.supportsBranching(nodeData.step) &&
+      nodeData.step.branches?.length !== nodeData.step.maxBranches
+    );
   }
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -574,18 +574,22 @@ export class VisualizationService {
    * @param isEndStep
    */
   static showAppendStepButton(nodeData: IVizStepNodeData, isEndStep: boolean) {
-    // it cannot be an END step, it must be the last step in the array,
-    // OR it must support branching AND contain at least one branch, otherwise users will
-    // be able to add a branch through INSERT step
     const supportsBranching = !!(nodeData.step.minBranches || nodeData.step.maxBranches);
+    // if it's an end step and there's no chance of adding a branch, there is nothing to append
     if (isEndStep && !supportsBranching) return false;
+
+    // if it supports branching AND contains at least one branch, show it. otherwise users will
+    // be able to add a branch through INSERT step, or append if it's the last in the array
     if (supportsBranching && nodeData.step.branches && nodeData.step.branches.length > 0) {
-      // check if max branches reached
-      return ValidationService.reachedMaxBranches(
-        nodeData.step.branches.length,
-        nodeData.step.maxBranches
+      // if max branches reached AND there is a next step, hide it, otherwise show it
+      return !(
+        ValidationService.reachedMaxBranches(
+          nodeData.step.branches.length,
+          nodeData.step.maxBranches
+        ) && nodeData.nextStepUuid
       );
-      // return true;
+
+      // handles when it's not an END step, but it's the last step in the array
     } else return !!(nodeData.isLastStep && !isEndStep);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -185,23 +185,23 @@ export type IVizStepNodeDataBranch = Partial<IStepPropsBranch> & {
    * An optional label for the branch (e.g. 'if', 'else', 'otherwise')
    */
   branchIdentifier?: string;
-
-  /**
-   * The UUID of the original (n=1) branch's parent node
-   */
-  branchParentUuid: string;
-
-  /**
-   * The UUID of the node *after* the original (n=1) branch's
-   * parent node (used for connecting branch steps back)
-   */
-  branchParentNextUuid: string;
   branchStep: boolean;
 
   /**
    * The branch node's immediate parent
    */
   parentUuid?: string;
+
+  /**
+   * The UUID of the original (n=1) branch's parent node
+   */
+  rootStepUuid: string;
+
+  /**
+   * The UUID of the node *after* the original (n=1) branch's
+   * parent node (used for connecting branch steps back)
+   */
+  rootStepNextUuid: string;
 };
 
 /**


### PR DESCRIPTION
This PR adds support for handling minimum and maximum branches.
Resolves #1143 

## Changes
- Add methods for checking if branches have reached the minimum threshold and maximum number of branches
- Hide button to delete branch if deleting will drop number of branches below the minimum
- Disable Branches tab in mini catalog if max number of branches have been reached
- Add custom validation tooltip message for when steps have reached their maximum number of branches, to explain why the branches tab is disabled
- Rename `originStep` and `parentStep` to `rootStep` for improved clarity
- Update services `README`
- Add a sneaky `codecov.yml` file


## Screenshots

**NOTE:** In the following examples, `filter` has a minimum number of branches of 1 and a maximum number of branches of 1.

Minimum threshold has not been met (`minBranches` + 1), so delete branch button is hidden, but append step shows because you can still add a step after the branch:

![Show append step button](https://user-images.githubusercontent.com/3844502/220991918-26e909a6-4032-48e6-b7ff-6ff3d1655e3e.png)

Once the maximum number of branches is reached, disable the Branches tab:
![Disable Branches tab](https://user-images.githubusercontent.com/3844502/220991945-9ab35ec9-57c8-43c8-9ef6-5c7b2d2dc5e6.png)

On reaching minimum number of branches, show delete branch button again (this is just for an example, `filter` max number of branches is usually 1):

![Show delete branch button](https://user-images.githubusercontent.com/3844502/220992099-19911378-623c-4cb1-bb6b-299594f8f28b.png)


Once you have a next step, you can no longer add a step, only branches, but in this case the maximum number of branches has also been reached, so you can't add either. In this case we hide the append step button:

![Hide append step button](https://user-images.githubusercontent.com/3844502/220991979-209619be-b858-4faa-a3a6-c6323bf77f71.png)



