### PR TITLE
fix(viz): change outgoing edge for placeholders to default

### DIFF
--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -94,39 +94,39 @@ describe('visualizationService', () => {
       expect(
         VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext, 'CUSTOM-NODE')
       ).toEqual([
-          {
-            arrowHeadType: 'arrowclosed',
-            id: 'e-undefined>undefined',
-            markerEnd: {
-              color: '#d2d2d2',
-              strokeWidth: 2,
-              type: 'arrow'
-            },
-            source: undefined,
-            style: {
-              stroke: '#d2d2d2',
-              strokeWidth: 2
-            },
-            target: undefined,
-            type: 'CUSTOM-NODE'
+        {
+          arrowHeadType: 'arrowclosed',
+          id: 'e-undefined>undefined',
+          markerEnd: {
+            color: '#d2d2d2',
+            strokeWidth: 2,
+            type: 'arrow',
           },
-          {
-            arrowHeadType: 'arrowclosed',
-            id: 'e-undefined>undefined',
-            markerEnd: {
-              color: '#d2d2d2',
-              strokeWidth: 2,
-              type: 'arrow'
-            },
-            source: undefined,
-            style: {
-              stroke: '#d2d2d2',
-              strokeWidth: 2
-            },
-            target: undefined,
-            type: 'CUSTOM-NODE'
-          }
-        ]);
+          source: undefined,
+          style: {
+            stroke: '#d2d2d2',
+            strokeWidth: 2,
+          },
+          target: undefined,
+          type: 'CUSTOM-NODE',
+        },
+        {
+          arrowHeadType: 'arrowclosed',
+          id: 'e-undefined>undefined',
+          markerEnd: {
+            color: '#d2d2d2',
+            strokeWidth: 2,
+            type: 'arrow',
+          },
+          source: undefined,
+          style: {
+            stroke: '#d2d2d2',
+            strokeWidth: 2,
+          },
+          target: undefined,
+          type: 'default',
+        },
+      ]);
     });
 
     it('should use branchIdentifier as label if exists', () => {
@@ -147,9 +147,8 @@ describe('visualizationService', () => {
       const rootNode = {} as IVizStepNode;
       const rootNodeNext = {} as IVizStepNode;
 
-      expect(
-        VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)
-      ).toEqual([
+      expect(VisualizationService.buildBranchSingleStepEdges(node, rootNode, rootNodeNext)).toEqual(
+        [
           {
             arrowHeadType: 'arrowclosed',
             id: 'e-undefined>undefined',
@@ -157,15 +156,15 @@ describe('visualizationService', () => {
             markerEnd: {
               color: '#d2d2d2',
               strokeWidth: 2,
-              type: 'arrow'
+              type: 'arrow',
             },
             source: undefined,
             style: {
               stroke: '#d2d2d2',
-              strokeWidth: 2
+              strokeWidth: 2,
             },
             target: undefined,
-            type: 'default'
+            type: 'default',
           },
           {
             arrowHeadType: 'arrowclosed',
@@ -173,17 +172,18 @@ describe('visualizationService', () => {
             markerEnd: {
               color: '#d2d2d2',
               strokeWidth: 2,
-              type: 'arrow'
+              type: 'arrow',
             },
             source: undefined,
             style: {
               stroke: '#d2d2d2',
-              strokeWidth: 2
+              strokeWidth: 2,
             },
             target: undefined,
-            type: 'default'
-          }
-        ]);
+            type: 'default',
+          },
+        ]
+      );
     });
   });
 

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,6 +1,11 @@
 import { StepsService } from './stepsService';
 import { ValidationService } from './validationService';
-import { IIntegrationJsonStore, RFState, useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
+import {
+  IIntegrationJsonStore,
+  RFState,
+  useIntegrationJsonStore,
+  useVisualizationStore,
+} from '@kaoto/store';
 import {
   IStepProps,
   IVizStepNode,
@@ -87,7 +92,7 @@ export class VisualizationService {
 
     if (rootNextNode) {
       branchPlaceholderEdges.push(
-        VisualizationService.buildEdgeParams(node, rootNextNode, edgeType ?? 'default')
+        VisualizationService.buildEdgeParams(node, rootNextNode, 'default')
       );
     }
 


### PR DESCRIPTION
Fixes #1378, where a delete button on the right-hand side isn't working for empty branches. This delete button should never have been there to begin with. The delete button not showing on the left-hand side seems to be related to a separate issue, https://github.com/KaotoIO/kaoto-ui/issues/1277, but that button works as expected.

## Changes
- Changed the outgoing edge of a placeholder within a branch from `delete` to `default`
- Fixed expected output of edges unit test


## Screenshots
![Screen Shot 2023-03-07 at 3 06 04 pm](https://user-images.githubusercontent.com/3844502/223464779-fcd6e37c-7be3-4f31-b86f-955ebf434448.png)
