### PR TITLE
fix(MiniCatalog): Add loading and decoding attributes to <img>

### DIFF
--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -174,10 +174,10 @@ export const MiniCatalog = (props: IMiniCatalog) => {
           </Toolbar>
           <Gallery hasGutter={false} className={'miniCatalog__gallery'}>
             {catalogData &&
-              search(catalogData).map((step, idx) => {
+              search(catalogData).map((step) => {
                 return (
                   <Button
-                    key={idx}
+                    key={step.id}
                     variant={'tertiary'}
                     onClick={() => {
                       handleSelectStep(step);
@@ -192,6 +192,8 @@ export const MiniCatalog = (props: IMiniCatalog) => {
                             src={step.icon}
                             className={'miniCatalog__stepImage'}
                             alt={'Step Image'}
+                            loading="lazy"
+                            decoding="async"
                           />
                         </Bullseye>
                       </GridItem>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -128,6 +128,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* PREPEND STEP BUTTON */}
           {visualizationService.showPrependStepButton(data) && (
             <Popover
+              id="popover-prepend-step"
               appendTo={() => document.body}
               aria-label="Add a step"
               bodyContent={
@@ -208,6 +209,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* ADD/APPEND STEP BUTTON */}
           {VisualizationService.showAppendStepButton(data, endStep) ? (
             <Popover
+              id="popover-append-step"
               appendTo={() => document.body}
               aria-label="Add a step or branch"
               bodyContent={
@@ -255,6 +257,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
         </div>
       ) : (
         <Popover
+          id="popover-add-step"
           appendTo={() => document.body}
           aria-label="Add a step"
           bodyContent={


### PR DESCRIPTION
### Description
In order to improve the MiniCatalog load speed, two attributes were added to the <img> tag, said attributes were loading and decoding.

#### Added attributes
* loading: lazy
  Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser.
* decoding: async
  Decode the image asynchronously, to reduce delay in presenting other content.

Related read: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes

### Changes
* Add `<img>` attributes to defer loading and decoding.
* Add `id` to `Popover` components to avoid rerendering them every time [with a different id](https://github.com/patternfly/patternfly-react/blob/d526d77ef63c407a7917657536c4d242822e956b/packages/react-core/src/components/Popover/Popover.tsx#L272).


Fixes https://github.com/KaotoIO/kaoto-ui/issues/1316