### PR TITLE
fix(defaultConfigTab): add setIndex to useEffect

### DIFF
--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -77,6 +77,7 @@ const VisualizationStepViews = ({
   };
 
   useEffect(() => {
+    setActiveTabKey(configTabIndex);
     let tempSchemaObject: { [label: string]: { type: string; value?: any; description?: string } } =
       {};
 
@@ -88,7 +89,7 @@ const VisualizationStepViews = ({
 
     setStepPropertySchema(tempSchemaObject);
     setStepPropertyModel(tempModelObject);
-  }, [step.parameters, isPanelExpanded]);
+  }, [step.parameters, isPanelExpanded, configTabIndex]);
 
   const handleTabClick = useCallback((_event: unknown, tabIndex: string | number) => {
     setActiveTabKey(tabIndex);


### PR DESCRIPTION
I copy my view on that problem from #1433:

ConfigTab use `useState` with the default value `configTabIndex`, but it works only for the initial Tab open, with clicking on another element it use `useEffect` without change of `configTabIndex` but it can be different for example here Choice config tab is extension and it has index 0 so without useEffect if you click on some other  step you will see a tab with index 0 (empty) and also in reverse after some general step you open choice with configtab index 2 (empty)

With that update switch between steps (with open details/config  VisualizationStepViews) always open the config tab as default

fixes #1433 