### PR TITLE
fix(Visualization): Sync Code editor with step's details view

### DIFF
--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -46,7 +46,22 @@ const Visualization = () => {
    */
   useEffect(() => {
     stepsService.updateViews();
-  }, [integrationJson]);
+  }, [integrationJson, stepsService]);
+
+  /**
+   * Check for changes to integrationJson to refresh the selected step's data.
+   * This is usually caused because of code sync or changes through a step extension
+   */
+  useEffect(() => {
+    if (!selectedStep.UUID) {
+      return;
+    }
+
+    const step = stepsService.findStepWithUUID(selectedStep.UUID);
+    if (step) {
+      setSelectedStep(step);
+    }
+  }, [integrationJson, selectedStep.UUID, stepsService]);
 
   useEffect(() => {
     visualizationService.redrawDiagram(handleDeleteStep, true).catch((e) => console.error(e));


### PR DESCRIPTION
### Context
Selecting a given step populates a `selectedStep` variable which it's used in combination with the `isPanelExpanded` variable to display the step's details.

The problem comes when a change to said step happens outside of the details view because those changes are not propagated to the `VisualizationStepViews` component.

### Changes
A fix for this problem is to listen to `selectedStep.UUID` property in combination with the `integrationJson` property to reload the information whenever a change happens.

### Demo
[Screencast from 2023-03-14 14-50-20.webm](https://user-images.githubusercontent.com/16512618/225022425-2bdae75f-cdfa-4852-bb13-fcceae95d702.webm)

### Known issues
Selecting a nested step and syncing the code, doesn't behave quite the same, because the selected step gets lost. A related issue it's raised [here](https://github.com/KaotoIO/kaoto-ui/issues/1475)

Fixes https://github.com/KaotoIO/kaoto-ui/issues/1395