### PR TITLE
Add new e2e Kaoto editor tests

### DIFF
--- a/cypress/e2e/8-code-editor-actions/code_editor_actions.cy.js
+++ b/cypress/e2e/8-code-editor-actions/code_editor_actions.cy.js
@@ -1,0 +1,110 @@
+describe('editing properties', () => {
+  beforeEach(() => {
+    let url = Cypress.config().baseUrl;
+
+    cy.visit(url);
+
+    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    cy.get('[data-testid="sourceCode--clearButton"]').should('be.visible').click({ force: true });
+    cy.get('.pf-c-code-editor__main').should('be.visible');
+  });
+
+  it('User adds step to the YAML', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('TimerKafka.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    const stepToInsert = `  steps:
+  - ref:
+      apiVersion: camel.apache.org/v1alpha1
+      name: insert-field-action
+      kind: Kamelet`;
+    const insertLine = 10;
+    cy.editorAddText(insertLine, stepToInsert);
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK the insert-field-action step was added
+    cy.get('[data-testid="viz-step-insert-field-action"]').should('be.visible');
+  });
+
+  it('User removes step from the YAML', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('TimerKafka.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+    cy.editorDeleteLine(10, 5);
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK the kafka-sink step was removed
+    cy.get('[data-testid="viz-step-kafka-sink"]').should('not.exist');
+  });
+
+  it('User edits step in the YAML', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('TimerKafka.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+    cy.editorDeleteLine(14);
+    const name = `      name: aws-s3-sink`;
+    cy.editorAddText(14, name);
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK the kafka-sink step was replaced by the aws s3 sink step
+    cy.get('[data-testid="viz-step-kafka-sink"]').should('not.exist');
+    cy.get('[data-testid="viz-step-aws-s3-sink"]').should('be.visible');
+  });
+
+  it('User Deletes branch in the YAML', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('EipAction.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+    cy.editorDeleteLine(31, 7);
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK branch with digitalocean and set header step was deleted
+    cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
+    cy.get('[data-testid="viz-step-set-header"]').should('not.exist');
+  });
+
+  it('User Add a new branch in the YAML', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('EipAction.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK atlasmap step is not
+    cy.get('[data-testid="viz-step-atlasmap"]').should('not.exist');
+
+    const stepToInsert = `          - simple: '{{}{{}?test}}'
+            steps:
+            - to:
+              uri: atlasmap:null`;
+    const insertLine = 30;
+    cy.editorAddText(insertLine, stepToInsert);
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK branch with atlasmap was created
+    cy.get('[data-testid="viz-step-atlasmap"]').should('be.visible');
+  });
+
+  it('User undoes a change they saved, syncs with canvas', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('EipAction.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+    cy.editorDeleteLine(31, 7);
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK branch with digitalocean and set header step was deleted
+    cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
+    cy.get('[data-testid="viz-step-set-header"]').should('not.exist');
+
+    // Undo and apply the reverted changes - has to click twice, as there is an alert displayed
+    cy.get('[data-testid="sourceCode--undoButton"]').click();
+    cy.get('[data-testid="sourceCode--undoButton"]').click();
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK branch with digitalocean and set header step was deleted
+    cy.get('[data-testid="viz-step-digitalocean"]').should('be.visible');
+    cy.get('[data-testid="viz-step-set-header"]').should('be.visible');
+  });
+
+  it('User uploads YAML file, syncs with canvas', () => {
+    cy.get('.pf-c-code-editor__main > input').attachFile('TimerKafka.yaml');
+    cy.get('[data-testid="sourceCode--applyButton"]').click();
+
+    // CHECK the kafka-sink and timer-source were imported
+    cy.get('[data-testid="viz-step-timer-source"]').should('be.visible');
+    cy.get('[data-testid="viz-step-kafka-sink"]').should('be.visible');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,26 +1,26 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 import 'cypress-file-upload';
+
+Cypress.Commands.add('editorAddText', (line, text) => {
+  var arr = text.split('\n');
+  Cypress._.times(arr.length, (i) => {
+    cy.get('.code-editor')
+      .click()
+      .type('{pageUp}{pageUp}' + '{downArrow}'.repeat(line + i) + '{enter}{upArrow}' + arr[i], {
+        delay: 1,
+      });
+  });
+});
+
+Cypress.Commands.add('editorDeleteLine', (line, repeatCount) => {
+  repeatCount = repeatCount ?? 1;
+  cy.get('.code-editor')
+    .click()
+    .type(
+      '{pageUp}' +
+        '{downArrow}'.repeat(line) +
+        '{shift}' +
+        '{downArrow}'.repeat(repeatCount) +
+        '{backspace}',
+      { delay: 1 }
+    );
+});


### PR DESCRIPTION
Added new Kaoto editor tests - related to https://github.com/KaotoIO/kaoto-ui/issues/1297

Code editor actions

- [x] User adds, edits, and removes a step from the YAML*
- [x] User adds and removes a branch from the YAML
- [x] User undoes a change they saved, syncs with canvas*
- [ ] User clears the state of the code editor, syncs with canvas*
- [x] User uploads YAML file, syncs with canvas
- [ ] User downloads YAML file, syncs with canvas

The item **User clears the state of the code editor, syncs with canvas** is blocked ATM by https://github.com/KaotoIO/kaoto-ui/issues/1383
The second missing item @kahboom -  **User downloads YAML file, syncs with canvas** - I may have not understood this correctly, but the download doesn't affect the editor, so is this test necessary?
