### PR TITLE
fix(viz): Avoid rerendering VisualizationStepViews component

### DIFF
--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -1,7 +1,7 @@
 import { dynamicImport } from './import';
 import { Extension, JsonSchemaConfigurator, StepErrorBoundary } from '@kaoto/components';
 import { StepsService } from '@kaoto/services';
-import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
+import { useIntegrationJsonStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
 import {
   AlertVariant,
@@ -16,7 +16,7 @@ import {
   TabTitleText,
 } from '@patternfly/react-core';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { lazy, useEffect, useState } from 'react';
+import { lazy, useCallback, useEffect, useMemo, useState } from 'react';
 
 export interface IStepViewsProps {
   isPanelExpanded: boolean;
@@ -39,15 +39,15 @@ const VisualizationStepViews = ({
   const extensionConfigViewIndex = views?.findIndex((v) => v.name === 'Config');
   const hasConfigView = extensionConfigViewIndex !== -1;
   const configTabIndex = !hasConfigView ? views?.length! + 2 : extensionConfigViewIndex;
-  const nestedStepsStore = useNestedStepsStore();
-  const visualizationStore = useVisualizationStore();
-  const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
-  const [activeTabKey, setActiveTabKey] = useState(configTabIndex);
+
+  const [activeTabKey, setActiveTabKey] = useState<string | number>(configTabIndex);
   const [stepPropertySchema, setStepPropertySchema] = useState<{
     [label: string]: { type: string };
   }>({});
   const [stepPropertyModel, setStepPropertyModel] = useState<{ [label: string]: any }>({});
   const { addAlert } = useAlert() || {};
+
+  const stepsService = useMemo(() => new StepsService(), []);
 
   const alertKaoto = (title: string, body?: string, variant?: string) => {
     let variantType = AlertVariant.default;
@@ -91,15 +91,15 @@ const VisualizationStepViews = ({
       tempModelObject[propKey] = parameter.value ?? parameter.defaultValue;
     };
 
-    step.parameters?.map(schemaProps);
+    step.parameters?.forEach(schemaProps);
 
     setStepPropertySchema(tempSchemaObject);
     setStepPropertyModel(tempModelObject);
   }, [step.parameters, isPanelExpanded]);
 
-  const handleTabClick = (_event: any, tabIndex: any) => {
+  const handleTabClick = useCallback((_event: unknown, tabIndex: string | number) => {
     setActiveTabKey(tabIndex);
-  };
+  }, []);
 
   return (
     <>

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -56,23 +56,135 @@ describe('visualizationService', () => {
     });
   });
 
-  it('buildBranchSingleStepEdges(): should build edges before and after a branch with only one step', () => {
-    const node = {
-      data: {
-        step: {
-          branches: [
-            {
-              steps: [{ UUID: 'single-step' }],
-            },
-          ],
+  describe('buildBranchSingleStepEdges()', () => {
+    it('should build edges before and after a branch with only one step', () => {
+      const node = {
+        data: {
+          step: {
+            branches: [
+              {
+                steps: [{ UUID: 'single-step' }],
+              },
+            ],
+          },
         },
-      },
-    } as IVizStepNode;
-    const rootNode = {} as IVizStepNode;
-    const rootNodeNext = {} as IVizStepNode;
-    expect(
-      VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)
-    ).toHaveLength(2);
+      } as IVizStepNode;
+      const rootNode = {} as IVizStepNode;
+      const rootNodeNext = {} as IVizStepNode;
+      expect(
+        VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)
+      ).toHaveLength(2);
+    });
+
+    it('should use edgeType if exists', () => {
+      const node = {
+        data: {
+          step: {
+            branches: [
+              {
+                steps: [{ UUID: 'single-step' }],
+              },
+            ],
+          },
+        },
+      } as IVizStepNode;
+      const rootNode = {} as IVizStepNode;
+      const rootNodeNext = {} as IVizStepNode;
+
+      expect(
+        VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext, 'CUSTOM-NODE')
+      ).toEqual([
+          {
+            arrowHeadType: 'arrowclosed',
+            id: 'e-undefined>undefined',
+            markerEnd: {
+              color: '#d2d2d2',
+              strokeWidth: 2,
+              type: 'arrow'
+            },
+            source: undefined,
+            style: {
+              stroke: '#d2d2d2',
+              strokeWidth: 2
+            },
+            target: undefined,
+            type: 'CUSTOM-NODE'
+          },
+          {
+            arrowHeadType: 'arrowclosed',
+            id: 'e-undefined>undefined',
+            markerEnd: {
+              color: '#d2d2d2',
+              strokeWidth: 2,
+              type: 'arrow'
+            },
+            source: undefined,
+            style: {
+              stroke: '#d2d2d2',
+              strokeWidth: 2
+            },
+            target: undefined,
+            type: 'CUSTOM-NODE'
+          }
+        ]);
+    });
+
+    it('should use branchIdentifier as label if exists', () => {
+      const node = {
+        data: {
+          branchInfo: {
+            branchIdentifier: 'This is a fixed branch identifier',
+          },
+          step: {
+            branches: [
+              {
+                steps: [{ UUID: 'single-step' }],
+              },
+            ],
+          },
+        },
+      } as IVizStepNode;
+      const rootNode = {} as IVizStepNode;
+      const rootNodeNext = {} as IVizStepNode;
+
+      expect(
+        VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)
+      ).toEqual([
+          {
+            arrowHeadType: 'arrowclosed',
+            id: 'e-undefined>undefined',
+            label: 'This is a fixed branch identifier',
+            markerEnd: {
+              color: '#d2d2d2',
+              strokeWidth: 2,
+              type: 'arrow'
+            },
+            source: undefined,
+            style: {
+              stroke: '#d2d2d2',
+              strokeWidth: 2
+            },
+            target: undefined,
+            type: 'default'
+          },
+          {
+            arrowHeadType: 'arrowclosed',
+            id: 'e-undefined>undefined',
+            markerEnd: {
+              color: '#d2d2d2',
+              strokeWidth: 2,
+              type: 'arrow'
+            },
+            source: undefined,
+            style: {
+              stroke: '#d2d2d2',
+              strokeWidth: 2
+            },
+            target: undefined,
+            type: 'default'
+          }
+        ]);
+    });
   });
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -9,9 +9,8 @@ import {
   IVizStepPropsEdge,
 } from '@kaoto/types';
 import { getRandomArbitraryNumber, truncateString } from '@kaoto/utils';
-import { ElkExtendedEdge, ElkNode } from 'elkjs';
+import ELK, { ElkExtendedEdge, ElkNode } from 'elkjs';
 import { MarkerType, Position } from 'reactflow';
-import ELK from 'elkjs';
 
 /**
  * A collection of business logic to process visualization related tasks.


### PR DESCRIPTION
### Context
At the moment, whenever the step's detail view is open, hovering over a step forces the `VisualizationStepViews` component to rerender creating a content flash.

### Changes
Built on top of the previous commit, this commit removes the
need of binding entire stores in the following components:

- Visualization
- VisualizationStepViews

and only subscribes to the individual properties that need to be watched.

### Example

[Screencast from 2023-03-06 13-22-37.webm](https://user-images.githubusercontent.com/16512618/223109302-4e2c5e00-b9af-4303-b74c-35d4cf999caa.webm)

Fixes #1314 
