### PR TITLE
fix(SettingsModal): update description in the settings from the integration

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,7 +7,7 @@ import {
   useStepCatalogStore,
 } from '@kaoto/store';
 import { ICapabilities, ISettings } from '@kaoto/types';
-import { usePrevious } from '@kaoto/utils';
+import { getDescriptionIfExists, usePrevious } from '@kaoto/utils';
 import {
   AlertVariant,
   Button,
@@ -60,7 +60,17 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
     // update settings if there is a name change
     if (settings.name === previousName) return;
     setLocalSettings({ ...localSettings, name: settings.name });
-  }, [settings.name]);
+
+    //update the description
+    let description = getDescriptionIfExists(integrationJson);
+    if (settings.description === description) return;
+    if (description) {
+      setLocalSettings({
+        ...localSettings,
+        description: description,
+      });
+    }
+  }, [settings.name, settings.description]);
 
   useEffect(() => {
     // update settings with the default namespace fetched from the API
@@ -70,7 +80,6 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
 
   useEffect(() => {
     if (previousIntegrationJson === integrationJson) return;
-
     // subsequent changes to the integration requires fetching
     // DSLs compatible with the specific integration
     fetchCompatibleDSLs({

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import { useEffect, useRef } from 'react';
 
 export function accessibleRouteChangeHandler() {
   return window.setTimeout(() => {
@@ -141,6 +141,7 @@ export function bindUndoRedo(undoCallback: () => void, redoCallback: () => void)
 export function unbindUndoRedo(callback: (event: KeyboardEvent) => void) {
   document.removeEventListener('keydown', callback);
 }
+
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -148,4 +149,19 @@ export function sleep(ms: number) {
 export function getRandomArbitraryNumber(): number {
   const crypto = window.crypto;
   return Math.floor(crypto?.getRandomValues(new Uint32Array(1))[0]);
+}
+
+export function getDescriptionIfExists(integrationJson: any) {
+  if (integrationJson) {
+    //kamelet description location
+    if (integrationJson.metadata?.definition) {
+      return integrationJson.metadata.definition.description;
+      // integration/camel-route descipriton
+    } else if (integrationJson.description) {
+      return integrationJson.description;
+    } else if (integrationJson.metadata?.description) {
+      return integrationJson.metadata.description;
+    }
+  }
+  return undefined;
 }

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,5 +1,11 @@
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
-import { findPath, getDeepValue, getRandomArbitraryNumber, setDeepValue } from './index';
+import {
+  findPath,
+  getDeepValue,
+  getDescriptionIfExists,
+  getRandomArbitraryNumber,
+  setDeepValue,
+} from './index';
 
 describe('utils', () => {
   it('findPath(): should find the path from a deeply nested object, given a value', () => {
@@ -57,5 +63,24 @@ describe('utils', () => {
 
     expect(getRandomArbitraryNumber()).toEqual(new Uint32Array(10));
     expect(mGetRandomValues).toBeCalledWith(new Uint8Array(1));
+  });
+
+  it('test getDescription from different DSLs', () => {
+    const kamelet = {
+      metadata: {
+        definition: {
+          description: 'test',
+        },
+      },
+    };
+    const integration1 = {
+      steps: [],
+    };
+    const integration2 = { ...integration1, description: 'test' };
+    const integration3 = { ...integration1, metadata: { description: 'test' } };
+    expect(getDescriptionIfExists(kamelet)).toEqual('test');
+    expect(getDescriptionIfExists(integration1)).toEqual(undefined);
+    expect(getDescriptionIfExists(integration2)).toEqual('test');
+    expect(getDescriptionIfExists(integration3)).toEqual('test');
   });
 });


### PR DESCRIPTION
This PR updates the description in the settings from the integration. Currently the description field is present only in the Kamelet (in the backend) but this PR checks also descriptions for other DSLs.

fix #1148 
to syncing both ways also https://github.com/KaotoIO/kaoto-backend/pull/519 has to be merged. 