### PR TITLE
fix(vscode): Adding a step in Kaoto VSCode takes several seconds

### DIFF
--- a/src/components/MiniCatalog.tsx
+++ b/src/components/MiniCatalog.tsx
@@ -78,7 +78,7 @@ export const MiniCatalog = (props: IMiniCatalog) => {
         });
     }
     searchInputRef.current?.focus();
-  }, [dsl]);
+  }, []);
 
   const changeSearch = (e: string) => {
     setQuery(e);

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -17,6 +17,11 @@
     right: -20px !important;
 }
 
+.reactflow-wrapper {
+    width: 100vw;
+    height: calc(100vh - 77px);
+}
+
 .stepNode {
     align-items: center;
     background: var(--pf-global--BackgroundColor--100);
@@ -51,7 +56,7 @@
     left: 0;
     top: 0;
  }
-  
+
  .stepNode__Icon {
     position: relative;
     top: 55%;


### PR DESCRIPTION
### Description
Currently, adding a new step from the `VSCode` extension takes more than 12 seconds.

This is because, in `VSCode`, the `MiniCatalog` component gets rerendered many times blocking the UI thread.

### Examples
* KaotoUI - Firefox Developer edition
![Screenshot from 2023-02-28 15-02-26](https://user-images.githubusercontent.com/16512618/221917173-ad4bc370-91e9-4d72-989d-73f9be09eb7b.png)

* KaotoUI - VSCode
![Screenshot from 2023-02-28 15-04-50](https://user-images.githubusercontent.com/16512618/221917339-170685a8-3477-463d-be9a-1817ceb88b87.png)

Notice how in VSCode there are many more render passes hence blocking the UI thread.

Part of the solution is to avoid recreating functions inside of components that later on are passed to child components. A more robust solution would include removing many other points that trigger extra renders.

### Changes
* Move the `onNodeClick` function inside of a `useCallback()` hook
* Given that stepsService it's a dependency of `onNodeClick`, it needed to be moved inside a `useMemo()` hook.
* Remove `setReactFlowInstance` since seems not used
* Remove `reactFlowWrapper` since is not linked with anything
* Move inline styles to a dedicated CSS class

Fixes https://github.com/KaotoIO/vscode-kaoto/issues/132