### PR TITLE
fix(1379): improve layouting

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@patternfly/react-table": "4.112.39",
     "@rhoas/app-services-ui-shared": "^0.16.6",
     "ajv": "^8.12.0",
+    "dagre": "^0.8.5",
     "elkjs": "^0.8.2",
     "immer": "^9.0.19",
     "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@rhoas/app-services-ui-shared": "^0.16.6",
     "ajv": "^8.12.0",
     "dagre": "^0.8.5",
-    "elkjs": "^0.8.2",
     "immer": "^9.0.19",
     "lodash.isequal": "^4.5.0",
     "monaco-editor": "^0.36.1",

--- a/src/components/VisualizationControls.tsx
+++ b/src/components/VisualizationControls.tsx
@@ -12,14 +12,14 @@ export const VisualizationControls = () => {
   return (
     <Controls className={'visualization__controls'}>
       {/* VERTICAL BUTTON */}
-      <ControlButton onClick={() => setLayout('DOWN')}>
+      <ControlButton onClick={() => setLayout('TB')}>
         <Icon>
           <img src={vertical} alt={'Vertical'} />
         </Icon>
       </ControlButton>
 
       {/* HORIZONTAL BUTTON */}
-      <ControlButton onClick={() => setLayout('RIGHT')}>
+      <ControlButton onClick={() => setLayout('LR')}>
         <Icon>
           <img src={horizontal} alt={'Horizontal'} />
         </Icon>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -171,7 +171,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <Handle
               isConnectable={false}
               type="target"
-              // position={visualizationStore.layout === 'RIGHT' ? Position.Left : Position.Top}
               position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
               id="a"
               style={{ borderRadius: 0 }}
@@ -202,7 +201,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <Handle
               isConnectable={false}
               type="source"
-              // position={visualizationStore.layout === 'RIGHT' ? Position.Right : Position.Bottom}
               position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
               style={{ borderRadius: 0 }}
@@ -266,7 +264,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               <Handle
                 isConnectable={false}
                 type="target"
-                // position={visualizationStore.layout === 'RIGHT' ? Position.Left : Position.Top}
                 position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
                 id="a"
                 style={{ borderRadius: 0 }}
@@ -281,7 +278,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             <Handle
               type="source"
-              // position={visualizationStore.layout === 'RIGHT' ? Position.Right : Position.Bottom}
               position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
               style={{ borderRadius: 0 }}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -171,7 +171,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <Handle
               isConnectable={false}
               type="target"
-              position={visualizationStore.layout === 'RIGHT' ? Position.Left : Position.Top}
+              // position={visualizationStore.layout === 'RIGHT' ? Position.Left : Position.Top}
+              position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
               id="a"
               style={{ borderRadius: 0 }}
             />
@@ -201,7 +202,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <Handle
               isConnectable={false}
               type="source"
-              position={visualizationStore.layout === 'RIGHT' ? Position.Right : Position.Bottom}
+              // position={visualizationStore.layout === 'RIGHT' ? Position.Right : Position.Bottom}
+              position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
               style={{ borderRadius: 0 }}
             />
@@ -264,7 +266,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               <Handle
                 isConnectable={false}
                 type="target"
-                position={visualizationStore.layout === 'RIGHT' ? Position.Left : Position.Top}
+                // position={visualizationStore.layout === 'RIGHT' ? Position.Left : Position.Top}
+                position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
                 id="a"
                 style={{ borderRadius: 0 }}
               />
@@ -278,7 +281,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             <Handle
               type="source"
-              position={visualizationStore.layout === 'RIGHT' ? Position.Right : Position.Bottom}
+              // position={visualizationStore.layout === 'RIGHT' ? Position.Right : Position.Bottom}
+              position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
               style={{ borderRadius: 0 }}
               isConnectable={false}

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -16,3 +16,5 @@ Contains methods pertaining to validation of Steps. These methods ensure that th
 
 ### visualizationService
 Contains methods pertaining to any mutations for the canvas or visualization. This is where you build nodes, find nodes, etc. Example methods: `buildNodesAndEdges`
+
+**NOTE:** Check the [elkjs branch](https://github.com/KaotoIO/kaoto-ui/tree/elkjs) to see Kaoto layouting with ELK instead of Dagre.

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -9,6 +9,7 @@ import {
   IVizStepNode,
   IVizStepNodeData,
   IVizStepNodeDataBranch,
+  IVizStepPropsEdge,
 } from '@kaoto/types';
 import { truncateString } from '@kaoto/utils';
 import { MarkerType, Position } from 'reactflow';
@@ -17,9 +18,6 @@ describe('visualizationService', () => {
   const groupWidth = 80;
   const baseStep = { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '' };
 
-  /**
-   * buildBranchNodeParams
-   */
   it('buildBranchNodeParams(): should build params for a branch node', () => {
     const currentStep = steps[3];
     const nodeId = 'node_example-1234';
@@ -187,9 +185,6 @@ describe('visualizationService', () => {
     });
   });
 
-  /**
-   * buildEdgeParams
-   */
   it("buildEdgeParams(): should build an edge's default parameters for a single given node", () => {
     const currentStep = nodes[1];
     const previousStep = nodes[0];
@@ -212,9 +207,6 @@ describe('visualizationService', () => {
     });
   });
 
-  /**
-   * buildEdges
-   */
   it('buildEdges(): should build an edge for every node except the first, given an array of nodes', () => {
     const nodes = [
       {
@@ -241,9 +233,6 @@ describe('visualizationService', () => {
     expect(VisualizationService.buildEdges(stepNodes)).toHaveLength(branchSteps.length - 1);
   });
 
-  /**
-   * buildNodeDefaultParams
-   */
   it('buildNodeDefaultParams(): should build the default parameters for a single node, given a step', () => {
     const position = { x: 0, y: 0 };
     const step = { name: 'avro-deserialize-action', icon: '', kind: 'Kamelet' } as IStepProps;
@@ -270,27 +259,18 @@ describe('visualizationService', () => {
     });
   });
 
-  /**
-   * buildNodesFromSteps
-   */
   it('buildNodesFromSteps(): should build visualization nodes from an array of steps', () => {
     const stepNodes = VisualizationService.buildNodesFromSteps(steps, 'RIGHT');
     expect(stepNodes[0].data.step.UUID).toBeDefined();
     expect(stepNodes[0].id).toContain(stepNodes[0].data.step.UUID);
   });
 
-  /**
-   * buildNodesFromSteps for integrations with branches
-   */
   it.skip('buildNodesFromSteps(): should build visualization nodes from an array of steps with branches', () => {
     const stepNodes = VisualizationService.buildNodesFromSteps(branchSteps, 'RIGHT');
     expect(stepNodes[0].data.step.UUID).toBeDefined();
     expect(stepNodes).toHaveLength(branchSteps.length);
   });
 
-  /**
-   * containsAddStepPlaceholder
-   */
   it('containsAddStepPlaceholder(): should determine if there is an ADD STEP placeholder in the steps', () => {
     const nodes = [
       {
@@ -327,12 +307,58 @@ describe('visualizationService', () => {
     ).toBe(false);
   });
 
-  /**
-   * findNodeIdxWithUUID
-   */
   it('findNodeIdxWithUUID(): should find a node from an array of nodes, given a UUID', () => {
     expect(VisualizationService.findNodeIdxWithUUID(nodes[0].data.step.UUID, nodes)).toBe(0);
     expect(VisualizationService.findNodeIdxWithUUID(nodes[1].data.step.UUID, nodes)).toBe(1);
+  });
+
+  it('getLayoutedElements(): given an array of nodes and edges, return them with the correct graph layout', () => {
+    const nodes: IVizStepNode[] = [
+      { data: { step: {} } } as IVizStepNode,
+      { data: { step: {} } } as IVizStepNode,
+    ];
+    const edges: IVizStepPropsEdge[] = [
+      {
+        arrowHeadType: 'arrowclosed',
+        id: 'some-id',
+        markerEnd: { type: 'arrow', color: '', strokeWidth: 2 },
+        style: { stroke: '', strokeWidth: 2 },
+        source: 'one',
+        target: 'two',
+        type: 'insert',
+      } as IVizStepPropsEdge,
+    ];
+    let direction: string = 'LR';
+
+    return VisualizationService.getLayoutedElements(nodes, edges, direction).then((res) => {
+      const { layoutedNodes, layoutedEdges } = res;
+
+      expect(layoutedNodes).toEqual([
+        {
+          data: { step: {} },
+          position: { x: 0, y: 0 },
+          sourcePosition: 'right',
+          targetPosition: 'left',
+        },
+        {
+          data: { step: {} },
+          position: { x: 0, y: 0 },
+          sourcePosition: 'right',
+          targetPosition: 'left',
+        },
+      ]);
+      expect(layoutedEdges).toEqual([
+        {
+          arrowHeadType: 'arrowclosed',
+          id: 'some-id',
+          markerEnd: { type: 'arrow', color: '', strokeWidth: 2 },
+          style: { stroke: '', strokeWidth: 2 },
+          source: 'one',
+          target: 'two',
+          type: 'insert',
+        },
+      ]);
+    });
   });
 
   it('getNodeClass(): given two strings to compare and a class name, returns the class name if they match', () => {
@@ -349,18 +375,12 @@ describe('visualizationService', () => {
     ).toEqual(' stepNode__Hover');
   });
 
-  /**
-   * insertAddStepPlaceholder
-   */
   it('insertAddStepPlaceholder(): should add an ADD STEP placeholder to the beginning of the array', () => {
     const nodes: IVizStepNode[] = [];
     VisualizationService.insertAddStepPlaceholder(nodes, '', 'START', { nextStepUuid: '' });
     expect(nodes).toHaveLength(1);
   });
 
-  /**
-   * insertBranchGroupNode
-   */
   it.skip('insertBranchGroupNode', () => {
     const nodes: IVizStepNode[] = [];
     VisualizationService.insertBranchGroupNode(nodes, { x: 0, y: 0 }, 150, groupWidth);
@@ -380,9 +400,6 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
-  /**
-   * shouldAddEdge
-   */
   it('shouldAddEdge(): given a node, should determine whether to add an edge for it', () => {
     const nodeWithoutBranches = {
       id: 'node-without-branches',

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -14,7 +14,9 @@ import {
   IVizStepPropsEdge,
 } from '@kaoto/types';
 import { getRandomArbitraryNumber, truncateString } from '@kaoto/utils';
-import ELK, { ElkExtendedEdge, ElkNode } from 'elkjs';
+// import ELK, { ElkExtendedEdge, ElkNode } from 'elkjs';
+// @ts-ignore
+import dagre from 'dagre';
 import { MarkerType, Position } from 'reactflow';
 
 /**
@@ -410,72 +412,122 @@ export class VisualizationService {
     edges: IVizStepPropsEdge[],
     direction: string
   ) {
+    const dagreGraph = new dagre.graphlib.Graph();
+    dagreGraph.setDefaultEdgeLabel(() => ({}));
+
     const DEFAULT_WIDTH_HEIGHT = 80;
-    const isHorizontal = direction === 'RIGHT';
-
-    const elk = new ELK({
-      defaultLayoutOptions: {
-        'elk.algorithm': 'layered',
-        'elk.direction': direction,
-
-        // vertical spacing of nodes
-        'elk.spacing.nodeNode': `${DEFAULT_WIDTH_HEIGHT / 2}`,
-
-        // ensures balanced, linear graph from beginning to end
-        'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-
-        // *between handles horizontal spacing
-        'elk.layered.spacing.nodeNodeBetweenLayers': `${DEFAULT_WIDTH_HEIGHT}`,
-        'elk.layered.spacing.edgeEdgeBetweenLayers': `${DEFAULT_WIDTH_HEIGHT * 1.5}`,
-        'spacing.componentComponent': '70',
-        spacing: '75',
-
-        // ensures correct order of nodes (particularly important for branches)
-        'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
-      },
+    // const isHorizontal = direction === 'RIGHT';
+    const isHorizontal = direction === 'LR';
+    dagreGraph.setGraph({
+      // edgesep: DEFAULT_WIDTH_HEIGHT,
+      // nodesep: DEFAULT_WIDTH_HEIGHT,
+      rankdir: direction,
+      ranksep: DEFAULT_WIDTH_HEIGHT,
     });
 
-    const elkNodes: ElkNode[] = [];
-    const elkEdges: ElkExtendedEdge[] = [];
-
-    nodes.forEach((flowNode) => {
-      elkNodes.push({
-        id: flowNode.id,
-        width: flowNode.width ?? DEFAULT_WIDTH_HEIGHT,
-        height: flowNode.height ?? DEFAULT_WIDTH_HEIGHT,
+    nodes.forEach((node) => {
+      dagreGraph.setNode(node.id, {
+        width: node.width ?? DEFAULT_WIDTH_HEIGHT,
+        height: node.height ?? DEFAULT_WIDTH_HEIGHT,
       });
     });
 
-    edges.forEach((flowEdge) => {
-      elkEdges.push({
-        id: flowEdge.id,
-        targets: [flowEdge.target],
-        sources: [flowEdge.source],
-      });
+    edges.forEach((edge) => {
+      dagreGraph.setEdge(edge.source, edge.target);
     });
 
-    const newGraph = await elk.layout({
-      id: 'root',
-      portConstraints: 'FIXED_ORDER',
-      children: elkNodes,
-      edges: elkEdges,
-    } as ElkNode);
+    dagre.layout(dagreGraph);
 
     nodes.forEach((flowNode) => {
-      const node = newGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
-      if (node?.x && node?.y && node?.width && node?.height) {
-        flowNode.position = {
-          x: node.x - node.width / 2,
-          y: node.y - node.height / 2,
-        };
+      // const node = dagreGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
+      // if (node?.x && node?.y && node?.width && node?.height) {
+      const nodeWithPosition = dagreGraph.node(flowNode.id);
+      // flowNode.targetPosition = isHorizontal ? 'left' : 'top';
+      // flowNode.sourcePosition = isHorizontal ? 'right' : 'bottom';
 
-        flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
-        flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
-      }
+      // We are shifting the dagre node position (anchor=center center) to the top left,
+      // so it matches the React Flow node anchor point (top left).
+      flowNode.position = {
+        x: nodeWithPosition.x - nodeWithPosition.width / 2,
+        y: nodeWithPosition.y - nodeWithPosition.height / 2,
+        // x: node.x - node.width / 2,
+        // y: node.y - node.width / 2
+        // x: nodeWithPosition.x - nodeWidth / 2,
+        // y: nodeWithPosition.y - nodeHeight / 2,
+      };
+
+      flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
+      flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
+      // }
+
       return flowNode;
     });
 
     return { layoutedNodes: nodes, layoutedEdges: edges };
+
+    // const elk = new ELK({
+    //   defaultLayoutOptions: {
+    //     'elk.algorithm': 'layered',
+    //     'elk.direction': direction,
+    //
+    //     // vertical spacing of nodes
+    //     'elk.spacing.nodeNode': `${DEFAULT_WIDTH_HEIGHT / 2}`,
+    //
+    //     // ensures balanced, linear graph from beginning to end
+    //     'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
+    //
+    //     // *between handles horizontal spacing
+    //     'elk.layered.spacing.nodeNodeBetweenLayers': `${DEFAULT_WIDTH_HEIGHT}`,
+    //     'elk.layered.spacing.edgeEdgeBetweenLayers': `${DEFAULT_WIDTH_HEIGHT * 1.5}`,
+    //     'spacing.componentComponent': '70',
+    //     spacing: '75',
+    //
+    //     // ensures correct order of nodes (particularly important for branches)
+    //     'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
+    //   },
+    // });
+    //
+    // const elkNodes: ElkNode[] = [];
+    // const elkEdges: ElkExtendedEdge[] = [];
+    //
+    // nodes.forEach((flowNode) => {
+    //   elkNodes.push({
+    //     id: flowNode.id,
+    //     width: flowNode.width ?? DEFAULT_WIDTH_HEIGHT,
+    //     height: flowNode.height ?? DEFAULT_WIDTH_HEIGHT,
+    //   });
+    // });
+    //
+    // edges.forEach((flowEdge) => {
+    //   elkEdges.push({
+    //     id: flowEdge.id,
+    //     targets: [flowEdge.target],
+    //     sources: [flowEdge.source],
+    //   });
+    // });
+    //
+    // const newGraph = await elk.layout({
+    //   id: 'root',
+    //   portConstraints: 'FIXED_ORDER',
+    //   children: elkNodes,
+    //   edges: elkEdges,
+    // } as ElkNode);
+    //
+    // nodes.forEach((flowNode) => {
+    //   const node = newGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
+    //   if (node?.x && node?.y && node?.width && node?.height) {
+    //     flowNode.position = {
+    //       x: node.x - node.width / 2,
+    //       y: node.y - node.height / 2,
+    //     };
+    //
+    //     flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
+    //     flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
+    //   }
+    //   return flowNode;
+    // });
+    //
+    // return { layoutedNodes: nodes, layoutedEdges: edges };
   }
 
   /**

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -14,7 +14,6 @@ import {
   IVizStepPropsEdge,
 } from '@kaoto/types';
 import { getRandomArbitraryNumber, truncateString } from '@kaoto/utils';
-// import ELK, { ElkExtendedEdge, ElkNode } from 'elkjs';
 // @ts-ignore
 import dagre from 'dagre';
 import { MarkerType, Position } from 'reactflow';
@@ -402,7 +401,7 @@ export class VisualizationService {
 
   /**
    * Accepts an array of React Flow nodes and edges,
-   * build a new ELK layout graph with them
+   * build a new layouted graph with them
    * @param nodes
    * @param edges
    * @param direction
@@ -419,10 +418,10 @@ export class VisualizationService {
     const isHorizontal = direction === 'LR';
 
     dagreGraph.setGraph({
-      // edgesep: DEFAULT_WIDTH_HEIGHT,
-      // nodesep: DEFAULT_WIDTH_HEIGHT,
+      edgesep: 50,
+      nodesep: 50,
       rankdir: direction,
-      ranksep: DEFAULT_WIDTH_HEIGHT,
+      ranksep: 80,
     });
 
     nodes.forEach((node) => {
@@ -433,7 +432,12 @@ export class VisualizationService {
     });
 
     edges.forEach((edge) => {
-      dagreGraph.setEdge(edge.source, edge.target);
+      const sourceNode = nodes.find((node) => node.id === edge.source);
+
+      dagreGraph.setEdge(edge.source, edge.target, {
+        minlen: sourceNode?.data.step.branches?.length > 1 ? 2 : 1,
+        weight: sourceNode?.data.step.branches?.length > 0 ? 2 : 1,
+      });
     });
 
     await dagre.layout(dagreGraph);

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -416,8 +416,8 @@ export class VisualizationService {
     dagreGraph.setDefaultEdgeLabel(() => ({}));
 
     const DEFAULT_WIDTH_HEIGHT = 80;
-    // const isHorizontal = direction === 'RIGHT';
     const isHorizontal = direction === 'LR';
+
     dagreGraph.setGraph({
       // edgesep: DEFAULT_WIDTH_HEIGHT,
       // nodesep: DEFAULT_WIDTH_HEIGHT,
@@ -436,98 +436,25 @@ export class VisualizationService {
       dagreGraph.setEdge(edge.source, edge.target);
     });
 
-    dagre.layout(dagreGraph);
+    await dagre.layout(dagreGraph);
 
     nodes.forEach((flowNode) => {
-      // const node = dagreGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
-      // if (node?.x && node?.y && node?.width && node?.height) {
       const nodeWithPosition = dagreGraph.node(flowNode.id);
-      // flowNode.targetPosition = isHorizontal ? 'left' : 'top';
-      // flowNode.sourcePosition = isHorizontal ? 'right' : 'bottom';
 
       // We are shifting the dagre node position (anchor=center center) to the top left,
       // so it matches the React Flow node anchor point (top left).
       flowNode.position = {
         x: nodeWithPosition.x - nodeWithPosition.width / 2,
         y: nodeWithPosition.y - nodeWithPosition.height / 2,
-        // x: node.x - node.width / 2,
-        // y: node.y - node.width / 2
-        // x: nodeWithPosition.x - nodeWidth / 2,
-        // y: nodeWithPosition.y - nodeHeight / 2,
       };
 
       flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
       flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
-      // }
 
       return flowNode;
     });
 
     return { layoutedNodes: nodes, layoutedEdges: edges };
-
-    // const elk = new ELK({
-    //   defaultLayoutOptions: {
-    //     'elk.algorithm': 'layered',
-    //     'elk.direction': direction,
-    //
-    //     // vertical spacing of nodes
-    //     'elk.spacing.nodeNode': `${DEFAULT_WIDTH_HEIGHT / 2}`,
-    //
-    //     // ensures balanced, linear graph from beginning to end
-    //     'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-    //
-    //     // *between handles horizontal spacing
-    //     'elk.layered.spacing.nodeNodeBetweenLayers': `${DEFAULT_WIDTH_HEIGHT}`,
-    //     'elk.layered.spacing.edgeEdgeBetweenLayers': `${DEFAULT_WIDTH_HEIGHT * 1.5}`,
-    //     'spacing.componentComponent': '70',
-    //     spacing: '75',
-    //
-    //     // ensures correct order of nodes (particularly important for branches)
-    //     'elk.layered.crossingMinimization.forceNodeModelOrder': 'true',
-    //   },
-    // });
-    //
-    // const elkNodes: ElkNode[] = [];
-    // const elkEdges: ElkExtendedEdge[] = [];
-    //
-    // nodes.forEach((flowNode) => {
-    //   elkNodes.push({
-    //     id: flowNode.id,
-    //     width: flowNode.width ?? DEFAULT_WIDTH_HEIGHT,
-    //     height: flowNode.height ?? DEFAULT_WIDTH_HEIGHT,
-    //   });
-    // });
-    //
-    // edges.forEach((flowEdge) => {
-    //   elkEdges.push({
-    //     id: flowEdge.id,
-    //     targets: [flowEdge.target],
-    //     sources: [flowEdge.source],
-    //   });
-    // });
-    //
-    // const newGraph = await elk.layout({
-    //   id: 'root',
-    //   portConstraints: 'FIXED_ORDER',
-    //   children: elkNodes,
-    //   edges: elkEdges,
-    // } as ElkNode);
-    //
-    // nodes.forEach((flowNode) => {
-    //   const node = newGraph?.children?.find((n: { id: string }) => n.id === flowNode.id);
-    //   if (node?.x && node?.y && node?.width && node?.height) {
-    //     flowNode.position = {
-    //       x: node.x - node.width / 2,
-    //       y: node.y - node.height / 2,
-    //     };
-    //
-    //     flowNode.targetPosition = isHorizontal ? Position.Left : Position.Top;
-    //     flowNode.sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
-    //   }
-    //   return flowNode;
-    // });
-    //
-    // return { layoutedNodes: nodes, layoutedEdges: edges };
   }
 
   /**

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -43,7 +43,8 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
       nodes: [...state.nodes.filter((_n, idx) => idx !== nodeIndex)],
     })),
   hoverStepUuid: '',
-  layout: 'RIGHT', // e.g. RIGHT, DOWN
+  // layout: 'RIGHT', // e.g. RIGHT, DOWN
+  layout: 'LR', // e.g. LR, TB
   onNodesChange: (changes: NodeChange[]) =>
     set((state) => ({
       nodes: applyNodeChanges(changes, state.nodes),

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -43,7 +43,6 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
       nodes: [...state.nodes.filter((_n, idx) => idx !== nodeIndex)],
     })),
   hoverStepUuid: '',
-  // layout: 'RIGHT', // e.g. RIGHT, DOWN
   layout: 'LR', // e.g. LR, TB
   onNodesChange: (changes: NodeChange[]) =>
     set((state) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7058,11 +7058,6 @@ electron-to-chromium@^1.4.284:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.286.tgz#0e039de59135f44ab9a8ec9025e53a9135eba11f"
   integrity sha512-Vp3CVhmYpgf4iXNKAucoQUDcCrBQX3XLBtwgFqP9BUXuucgvAV9zWp1kYU7LL9j4++s9O+12cb3wMtN4SJy6UQ==
 
-elkjs@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.8.2.tgz#c37763c5a3e24e042e318455e0147c912a7c248e"
-  integrity sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==
-
 elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6674,6 +6674,14 @@ d3-zoom@^3.0.0:
     d3-selection "2 - 3"
     d3-transition "2 - 3"
 
+dagre@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  dependencies:
+    graphlib "^2.1.8"
+    lodash "^4.17.15"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -8500,6 +8508,13 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
 
 handle-thing@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This PR fixes an issue where the "delete branch" button is covered by a step label, which is caused by the layouting. It fixes #1379, fixes #1374, and resolves #1146.

## Changes
- Change DAG layouting engine
- Update default layout strings
- Improve separation between rankings of nodes
- Increase weight of edge connecting first steps in a branch (to shift unbalanced branch nodes to be left-aligned)
- Adds a reference to the elkjs branch in the services `README` for reference

There is still some room for improvement:
- Add proper typings for the library
- It would be nice if the graph were symmetrical (for uneven branches, for example), so that edges are the same regardless of the number of nodes in a branch (see "After" of first example below)
- Maybe spacing should also be increased at certain places for vertical mode

## Screenshots

Before (delete branch button)

![Screen Shot 2023-03-14 at 11 32 11 am copy](https://user-images.githubusercontent.com/3844502/224988565-0fcf3e08-22fc-4f00-8fa8-cdf6a7264411.png)

After

<img width="1697" alt="Screen Shot 2023-03-13 at 7 59 00 pm" src="https://user-images.githubusercontent.com/3844502/224987880-093fbff1-93fb-4696-a02c-263593e23353.png">

Before (unbalanced branches)

![Screen Shot 2023-03-14 at 11 34 40 am](https://user-images.githubusercontent.com/3844502/224989191-3cc3c072-3094-4a63-9029-b3c9c7342a96.png)

After

![Screen Shot 2023-03-14 at 11 36 05 am](https://user-images.githubusercontent.com/3844502/224989225-91b4327e-f32b-44aa-902f-2f4dc4a10f61.png)

Before (spacing of labels for nested branches in vertical mode)

![Screen Shot 2023-03-14 at 11 38 18 am](https://user-images.githubusercontent.com/3844502/224989713-5c965ff7-044a-44f3-85cf-06b2f95bd63e.png)

After

![Screen Shot 2023-03-14 at 11 37 48 am](https://user-images.githubusercontent.com/3844502/224989746-a404d121-3124-4582-9f06-2d6441e424b8.png)


