### PR TITLE
Add gzip config to nginx server

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,57 +3,63 @@ worker_processes auto;
 error_log /var/log/nginx/error.log notice;
 pid /tmp/nginx.pid;
 
-events {
-  worker_connections 1024;
+events
+{
+	worker_connections 1024;
 }
 
-http {
-  proxy_temp_path /tmp/proxy_temp;
-  client_body_temp_path /tmp/client_temp;
-  fastcgi_temp_path /tmp/fastcgi_temp;
-  uwsgi_temp_path /tmp/uwsgi_temp;
-  scgi_temp_path /tmp/scgi_temp;
+http
+{
+	proxy_temp_path /tmp/proxy_temp;
+	client_body_temp_path /tmp/client_temp;
+	fastcgi_temp_path /tmp/fastcgi_temp;
+	uwsgi_temp_path /tmp/uwsgi_temp;
+	scgi_temp_path /tmp/scgi_temp;
 
-  include /etc/nginx/mime.types;
-  default_type application/octet-stream;
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
 
-  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-  '$status $body_bytes_sent "$http_referer" '
-  '"$http_user_agent" "$http_x_forwarded_for"';
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+	'$status $body_bytes_sent "$http_referer" '
+	'"$http_user_agent" "$http_x_forwarded_for"';
 
-  access_log /var/log/nginx/access.log main;
+	access_log /var/log/nginx/access.log main;
 
-  sendfile on;
-  #tcp_nopush     on;
+	sendfile on;
+	#tcp_nopush     on;
 
-  keepalive_timeout 65;
+	keepalive_timeout 65;
 
-  server {
-    listen 8080;
-    server_name $http_host;
-    #access_log  /var/log/nginx/host.access.log  main;
+	server
+	{
+		listen 8080;
+		server_name $http_host;
+		#access_log  /var/log/nginx/host.access.log  main;
 
-    location /api/ {
-      proxy_set_header Host $host;
-      proxy_pass http://kaoto-backend-svc:8081/;
-    }
+		location /api/
+		{
+			proxy_set_header Host $host;
+			proxy_pass http://kaoto-backend-svc:8081/;
+		}
 
-    location / {
-      root /usr/share/nginx/html;
-      index index.html index.htm;
-    }
+		location /
+		{
+			root /usr/share/nginx/html;
+			index index.html index.htm;
+		}
 
-    error_page 500 502 503 504 /50x.html;
-    location = /50x.html {
-      root /usr/share/nginx/html;
-    }
+		error_page 500 502 503 504 /50x.html;
+		location = /50x.html
+		{
+			root /usr/share/nginx/html;
+		}
 
-    # gzip
-    gzip on;
-    gzip_vary on;
-    gzip_proxied any;
-    gzip_comp_level 6;
-    gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
-  }
+		# gzip
+		gzip on;
+		gzip_vary on;
+		gzip_proxied any;
+		gzip_comp_level 6;
+		gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+	}
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,60 +1,59 @@
+worker_processes auto;
 
-worker_processes  auto;
-
-error_log  /var/log/nginx/error.log notice;
-pid        /tmp/nginx.pid;
-
+error_log /var/log/nginx/error.log notice;
+pid /tmp/nginx.pid;
 
 events {
-    worker_connections  1024;
+  worker_connections 1024;
 }
 
-
 http {
-    proxy_temp_path /tmp/proxy_temp;
-    client_body_temp_path /tmp/client_temp;
-    fastcgi_temp_path /tmp/fastcgi_temp;
-    uwsgi_temp_path /tmp/uwsgi_temp;
-    scgi_temp_path /tmp/scgi_temp;
+  proxy_temp_path /tmp/proxy_temp;
+  client_body_temp_path /tmp/client_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  scgi_temp_path /tmp/scgi_temp;
 
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" '
+  '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+  access_log /var/log/nginx/access.log main;
 
-    sendfile        on;
-    #tcp_nopush     on;
+  sendfile on;
+  #tcp_nopush     on;
 
-    keepalive_timeout  65;
+  keepalive_timeout 65;
 
-    #gzip  on;
-
-server {
-    listen       8080;
-    server_name  $http_host;
-
+  server {
+    listen 8080;
+    server_name $http_host;
     #access_log  /var/log/nginx/host.access.log  main;
 
-         location  /api/ {
-            proxy_set_header Host $host;
-            proxy_pass   http://kaoto-backend-svc:8081/;
+    location /api/ {
+      proxy_set_header Host $host;
+      proxy_pass http://kaoto-backend-svc:8081/;
     }
 
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+      root /usr/share/nginx/html;
+      index index.html index.htm;
     }
 
-
-    error_page   500 502 503 504  /50x.html;
+    error_page 500 502 503 504 /50x.html;
     location = /50x.html {
-        root   /usr/share/nginx/html;
+      root /usr/share/nginx/html;
     }
 
-}
-   
+    # gzip
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+  }
+
 }


### PR DESCRIPTION
### Description
At the moment, there is no gzip configuration enabled for the `nginx` server, meaning that all payloads are being sent to clients without compression.

This commit enabled gzip on the `nginx` side to reduce the amount of data transferred over the wire

### Changes
* Enable `gzip`
* Format the `nginx.conf` file using the VS Code [NGINX Configuration Language Support](https://marketplace.visualstudio.com/items?itemName=ahmadalli.vscode-nginx-conf)

| filename | size | gzip |
| --- | --- | --- |
| mini-catalog | 1.77 MB | 37.94 kB |
| catalog | 7.18 MB | 133.73 kB |

### Before
![Screenshot from 2023-03-03 11-42-31](https://user-images.githubusercontent.com/16512618/222702068-67e9826c-3b6d-40c5-8da9-d4e030f366a2.png)

### After
![Screenshot from 2023-03-03 11-47-48](https://user-images.githubusercontent.com/16512618/222702080-21a3021d-def6-4eb9-8c29-0d3620d1c93f.png)

fixes https://github.com/KaotoIO/kaoto-ui/issues/1363