### PR TITLE
Fix e2e tests, relates to default DSL change

### DIFF
--- a/cypress/e2e/1-settings/settings.cy.js
+++ b/cypress/e2e/1-settings/settings.cy.js
@@ -39,7 +39,7 @@ describe('Settings', () => {
     // add a step
     cy.get('.stepNode').contains('ADD A STEP').click({ force: true });
     cy.get('#stepSearch').type('timer');
-    cy.get('[data-testid="miniCatalog__stepItem--timer-source"]').click();
+    cy.get('[data-testid="miniCatalog__stepItem--timer"]').click();
 
     cy.wait('@getDSLs');
     cy.wait('@getViewDefinitions');
@@ -70,14 +70,14 @@ describe('Settings', () => {
     cy.get('[data-testid="settings-modal--save"]').click();
 
     // verify that steps are still there
-    cy.get('[data-testid="viz-step-timer-source"]').should('be.visible');
+    cy.get('[data-testid="viz-step-timer"]').should('be.visible');
 
     // verify that toolbar contains new name
     cy.get('[data-testid="kaoto-toolbar--name"]').should('have.text', 'cherry');
 
     // verify that source code editor contains new values
     cy.get('[data-testid="toolbar-show-code-btn"]').click();
-    cy.get('.code-editor').contains('timer-source');
+    cy.get('.code-editor').contains('timer');
 
     // reopen modal, verify that value is changed accordingly
     cy.wait('@getIntegration');

--- a/cypress/e2e/3-step_integration/step_integration.cy.js
+++ b/cypress/e2e/3-step_integration/step_integration.cy.js
@@ -7,51 +7,51 @@ describe('3 step integration', () => {
   it('add the step integration', () => {
     cy.get('.stepNode').contains('ADD A STEP').click({ force: true });
 
-    // add timer-source via drag and drop from the catalog
+    // add timer via drag and drop from the catalog
     const dataTransfer = new DataTransfer();
     cy.get('#stepSearch').type('timer');
-    cy.get('[data-testid="miniCatalog__stepItem--timer-source"]').click();
+    cy.get('[data-testid="miniCatalog__stepItem--timer"]').click();
 
-    // verify the code editor contains the new timer source step
+    // verify the code editor contains the new timer step
     cy.get('[data-testid="toolbar-show-code-btn"]').click();
-    cy.get('.code-editor').should('contain.text', 'timer-source');
+    cy.get('.code-editor').should('contain.text', 'timer');
 
     // add an action from the mini catalog
     cy.get('[data-testid="stepNode__appendStep-btn"]').click();
-    cy.get('#stepSearch').type('extra').wait(1000);
-    cy.get('[data-testid="miniCatalog__stepItem--extract-field-action"]').click();
-    cy.get('.code-editor').should('contain.text', 'extract-field-action');
+    cy.get('#stepSearch').type('aggre').wait(1000);
+    cy.get('[data-testid="miniCatalog__stepItem--aggregate"]').click();
+    cy.get('.code-editor').should('contain.text', 'aggregate');
 
-    // add kafka sink from the mini catalog
+    // add kafka from the mini catalog
     cy.get('[data-testid="stepNode__appendStep-btn"]').click();
     cy.get('[data-testid="miniCatalog"]').should('be.visible');
     cy.get('#END').click({ force: true });
-    cy.get('.pf-c-text-input-group__text-input').type('kafka-sink');
-    cy.get('[data-testid="miniCatalog__stepItem--kafka-sink"]').click();
+    cy.get('.pf-c-text-input-group__text-input').type('kafka');
+    cy.get('[data-testid="miniCatalog__stepItem--kafka"]').click();
 
-    // verify the code editor contains the new kafka sink step
-    cy.get('.code-editor').should('contain.text', 'kafka-sink');
+    // verify the code editor contains the new kafka step
+    cy.get('.code-editor').should('contain.text', 'kafka');
 
     // delete middle step
-    cy.get('[data-testid="viz-step-extract-field-action"]').trigger('mouseover');
+    cy.get('[data-testid="viz-step-aggregate"]').trigger('mouseover');
     cy.get(
-      '[data-testid="viz-step-extract-field-action"] > [data-testid="configurationTab__deleteBtn"]'
+      '[data-testid="viz-step-aggregate"] > [data-testid="configurationTab__deleteBtn"]'
     ).click({ force: true });
 
-    // open step catalog, replace timer-source with postgresql-source
+    // open step catalog, replace timer with debezium-postgres
     cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
     cy.get('#stepSearch').click().clear();
     cy.get('.pf-l-gallery').scrollTo('0%', '75%');
-    cy.get('.pf-c-card__title').contains('postgresql-source').trigger('dragstart', {
+    cy.get('.pf-c-card__title').contains('debezium-postgres').trigger('dragstart', {
       dataTransfer,
     });
-    cy.get('[data-testid="react-flow-wrapper"]').contains('timer-source').trigger('drop', {
+    cy.get('[data-testid="react-flow-wrapper"]').contains('timer').trigger('drop', {
       dataTransfer,
     });
 
-    // verify the visualization has the correct steps (postgresql-source)
+    // verify the visualization has the correct steps (debezium-postgres)
     // and configuration loads as expected
-    cy.get('[data-testid="viz-step-postgresql-source"]').click();
+    cy.get('[data-testid="viz-step-debezium-postgres"]').click();
     cy.get('[data-testid="configurationTab"]').should('be.visible');
     cy.get('[data-testid="kaoto-left-drawer"]').within(() => {
       cy.get('.pf-c-drawer__close > .pf-c-button').click();
@@ -63,14 +63,14 @@ describe('3 step integration', () => {
     // and opens the mini catalog without issues
     cy.get('[data-testid="stepNode__insertStep-btn"]').click();
     cy.get('[data-testid="miniCatalog"]').should('be.visible');
-    cy.get('[data-testid="miniCatalog__search--input"]').type('chunk-template-action');
-    cy.get('[data-testid="miniCatalog__stepItem--chunk-template-action"]').click();
+    cy.get('[data-testid="miniCatalog__search--input"]').type('chunk');
+    cy.get('[data-testid="miniCatalog__stepItem--chunk"]').click();
 
-    // verify the code editor has the correct steps (postgresql-source, log, kafka-sink)
+    // verify the code editor has the correct steps (debezium-postgres, chunk, kafka)
     cy.get('[data-testid="toolbar-show-code-btn"]').click();
     cy.get('.code-editor')
-      .should('contain.text', 'postgresql-source')
-      .and('contain.text', 'chunk-template')
-      .and('contain.text', 'kafka-sink');
+      .should('contain.text', 'debezium-postgres')
+      .and('contain.text', 'chunk')
+      .and('contain.text', 'kafka');
   });
 });

--- a/cypress/e2e/7-catalog_actions/catalog_actions.cy.js
+++ b/cypress/e2e/7-catalog_actions/catalog_actions.cy.js
@@ -12,15 +12,15 @@ describe('Test for catalog actions', () => {
         cy.get('[data-testid="sourceCode--applyButton"]').click();
     });
 
-    // Try replace the digitalocean step with the timer-source step
+    // Try replace the digitalocean step (action) with the timer step (start)
     it("User drags and drops an invalid step onto a nested branch step", () => {
         const dataTransfer = new DataTransfer();
         // open catalog
         cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
-        // select timer-source step
-        cy.get('#stepSearch').type('timer-source');
-        // drag timer-source step from catalog
-        cy.get('[data-testid="catalog-step-timer-source"]').trigger('dragstart', {
+        // select timer step
+        cy.get('#stepSearch').type('timer');
+        // drag timer step from catalog
+        cy.get('[data-testid="catalog-step-timer"]').trigger('dragstart', {
             dataTransfer,
         });
         // drop aggregate step from catalog over nested digitalocean step
@@ -31,10 +31,10 @@ describe('Test for catalog actions', () => {
         // CHECK digitalocean step is visible
         cy.get('[data-testid="viz-step-digitalocean"]').should('be.visible');
         // CHECK aggregation step was not created
-        cy.get('[data-testid="viz-step-timer-source"]').should('not.exist');
+        cy.get('[data-testid="viz-step-timer"]').should('not.exist');
         // CHECK alert box is visible and contains error message
         cy.get('[data-testid="alert-box-replace-unsuccessful"]').should('be.visible');
-        cy.get('[data-testid="alert-box-replace-unsuccessful"]').should('contain', 'You cannot replace a middle step with a start step.');
+        cy.get('[data-testid="alert-box-replace-unsuccessful"]').should('contain', 'You cannot replace a middle step with a start step');
     });
 
     // Replace the digitalocean step with the delay step with the big catalog

--- a/cypress/fixtures/EipAction.yaml
+++ b/cypress/fixtures/EipAction.yaml
@@ -56,6 +56,6 @@ spec:
                       - aggregate: {}
         - filter:
             simple: "{{?foo}}"
-            steps: []
-        - to:
-            uri: kamelet:sink
+            steps:
+              - to:
+                uri: kamelet:sink


### PR DESCRIPTION
Hi,

This PR fix errors in e2e tests:
Mainly errors are related to changing the default DSL to Camel Route, and one is related to the change in the alert message.

## Changes
-  1-settings/settings.cy.js
   - timer-source -> timer
-  3-step_integration/step_integration.cy.js
   - timer-source -> timer
   - extract-field-action -> aggregate
   - kafka-sink -> kafka
   - postgresql-source -> debezium-postgres
-  7-catalog_actions/catalog_actions.cy.js
   - timer-source -> timer
   - Delete the extra dot in the alert message
- Change the EIP template, the difference in screenshots

## Screenshots

Error example:
![Screenshot from 2023-02-27 10-19-58](https://user-images.githubusercontent.com/46084942/221532180-d6e6d53e-0dc1-4aef-8422-cd41aa62d78b.png)

Template before the change:
![Screenshot from 2023-02-27 11-00-19](https://user-images.githubusercontent.com/46084942/221533160-8bc2ce1f-e945-4535-a9e6-64906172f3b6.png)

Template after the change:
![Screenshot from 2023-02-27 10-59-17](https://user-images.githubusercontent.com/46084942/221533241-a9eb55e2-852d-4c31-bf24-21ac9926d36b.png)

## Links
- [Issue-1099](https://github.com/KaotoIO/kaoto-ui/issues/1099)
- [Issue-1297](https://github.com/KaotoIO/kaoto-ui/issues/1297)
- [MR-1315 (alert message change)](https://github.com/KaotoIO/kaoto-ui/pull/1315)
- [MR-1313 (default DSL change)](https://github.com/KaotoIO/kaoto-ui/pull/1313)