### PR TITLE
Hide Add Branch button for steps with custom extensions

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,5 +1,15 @@
 import '@testing-library/jest-dom';
 import { TextEncoder } from 'util';
 import 'whatwg-fetch';
+import { stepsCatalog } from './src/__mocks__/steps';
 
 global.TextEncoder = TextEncoder;
+
+jest.mock('@kaoto/api', () => {
+  const actual = jest.requireActual('@kaoto/api');
+
+  return {
+    ...actual,
+    fetchCatalogSteps: jest.fn().mockResolvedValue(stepsCatalog),
+  };
+});

--- a/src/__mocks__/steps.ts
+++ b/src/__mocks__/steps.ts
@@ -1,4 +1,22 @@
+import { IStepProps } from '@kaoto/types';
 import { MarkerType, Position } from 'reactflow';
+
+export const kameletSourceStepStub: IStepProps = {
+  name: 'timer-source',
+  type: 'START',
+  id: 'timer-source',
+  kind: 'Kamelet',
+  icon: 'data:image/svg+xml;base64,',
+  title: 'Timer Source',
+  description: 'Produces periodic messages with a custom payload.',
+  group: 'Timer',
+  parameters: [],
+  required: [],
+  branches: [],
+  minBranches: 0,
+  maxBranches: 1,
+  UUID: 'timer-source-0'
+}
 
 export const stepsStub = {
   nodes: [
@@ -7,22 +25,7 @@ export const stepsStub = {
         icon: 'data:image/svg+xml;base64,',
         kind: 'Kamelet',
         label: 'timer-source',
-        step: {
-          name: 'timer-source',
-          type: 'START',
-          id: 'timer-source',
-          kind: 'Kamelet',
-          icon: 'data:image/svg+xml;base64,',
-          title: 'Timer Source',
-          description: 'Produces periodic messages with a custom payload.',
-          group: 'Timer',
-          parameters: [],
-          required: [],
-          branches: null,
-          minBranches: 0,
-          maxBranches: 0,
-          UUID: 'timer-source-0'
-        },
+        step: kameletSourceStepStub,
         isPlaceholder: false,
         isLastStep: true
       },
@@ -71,3 +74,45 @@ export const integrationJSONStub = {
   ],
   params: []
 }
+
+export const stepsCatalog: IStepProps[] = [
+  {
+    name: 'activemq',
+    type: 'MIDDLE',
+    id: 'activemq-action',
+    kind: 'Camel-Connector',
+    icon: 'data:image/svg+xml;base64,',
+    title: 'ActiveMQ',
+    description: 'Send messages to (or consume from) Apache ActiveMQ. This component extends the Camel JMS component.',
+    group: 'Camel-Component',
+    minBranches: 0,
+    maxBranches: 0,
+    UUID: 'random-id-1'
+  },
+  {
+    name: 'activemq',
+    type: 'START',
+    id: 'activemq-consumer',
+    kind: 'Camel-Connector',
+    icon: 'data:image/svg+xml;base64,',
+    title: 'ActiveMQ',
+    description: 'Send messages to (or consume from) Apache ActiveMQ. This component extends the Camel JMS component.',
+    group: 'Camel-Component',
+    minBranches: 0,
+    maxBranches: 0,
+    UUID: 'random-id-2'
+  },
+  {
+    name: 'activemq',
+    type: 'END',
+    id: 'activemq-producer',
+    kind: 'Camel-Connector',
+    icon: 'data:image/svg+xml;base64,',
+    title: 'ActiveMQ',
+    description: 'Send messages to (or consume from) Apache ActiveMQ. This component extends the Camel JMS component.',
+    group: 'Camel-Component',
+    minBranches: 0,
+    maxBranches: 0,
+    UUID: 'random-id-3'
+  },
+];

--- a/src/components/AddStepButton.tsx
+++ b/src/components/AddStepButton.tsx
@@ -29,11 +29,9 @@ export const AddStepButton: FunctionComponent<IAddStepButton> = ({
   return (
     <Popover
       id="popover-append-step"
-      appendTo={() => document.body}
       aria-label="Add a step or branch"
       bodyContent={
         <MiniCatalog
-          children={<BranchBuilder handleAddBranch={handleAddBranch} />}
           disableBranchesTab={!showBranchesTab}
           disableBranchesTabMsg={ValidationService.getBranchTabTooltipMsg(
             supportsBranching,
@@ -41,22 +39,24 @@ export const AddStepButton: FunctionComponent<IAddStepButton> = ({
             step.branches?.length
           )}
           disableStepsTab={!showStepsTab}
-          disableStepsTabMsg={"You can't add a step between a step and a branch."}
+          disableStepsTabMsg="You can't add a step between a step and a branch."
           handleSelectStep={handleSelectStep}
           queryParams={{
             dsl: currentDSL,
             type: ValidationService.appendableStepTypes(step.type),
           }}
           step={step}
-        />
+        >
+          <BranchBuilder handleAddBranch={handleAddBranch} />
+        </MiniCatalog>
       }
-      className={'miniCatalog__popover'}
-      data-testid={'miniCatalog__popover'}
+      className="miniCatalog__popover"
+      data-testid="miniCatalog__popover"
       enableFlip={true}
       flipBehavior={['top-start', 'left-start']}
       hasAutoWidth
       hideOnOutsideClick={true}
-      position={'right-start'}
+      position="right-start"
       showClose={false}
     >
       <Tooltip
@@ -64,8 +64,7 @@ export const AddStepButton: FunctionComponent<IAddStepButton> = ({
       >
         <button
           className="stepNode__Add plusButton nodrag"
-          data-testid={'stepNode__appendStep-btn'}
-          aria-label="Add a step or a branch"
+          data-testid="stepNode__appendStep-btn"
         >
           <PlusIcon />
         </button>

--- a/src/components/AddStepButton.tsx
+++ b/src/components/AddStepButton.tsx
@@ -1,0 +1,75 @@
+import { ValidationService } from '@kaoto/services';
+import { useSettingsStore } from '@kaoto/store';
+import { IStepProps } from '@kaoto/types';
+import { Popover, Tooltip } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+import { BranchBuilder } from './BranchBuilder';
+import { MiniCatalog } from './MiniCatalog';
+
+interface IAddStepButton {
+  handleAddBranch: () => void;
+  handleSelectStep: (selectedStep: IStepProps) => void;
+  step: IStepProps;
+  showBranchesTab: boolean;
+  showStepsTab: boolean;
+  supportsBranching: boolean;
+}
+
+export const AddStepButton: FunctionComponent<IAddStepButton> = ({
+  handleAddBranch,
+  handleSelectStep,
+  step,
+  showBranchesTab,
+  showStepsTab,
+  supportsBranching,
+}) => {
+  const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
+
+  return (
+    <Popover
+      id="popover-append-step"
+      appendTo={() => document.body}
+      aria-label="Add a step or branch"
+      bodyContent={
+        <MiniCatalog
+          children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+          disableBranchesTab={!showBranchesTab}
+          disableBranchesTabMsg={ValidationService.getBranchTabTooltipMsg(
+            supportsBranching,
+            step.maxBranches,
+            step.branches?.length
+          )}
+          disableStepsTab={!showStepsTab}
+          disableStepsTabMsg={"You can't add a step between a step and a branch."}
+          handleSelectStep={handleSelectStep}
+          queryParams={{
+            dsl: currentDSL,
+            type: ValidationService.appendableStepTypes(step.type),
+          }}
+          step={step}
+        />
+      }
+      className={'miniCatalog__popover'}
+      data-testid={'miniCatalog__popover'}
+      enableFlip={true}
+      flipBehavior={['top-start', 'left-start']}
+      hasAutoWidth
+      hideOnOutsideClick={true}
+      position={'right-start'}
+      showClose={false}
+    >
+      <Tooltip
+        content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
+      >
+        <button
+          className="stepNode__Add plusButton nodrag"
+          data-testid={'stepNode__appendStep-btn'}
+          aria-label="Add a step or a branch"
+        >
+          <PlusIcon />
+        </button>
+      </Tooltip>
+    </Popover>
+  );
+}

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -156,7 +156,7 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/step has a Custom Step Extension/,);
+      const tooltip = screen.getByText(/Please click on the step to configure branches for it./,);
       expect(tooltip).toBeInTheDocument();
     });
 

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -1,0 +1,166 @@
+import { StepsService } from '@kaoto/services';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { kameletSourceStepStub } from '../__mocks__/steps';
+import { AlertProvider } from '../layout';
+import { AppendStepButton } from './AppendStepButton';
+
+describe('AppendStepButton.tsx', () => {
+  const noopFn = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('component renders', () => {
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          showBranchesTab={true}
+          showStepsTab={true}
+          supportsBranching={true}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const element = screen.queryByTestId('stepNode__appendStep-btn');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('should display MiniCatalog when clicking on the plus icon', async () => {
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          showBranchesTab={true}
+          showStepsTab={true}
+          supportsBranching={true}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const element = screen.getByTestId('stepNode__appendStep-btn');
+    fireEvent.click(element);
+
+    await waitFor(() => {
+      const miniCatalog = screen.getByTestId('miniCatalog');
+      expect(miniCatalog).toBeInTheDocument();
+    });
+  });
+
+  test('should disable branches tab when reaching the max branches qty', async () => {
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          showBranchesTab={false}
+          showStepsTab={true}
+          supportsBranching={true}
+          step={{ ...kameletSourceStepStub, maxBranches: 1, branches: [{ branchUuid: 'random-uuid', identifier: 'branch-1', steps: [] }] }}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    fireEvent.click(plusIcon);
+
+    await waitFor(() => {
+      screen.getByTestId('miniCatalog__branches');
+    });
+
+    const branchTab = screen.getByTestId('miniCatalog__branches');
+
+    act(() => {
+      fireEvent.mouseEnter(branchTab);
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(/Max number of branches reached/,);
+      expect(tooltip).toBeInTheDocument();
+    });
+  });
+
+  test('should disable branches tab when showBranchesTab={false} and supportsBranching={false}', async () => {
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          showBranchesTab={false}
+          showStepsTab={true}
+          supportsBranching={false}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    fireEvent.click(plusIcon);
+
+    await waitFor(() => {
+      screen.getByTestId('miniCatalog__branches');
+    });
+
+    const branchTab = screen.getByTestId('miniCatalog__branches');
+
+    act(() => {
+      fireEvent.mouseEnter(branchTab);
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(/step doesn't support branching/,);
+      expect(tooltip).toBeInTheDocument();
+    });
+  });
+
+  test('should disable branches tab when the step has a CustomStepExtension', async () => {
+    const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(true);
+
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          showBranchesTab={true}
+          showStepsTab={true}
+          supportsBranching={true}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    fireEvent.click(plusIcon);
+
+    await waitFor(() => {
+      screen.getByTestId('miniCatalog__branches');
+    });
+
+    const branchTab = screen.getByTestId('miniCatalog__branches');
+
+    act(() => {
+      fireEvent.mouseEnter(branchTab);
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(/step has a Custom Step Extension/,);
+      expect(tooltip).toBeInTheDocument();
+    });
+
+    spy.mockReset();
+  });
+
+});

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -35,7 +35,7 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
 
   useEffect(() => {
     if (hasCustomStepExtension) {
-      setDisableBranchesTabMsg(`The "${step.name}" step has a Custom Step Extension, please click on the step to configure it`);
+      setDisableBranchesTabMsg("Please click on the step to configure branches for it.");
       return;
     }
 

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -13,7 +13,7 @@ import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { AddStepButton } from './AddStepButton';
+import { AppendStepButton } from './AppendStepButton';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -209,7 +209,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
           {/* ADD/APPEND STEP BUTTON */}
           {VisualizationService.showAppendStepButton(data, endStep)
-            && <AddStepButton
+            && <AppendStepButton
               handleAddBranch={handleAddBranch}
               handleSelectStep={onMiniCatalogClickAppend}
               step={data.step}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -13,6 +13,7 @@ import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
+import { AddStepButton } from './AddStepButton';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -208,49 +209,14 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
           {/* ADD/APPEND STEP BUTTON */}
           {VisualizationService.showAppendStepButton(data, endStep) ? (
-            <Popover
-              id="popover-append-step"
-              appendTo={() => document.body}
-              aria-label="Add a step or branch"
-              bodyContent={
-                <MiniCatalog
-                  children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-                  disableBranchesTab={!showBranchesTab}
-                  disableBranchesTabMsg={ValidationService.getBranchTabTooltipMsg(
-                    supportsBranching,
-                    data.step.maxBranches,
-                    data.step.branches?.length
-                  )}
-                  disableStepsTab={!showStepsTab}
-                  disableStepsTabMsg={"You can't add a step between a step and a branch."}
-                  handleSelectStep={onMiniCatalogClickAppend}
-                  queryParams={{
-                    dsl: currentDSL,
-                    type: ValidationService.appendableStepTypes(data.step.type),
-                  }}
-                  step={data.step}
-                />
-              }
-              className={'miniCatalog__popover'}
-              data-testid={'miniCatalog__popover'}
-              enableFlip={true}
-              flipBehavior={['top-start', 'left-start']}
-              hasAutoWidth
-              hideOnOutsideClick={true}
-              position={'right-start'}
-              showClose={false}
-            >
-              <Tooltip
-                content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
-              >
-                <button
-                  className="stepNode__Add plusButton nodrag"
-                  data-testid={'stepNode__appendStep-btn'}
-                >
-                  <PlusIcon />
-                </button>
-              </Tooltip>
-            </Popover>
+            <AddStepButton
+              handleAddBranch={handleAddBranch}
+              handleSelectStep={onMiniCatalogClickAppend}
+              step={data.step}
+              showBranchesTab={showBranchesTab}
+              showStepsTab={showStepsTab}
+              supportsBranching={supportsBranching}
+            />
           ) : (
             <></>
           )}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -208,8 +208,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* ADD/APPEND STEP BUTTON */}
-          {VisualizationService.showAppendStepButton(data, endStep) ? (
-            <AddStepButton
+          {VisualizationService.showAppendStepButton(data, endStep)
+            && <AddStepButton
               handleAddBranch={handleAddBranch}
               handleSelectStep={onMiniCatalogClickAppend}
               step={data.step}
@@ -217,9 +217,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               showStepsTab={showStepsTab}
               supportsBranching={supportsBranching}
             />
-          ) : (
-            <></>
-          )}
+          }
         </div>
       ) : (
         <Popover

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -3,7 +3,7 @@ import nestedBranch from '../store/data/kamelet.nested-branch.steps';
 import steps from '../store/data/steps';
 import { StepsService } from './stepsService';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
-import { IStepProps, IStepPropsBranch } from '@kaoto/types';
+import { IStepProps, IStepPropsBranch, IViewProps } from '@kaoto/types';
 
 describe('stepsService', () => {
   const stepsService = new StepsService(
@@ -165,6 +165,44 @@ describe('stepsService', () => {
     ).toBeFalsy();
 
     expect(StepsService.supportsBranching({ UUID: 'no-branches' } as IStepProps)).toBeFalsy();
+  });
+
+  describe('hasCustomStepExtension()', () => {
+    it('should return "false" for empty views', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [] as IViewProps[],
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return "false" for a matching view with no URL available', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [{ step: 'random-id', url: '' }] as IViewProps[],
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return "false" for non-matching views', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [{ step: 'not-a-random-id', url: '/dev/null' }] as IViewProps[],
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return "true" for matching views and an URL available', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [{ step: 'random-id', url: '/dev/null' }] as IViewProps[],
+      );
+
+      expect(result).toBeTruthy();
+    });
   });
 
   it('buildStepSchemaAndModel():should ignore empty array parameter', () => {

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -21,6 +21,7 @@ import {
   INestedStep,
   IStepProps,
   IStepPropsBranch,
+  IViewProps,
   IVizStepNode,
   IVizStepNodeData,
 } from '@kaoto/types';
@@ -515,6 +516,16 @@ export class StepsService {
   static supportsBranching(step?: IStepProps) {
     if (!step) return false;
     return !!(step.minBranches || step.maxBranches);
+  }
+
+
+  /**
+   * Determines if a given step has a custom step extension
+   * @param step
+   * @param views
+   */
+  static hasCustomStepExtension(step: IStepProps, views: IViewProps[]): boolean {
+    return views.findIndex((view) => view.step === step.UUID && view.url) !== -1;
   }
 
   /**


### PR DESCRIPTION
### Description
Taking as an example the `choice` EIP, currently there's no mechanism in place to determine whether a newly created branch it's from a `when` or `otherwise` type of branch hence the need for the custom step extension.

For said steps, displaying the `Add branch` button to the users might be confusing as adding empty branches leads to creating only one type of branch, also, if steps are added on said branches, those steps are lost upon syncing with the backend :cry: .

### Changes
* Extract a section of the `VisualizationStep` component into a dedicated `AppendStep` component to ease testing and as an initial step to remove not necessary logic from the `VisualizationStep` component
* Evaluate whether a given step has a Custom Step View in order to disable the `Add branch` button and display a tooltip explaining the reason to the user
![image](https://user-images.githubusercontent.com/16512618/224362713-78c43a95-f456-4c65-9f4e-18a37114b01b.png)
* In case a step doesn't have a Custom Step View, we allow creating branches from the Mini Catalog :tm: 
![image](https://user-images.githubusercontent.com/16512618/224362978-ffdd0696-c5ea-4526-8a5c-d46d104c3b71.png)

Fixes #1381