### PR TITLE
Make edge arrows bigger and more visible

### DIFF
--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -87,6 +87,12 @@ describe('visualizationService', () => {
       id: 'e-' + currentStep.id + '>' + previousStep.id,
       markerEnd: {
         type: MarkerType.Arrow,
+        color: '#d2d2d2',
+        strokeWidth: 2,
+      },
+      style: {
+        stroke: '#d2d2d2',
+        strokeWidth: 2,
       },
       source: currentStep.id,
       target: previousStep.id,

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -29,7 +29,7 @@ export class VisualizationService {
   constructor(
     private integrationJsonStore: IIntegrationJsonStore,
     private visualizationStore: RFState
-  ) {}
+  ) { }
 
   /**
    * for nodes within a branch
@@ -197,6 +197,12 @@ export class VisualizationService {
       id: `e-${sourceStep.id}>${targetStep.id}`,
       markerEnd: {
         type: MarkerType.Arrow,
+        color: '#d2d2d2',
+        strokeWidth: 2,
+      },
+      style: {
+        stroke: '#d2d2d2',
+        strokeWidth: 2,
       },
       source: sourceStep.id,
       target: targetStep.id,


### PR DESCRIPTION
Hi @kahboom!

Some settings are possible through  reactflow markers:

- The same color as node edges have
- The same strokeWidth as node edges have

Before:
![Screenshot from 2023-03-03 17-46-51](https://user-images.githubusercontent.com/46084942/222785034-57d8457e-a685-442b-8035-c9805a676f76.png)

After:
![Screenshot from 2023-03-03 18-07-42](https://user-images.githubusercontent.com/46084942/222784703-cff27f40-b227-4294-9b13-af5b97f00524.png)

Related:

- [Issue-1382](https://github.com/KaotoIO/kaoto-ui/issues/1382)

- [Markers examples](https://reactflow.dev/docs/examples/edges/markers/)

