### PR TITLE
chore: Adjust Source Maps to include JSX

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "noImplicitReturns": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "sourceMap": true,
+    "forceConsistentCasingInFileNames": true,
     "paths": {
       "*": ["*", "types/*"],
       "@kaoto/api": ["./src/api"],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,7 +4,7 @@ const webpack = require('webpack');
 
 module.exports = merge(common('development'), {
   mode: 'development',
-  devtool: 'eval-source-map',
+  devtool: 'inline-source-map',
   devServer: {
     allowedHosts: 'all',
 


### PR DESCRIPTION
### Context
Currently, KaotoUI has two types of source maps, one coming from webpack and another from typescript, and unfortunately aren't synced. 

This commit adjusts the webpack's to be inline, links them correctly, and reveals the JSX source code

| webpack | typescript |
| --- | --- |
| ![webpack-sourcemaps](https://user-images.githubusercontent.com/16512618/221422983-8024f79b-0d23-4453-b803-8866566b915d.png) | ![typescript-sourcemaps](https://user-images.githubusercontent.com/16512618/221422981-b47d05cc-3dc7-4741-8cd9-92d94e449fa1.png) |
| Raw output | Typescript output without JSX |

### Changes
* Adjust webpack source maps to be `devtool: 'inline-source-map',`
* Adjust typescript source maps to explicit `true`
* Force typescript to use consistent filename case for cross-environment build

| linked source maps |
| --- |
| ![link-sourcemaps](https://user-images.githubusercontent.com/16512618/221422979-546f11ab-e27e-4e36-9056-02414794071d.png) |

### Related reading
https://webpack.js.org/guides/typescript/#source-maps