### PR TITLE
fix(viz): fix actions for deeply nested steps

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,5 @@ coverage:
         target: auto
         threshold: 0.5%
         base: auto
+ignore:
+  - "**/*.stories.tsx"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "**/*.stories.tsx"

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -8,8 +8,6 @@ import { PlusIcon } from '@patternfly/react-icons';
 import { getBezierPath, Position, useReactFlow } from 'reactflow';
 
 const foreignObjectSize = 40;
-const insertStepInStore = useIntegrationJsonStore.getState().insertStep;
-const replaceStep = useIntegrationJsonStore.getState().replaceStep;
 
 export interface IPlusButtonEdge {
   data?: any;
@@ -44,7 +42,6 @@ const PlusButtonEdge = ({
   const nestedStepsStore = useNestedStepsStore();
   const visualizationStore = useVisualizationStore();
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
-  const currentIdx = stepsService.findStepIdxWithUUID(targetNode?.data.step.UUID);
   const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data);
   const showStepsTab = VisualizationService.showStepsTab(sourceNode?.data);
 
@@ -62,30 +59,7 @@ const PlusButtonEdge = ({
   };
 
   const onMiniCatalogClickInsert = (selectedStep: IStepProps) => {
-    if (targetNode?.data.branchInfo) {
-      const rootStepIdx = stepsService.findStepIdxWithUUID(targetNode?.data.branchInfo.parentUuid);
-      const currentStepNested = nestedStepsStore.nestedSteps.map(
-        (ns) => ns.stepUuid === targetNode?.data.step.UUID
-      );
-
-      if (currentStepNested) {
-        // 1. make a copy of the steps, get the root step
-        const newStep = integrationJsonStore.integrationJson.steps.slice()[rootStepIdx];
-        // 2. find the correct branch, insert new step there
-        newStep.branches?.forEach((b, bIdx) => {
-          b.steps.map((bs, bsIdx) => {
-            if (bs.UUID === targetNode?.data.step.UUID) {
-              // 3. assign the new steps back to the branch
-              newStep.branches![bIdx].steps = StepsService.insertStep(b.steps, bsIdx, selectedStep);
-            }
-          });
-        });
-
-        replaceStep(newStep, rootStepIdx);
-      }
-    } else {
-      insertStepInStore(selectedStep, currentIdx);
-    }
+    stepsService.handleInsertStep(targetNode, selectedStep);
   };
 
   return (

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -29,54 +29,24 @@ describe('stepsService', () => {
   });
 
   /**
-   * filterNestedSteps
-   */
-  it('filterNestedSteps(): should filter an array of steps given a conditional function', () => {
-    const nestedSteps = [
-      { branches: [{ steps: [{ branches: [{ steps: [{ UUID: 'log-340230' }] }] }] }] },
-    ] as IStepProps[];
-    expect(nestedSteps[0].branches![0].steps[0].branches![0].steps).toHaveLength(1);
-
-    const filtered = StepsService.filterNestedSteps(
-      nestedSteps,
-      (step) => step.UUID !== 'log-340230'
-    );
-    expect(filtered![0].branches![0].steps[0].branches![0].steps).toHaveLength(0);
-  });
-
-  /**
-   * filterStepWithBranches
-   */
-  it('filterStepWithBranches(): should filter the branch steps for a given step and conditional', () => {
-    const step = {
-      branches: [
-        {
-          steps: [
-            {
-              UUID: 'step-one',
-              branches: [{ steps: [{ UUID: 'strawberry' }, { UUID: 'banana' }] }],
-            },
-            { UUID: 'step-two', branches: [{ steps: [{ UUID: 'cherry' }] }] },
-          ],
-        },
-      ],
-    } as IStepProps;
-
-    expect(step.branches![0].steps[0].branches![0].steps).toHaveLength(2);
-
-    const filtered = StepsService.filterStepWithBranches(
-      step,
-      (step: { UUID: string }) => step.UUID !== 'banana'
-    );
-
-    expect(filtered.branches![0].steps[0].branches![0].steps).toHaveLength(1);
-  });
-
-  /**
    * findStepIdxWithUUID
    */
   it("findStepIdxWithUUID(): should find a step's index, given a particular UUID", () => {
+    const steps = [
+      { UUID: 'twitter-search-source-0' },
+      { UUID: 'pdf-action-1' },
+      { UUID: 'caffeine-action-2' },
+    ] as IStepProps[];
     expect(stepsService.findStepIdxWithUUID('caffeine-action-2', steps)).toEqual(2);
+    // passing it a nested branch's steps array
+    const nestedSteps = steps.slice();
+    nestedSteps.push({
+      UUID: 'new-step-3',
+      branches: [{ steps: [{ UUID: 'nested-step-0' }, { UUID: 'nested-step-1' }] }, {}],
+    } as IStepProps);
+    expect(
+      stepsService.findStepIdxWithUUID('nested-step-1', nestedSteps[3].branches![0].steps)
+    ).toEqual(1);
   });
 
   /**

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -20,7 +20,7 @@ export interface IIntegrationJsonStore {
   insertStep: (newStep: IStepProps, insertIndex: number) => void;
   integrationJson: IIntegration;
   prependStep: (currentStepIdx: number, newStep: IStepProps) => void;
-  replaceBranchStep: (newStep: IStepProps, pathToOldStep: string[] | undefined) => void;
+  replaceBranchParentStep: (newStep: IStepProps, pathToParentStep: string[] | undefined) => void;
   replaceStep: (newStep: IStepProps, oldStepIndex?: number) => void;
   setViews: (views: IViewProps[]) => void;
   updateIntegration: (newInt?: any) => void;
@@ -124,9 +124,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           };
         });
       },
-      replaceBranchStep: (newStep, pathToOldStep) => {
+      replaceBranchParentStep: (newStep, pathToParentStep) => {
         let stepsCopy = get().integrationJson.steps.slice();
-        stepsCopy = setDeepValue(stepsCopy, pathToOldStep, newStep);
+        stepsCopy = setDeepValue(stepsCopy, pathToParentStep, newStep);
 
         const stepsWithNewUuids = StepsService.regenerateUuids(stepsCopy);
         const { updateSteps } = useNestedStepsStore.getState();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,8 +107,11 @@ export interface IKaotoApi {
 }
 
 export interface INestedStep {
+  branchIndex: number;
   branchUuid: string;
-  originStepUuid: string;
+  parentStepUuid: string;
+  pathToBranch: string[] | undefined;
+  pathToParentStep: string[] | undefined;
   pathToStep: string[] | undefined;
   stepUuid: string;
 }

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,6 +1,5 @@
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
-import {findPath, getDeepValue, getRandomArbitraryNumber, setDeepValue} from './index';
-import { StepsService } from '@kaoto/services';
+import { findPath, getDeepValue, getRandomArbitraryNumber, setDeepValue } from './index';
 
 describe('utils', () => {
   it('findPath(): should find the path from a deeply nested object, given a value', () => {
@@ -15,20 +14,6 @@ describe('utils', () => {
       'steps',
       '0',
     ]);
-  });
-
-  /**
-   * filterNestedSteps
-   */
-  it('filterNestedSteps(): should filter an array of steps given a conditional function', () => {
-    const nestedBranchCopy = nestedBranch.slice();
-    expect(nestedBranchCopy[1].branches![0].steps[0].branches![0].steps).toHaveLength(1);
-
-    const filteredNestedBranch = StepsService.filterNestedSteps(
-      nestedBranchCopy,
-      (step) => step.UUID !== 'log-340230'
-    );
-    expect(filteredNestedBranch![1].branches![0].steps[0].branches![0].steps).toHaveLength(0);
   });
 
   /**
@@ -73,5 +58,4 @@ describe('utils', () => {
     expect(getRandomArbitraryNumber()).toEqual(new Uint32Array(10));
     expect(mGetRandomValues).toBeCalledWith(new Uint8Array(1));
   });
-
 });


### PR DESCRIPTION
This PR addresses the issues from https://github.com/KaotoIO/kaoto-ui/issues/1191, where typical actions like add/edit/delete were not working for steps within nested branches. Fixes #1191 

## Changes
- Fix prepend step, append step, delete step, and insert step actions for deeply nested branch steps
- Move logic from `PlusButtonEdge` component to `StepsService`
- Rename `originStep` with `parentStep`, as this caused confusion between a `parentStep` and `rootStep`, and `replaceBranchStep` to `replaceBranchParentStep`
- Add branch index to nested step model, for easier retrieval and consolidating other nested stuff code
- Remove unused methods

### Tasks completed
- [x] Fix prepend step
- [x] Fix append step
- [x] Fix delete step
- [x] Fix insert step
- [x] Verify that updating nested step configuration works
- [x] Update tests
- [x] Verify that replacing a nested placeholder step works from mini catalog
- [x] Verify that replacing a nested placeholder step works from the large catalog
- [x] Verify that replacing an existing nested step works
- [x] Verify all actions for non-nested steps (to prevent regressions)
	- [x] Replace
	- [x] Delete
	- [x] Config
	- [x] Prepend
	- [x] Append

## Screenshots

Prepend step within a nested branch:
![Prepend](https://user-images.githubusercontent.com/3844502/221889625-5d605ecf-da9c-4a5f-88fe-83dcb8ae1e27.gif)

Delete step within a nested branch:
![Delete](https://user-images.githubusercontent.com/3844502/221889793-f67bf1a9-9fce-4eb9-889a-04a09c7edc9b.gif)

Append step within a nested branch:
![Append](https://user-images.githubusercontent.com/3844502/221889921-e552b9e4-2d1a-4b88-9126-d6f379961bd6.gif)

Insert step within a nested branch:
![Insert](https://user-images.githubusercontent.com/3844502/221890033-c8dac346-253e-4ba8-8210-9aa0920e952a.gif)

Updating step configuration within a nested branch:
![Update config](https://user-images.githubusercontent.com/3844502/221890116-cd779de1-17d4-4400-a086-2f3ede3eeed3.gif)

