### PR TITLE
Fix Kogito integration for empty files for which dirty marker was no

### DIFF
--- a/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
+++ b/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
@@ -102,12 +102,13 @@ function KogitoEditorIntegrationProviderInternal(
         }
 
         let intCopy = JSON.parse(JSON.stringify(integrationJson));
-        let tmpInt = {
+        const tmpInt: IIntegration = {
           ...integrationJson,
           metadata: {
             ...integrationJson.metadata,
             ...settings,
           },
+          dsl: settings.dsl.name
         };
         fetchIntegrationSourceCode(tmpInt, settings.namespace).then((newSrc) => {
           if (canceled.get()) return;


### PR DESCRIPTION
more working

The IIntegration interface has been modified in
https://github.com/KaotoIO/kaoto-ui/commit/97f3d25d4ef7661b0a2bc5287d705fc4bd549b54 , the Kogito integration must be updated accordingly.

fixes kaotoio/vscode-kaoto#158

I don't know how to provide a test for this part of the code. I reported https://github.com/KaotoIO/vscode-kaoto/issues/159 to have at least a non-regression test for this use case at VS Code Kaoto level.