### PR TITLE
Add E2E branches step actions

### DIFF
--- a/cypress/e2e/10-branching_actions_from_canvas/branches_step_actions_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/branches_step_actions_from_canvas.cy.js
@@ -1,0 +1,37 @@
+describe('User completes normal actions on steps in a branch', () => {
+    beforeEach(() => {
+        cy.intercept('/v1/integrations/dsls').as('getDSLs');
+        cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+        cy.intercept('/v1/integrations*').as('getIntegration');
+
+        cy.openHomePage();
+        cy.uploadInitialState('EipAction.yaml');
+    });
+
+    it('User configures a step in a branch', () => {
+        cy.openStepConfigurationTab('digitalocean');
+
+        cy.interactWithInputObject('lazyStartProducer');
+        cy.interactWithInputObject('oAuthToken', 'token');
+
+        // CHECK that the step yaml is updated
+        cy.checkCodeSpanLine('lazyStartProducer', "true");
+        cy.checkCodeSpanLine('oAuthToken', "token");
+    });
+
+    it(' User deletes a step in a branch', () => {
+        cy.deleteStep('digitalocean');
+        cy.syncUpCodeChanges();
+
+        // CHECK that digitalocean step is deleted
+        cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
+    });
+
+    it('User replaces a step in a branch', () => {
+        cy.dragAndDropFromCatalog('amqp', 'digitalocean');
+
+        // CHECK digitalocean step was replaced with amqp
+        cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
+        cy.get('[data-testid="viz-step-amqp"]').should('have.length', 1).and('be.visible');
+    });
+});

--- a/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
@@ -1,0 +1,55 @@
+describe('User completes normal actions on steps in a branch', () => {
+    beforeEach(() => {
+        cy.intercept('/v1/integrations/dsls').as('getDSLs');
+        cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+        cy.intercept('/v1/integrations*').as('getIntegration');
+
+        cy.openHomePage();
+        cy.uploadInitialState('EipAction.yaml');
+
+        // Blocked due to: https://github.com/KaotoIO/kaoto-ui/issues/1381
+        // cy.insertBranch(3);
+        // cy.replaceEmptyStepMiniCatalog('activemq');
+        // cy.appendBranch(1);
+        // cy.replaceEmptyStepMiniCatalog('amqp');
+
+        // Workaround for: https://github.com/KaotoIO/kaoto-ui/issues/1381
+        cy.get('.react-flow__controls-button.react-flow__controls-zoomout').click().click().click();
+        cy.openStepConfigurationTab('choice', 1);
+        cy.addBranchChoiceExtension();
+        cy.addBranchChoiceExtension('other');
+        cy.editBranchCondition(0, 'jq-condition', 'jq');
+        cy.closeStepConfigurationTab();
+        cy.replaceEmptyStepMiniCatalog('activemq', 1);
+        cy.replaceEmptyStepMiniCatalog('amqp');
+    });
+
+    it('User configures a step in a branch', () => {
+        cy.openStepConfigurationTab('amqp');
+
+        cy.interactWithInputObject('includeSentJMSMessageID');
+        cy.interactWithInputObject('password', 'qwerty');
+
+        // CHECK that the step yaml is updated
+        cy.checkCodeSpanLine('includeSentJMSMessageID', 'true');
+        cy.checkCodeSpanLine('password', 'qwerty');
+    });
+
+    it(' User deletes a step in a branch', () => {
+        cy.deleteStep('amqp');
+        // Blocked due to: https://github.com/KaotoIO/kaoto-ui/issues/1381
+        // cy.syncUpCodeChanges();
+
+        // CHECK that amqp step is deleted and empty step is added
+        cy.get('[data-testid="viz-step-amqp"]').should('not.exist');
+        cy.get('[data-testid="viz-step-slot"]').should('have.length', 1).and('be.visible');
+    });
+
+    it('User replaces a step in a branch', () => {
+        cy.dragAndDropFromCatalog('arangodb', 'activemq');
+
+        // CHECK digitalocean step was replaced with amqp
+        cy.get('[data-testid="viz-step-activemq"]').should('not.exist');
+        cy.get('[data-testid="viz-step-arangodb"]').should('have.length', 1).and('be.visible');
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -50,17 +50,23 @@ Cypress.Commands.add('waitVisualizationUpdate', () => {
   cy.wait('@getViewDefinitions');
 });
 
+Cypress.Commands.add('replaceEmptyStepMiniCatalog', (step, stepIndex) => {
+  stepIndex = stepIndex ?? 0;
+  cy.get('[data-testid="viz-step-slot"]').eq(stepIndex).click();
+  cy.selectStepMiniCatalog(step);
+});
+
 Cypress.Commands.add('appendStepMiniCatalog', (step, appendedStep, stage, stepIndex) => {
   stepIndex = stepIndex ?? 0;
   cy.get(`[data-testid="viz-step-${step}"]`).eq(stepIndex).children('[data-testid="stepNode__appendStep-btn"]').click();
   cy.selectStepMiniCatalog(appendedStep, stage);
-})
+});
 
 Cypress.Commands.add('insertStepMiniCatalog', (step, insertIndex) => {
   insertIndex = insertIndex ?? 0;
   cy.get('[data-testid="stepNode__insertStep-btn"]').eq(insertIndex).click();
   cy.selectStepMiniCatalog(step);
-})
+});
 
 Cypress.Commands.add('selectStepMiniCatalog', (step, stage) => {
   if (stage != null) { cy.get(`[data-testid="miniCatalog__step-${stage}"]`).click(); }
@@ -77,12 +83,82 @@ Cypress.Commands.add('syncUpCodeChanges', () => {
 
 Cypress.Commands.add('openStepConfigurationTab', (step, stepIndex) => {
   stepIndex = stepIndex ?? 0;
-  cy.get(`[data-testid="viz-step-${step}"]`).eq(0).click();
+  cy.get(`[data-testid="viz-step-${step}"]`).eq(stepIndex).click();
   cy.get('[data-testid="configurationTab"]').click();
+});
+
+Cypress.Commands.add('closeStepConfigurationTab', () => {
+  cy.get('.pf-c-button.pf-m-plain').click();
 });
 
 Cypress.Commands.add('checkCodeSpanLine', (firstSpan, secondSpan) => {
   cy.get('.code-editor').contains(firstSpan).parent()
     .should('contain.text', firstSpan)
     .and('contain.text', secondSpan)
+});
+
+Cypress.Commands.add('interactWithInputObject', (inputName, value) => {
+  if (value != null) {
+    cy.get(`input[name="${inputName}"]`).clear().type(value);
+  } else {
+    cy.get(`input[name="${inputName}"]`).click();
+  }
+});
+
+Cypress.Commands.add('dragAndDropFromCatalog', (source, target, targetIndex) => {
+  targetIndex = targetIndex ?? 0;
+  const dataTransfer = new DataTransfer();
+  cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
+  cy.get('[data-testid="catalog-step-actions"]').click();
+  cy.get('#stepSearch').type(`${source}`);
+  cy.get(`[data-testid="catalog-step-${source}"]`).trigger('dragstart', {
+    dataTransfer,
+  });
+  cy.get(`[data-testid="viz-step-${target}"]`).eq(targetIndex).trigger('drop', {
+    dataTransfer,
+  });
+});
+
+// Blocked due to: https://github.com/KaotoIO/kaoto-ui/issues/1381
+// Cypress.Commands.add('insertBranch', (insertIndex) => {
+//   insertIndex = insertIndex ?? 0;
+//   cy.get('[data-testid="stepNode__insertStep-btn"]').eq(insertIndex).click();
+//   cy.get('[data-testid="miniCatalog__branches"]').click();
+//   cy.get('[data-testid="addBranch__button"]').click();
+//   cy.waitVisualizationUpdate();
+// });
+
+// Cypress.Commands.add('appendBranch', (choiceIndex) => {
+//   choiceIndex = choiceIndex ?? 0;
+//   cy.get('[data-testid="viz-step-choice"]').eq(choiceIndex).children('[data-testid="stepNode__appendStep-btn"]').click();
+//   cy.get('[data-testid="miniCatalog__branches"]').click();
+//   cy.get('[data-testid="addBranch__button"]').click();
+//   cy.waitVisualizationUpdate();
+// });
+
+Cypress.Commands.add('addBranchChoiceExtension', (otherwise) => {
+  otherwise = otherwise ?? null;
+  if (otherwise === null) {
+    cy.get('[data-testid="choice-add-when-button"]').click();
+    cy.get('.pf-c-alert').contains(/When: \d added/);
+  } else {
+    cy.get('[data-testid="choice-add-otherwise-button"]').click();
+    cy.get('.pf-c-alert').should('contain.text', 'Otherwise added');
+  }
+  cy.get('.pf-c-alert__action').children('button').click();
+  cy.waitVisualizationUpdate();
+});
+
+Cypress.Commands.add('editBranchCondition', (whenIndex, condition, type) => {
+  type = type ?? 'simple';
+  if (type === 'jq') {
+    cy.get(`[data-testid="when-${whenIndex}-predicate-syntax-select"]`).should('be.visible').select('Jq')
+    cy.get(`[data-testid="when-${whenIndex}-predicate-string-input"]`).clear().type(condition);
+  } else if (type === 'simple') {
+    cy.get(`[data-testid="when-${whenIndex}-predicate-string-input"]`).clear().type(condition);
+  }
+  cy.get('[data-testid="choice-apply-button"]').click();
+  cy.get('.pf-c-alert').should('contain.text', 'Choice step updated');
+  cy.get('.pf-c-alert__action').children('button').click();
+  cy.waitVisualizationUpdate();
 });


### PR DESCRIPTION
Added new Kaoto canvas tests - related to https://github.com/KaotoIO/kaoto-ui/issues/1297

Branching actions from the canvas:

#### User completes normal actions on steps in a branch:
- [x] User configures a step in a branch 
- [x] User deletes a step in a branch
- [x] User replaces a step in a branch

#### User completes normal actions on steps in a nested branch:
- [x] User configures a step in a nested branch 
- [x] User deletes a step in a nested branch
- [x] User replaces a step in a nested branch
