### PR TITLE
fix(jest): Jest warning about duplicated step mock

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -42,5 +42,7 @@ module.exports = {
   // The path to a module that runs some code to configure or set up the testing framework before each test
   setupFilesAfterEnv: [path.resolve(__dirname, './setupTests.ts')],
 
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+
   testEnvironment: 'jsdom',
 };


### PR DESCRIPTION
By adding a step.ts mock file, jest creates a warning because now there are 2 mock files with the same name after the build.

### Before
![Screenshot from 2023-03-06 10-29-18](https://user-images.githubusercontent.com/16512618/223071762-d89a98b5-acea-4f38-b3e1-8746eea3a042.png)

### After
![Screenshot from 2023-03-06 10-29-39](https://user-images.githubusercontent.com/16512618/223071811-f26bbcb8-96a6-4cf9-8dc6-5443e8b07288.png)

This commit adds the dist folder to the jest config file.