### PR TITLE
fix(viz): alignment append/prepend step 

### DIFF
--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -1,8 +1,8 @@
-import { StepsService } from '@kaoto/services';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { kameletSourceStepStub } from '../__mocks__/steps';
 import { AlertProvider } from '../layout';
 import { AppendStepButton } from './AppendStepButton';
+import { StepsService } from '@kaoto/services';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 describe('AppendStepButton.tsx', () => {
   const noopFn = jest.fn();
@@ -22,6 +22,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
@@ -40,6 +41,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
@@ -63,10 +65,15 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={true}
-          step={{ ...kameletSourceStepStub, maxBranches: 1, branches: [{ branchUuid: 'random-uuid', identifier: 'branch-1', steps: [] }] }}
+          step={{
+            ...kameletSourceStepStub,
+            maxBranches: 1,
+            branches: [{ branchUuid: 'random-uuid', identifier: 'branch-1', steps: [] }],
+          }}
         />
       </AlertProvider>
     );
@@ -86,7 +93,7 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/Max number of branches reached/,);
+      const tooltip = screen.getByText(/Max number of branches reached/);
       expect(tooltip).toBeInTheDocument();
     });
   });
@@ -97,6 +104,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={false}
@@ -120,7 +128,7 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/step doesn't support branching/,);
+      const tooltip = screen.getByText(/step doesn't support branching/);
       expect(tooltip).toBeInTheDocument();
     });
   });
@@ -133,6 +141,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
@@ -156,11 +165,10 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/Please click on the step to configure branches for it./,);
+      const tooltip = screen.getByText(/Please click on the step to configure branches for it./);
       expect(tooltip).toBeInTheDocument();
     });
 
     spy.mockReset();
   });
-
 });

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -1,15 +1,16 @@
+import { BranchBuilder } from './BranchBuilder';
+import { MiniCatalog } from './MiniCatalog';
 import { StepsService, ValidationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
 import { Popover, Tooltip } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useEffect, useState } from 'react';
-import { BranchBuilder } from './BranchBuilder';
-import { MiniCatalog } from './MiniCatalog';
 
 interface IAddStepButton {
   handleAddBranch: () => void;
   handleSelectStep: (selectedStep: IStepProps) => void;
+  layout: string;
   step: IStepProps;
   showBranchesTab: boolean;
   showStepsTab: boolean;
@@ -19,6 +20,7 @@ interface IAddStepButton {
 export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
   handleAddBranch,
   handleSelectStep,
+  layout,
   step,
   showBranchesTab,
   showStepsTab,
@@ -26,25 +28,29 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
   const views = useIntegrationJsonStore((state) => state.views);
-  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(StepsService.hasCustomStepExtension(step, views));
+  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(
+    StepsService.hasCustomStepExtension(step, views)
+  );
   const [disableBranchesTabMsg, setDisableBranchesTabMsg] = useState('');
 
   useEffect(() => {
     setHasCustomStepExtension(StepsService.hasCustomStepExtension(step, views));
-  }, [step, views])
+  }, [step, views]);
 
   useEffect(() => {
     if (hasCustomStepExtension) {
-      setDisableBranchesTabMsg("Please click on the step to configure branches for it.");
+      setDisableBranchesTabMsg('Please click on the step to configure branches for it.');
       return;
     }
 
-    setDisableBranchesTabMsg(ValidationService.getBranchTabTooltipMsg(
-      supportsBranching,
-      step.maxBranches,
-      step.branches?.length
-    ));
-  }, [hasCustomStepExtension, step, supportsBranching, views])
+    setDisableBranchesTabMsg(
+      ValidationService.getBranchTabTooltipMsg(
+        supportsBranching,
+        step.maxBranches,
+        step.branches?.length
+      )
+    );
+  }, [hasCustomStepExtension, step, supportsBranching, views]);
 
   return (
     <Popover
@@ -75,11 +81,11 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
       position="right-start"
       showClose={false}
     >
-      <Tooltip
-        content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
-      >
+      <Tooltip content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}>
         <button
-          className="stepNode__Add plusButton nodrag"
+          className={`${
+            layout === 'LR' ? 'stepNode__Add' : 'stepNode__Add--vertical'
+          } plusButton nodrag`}
           data-testid="stepNode__appendStep-btn"
         >
           <PlusIcon />
@@ -87,4 +93,4 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
       </Tooltip>
     </Popover>
   );
-}
+};

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -81,7 +81,10 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
       position="right-start"
       showClose={false}
     >
-      <Tooltip content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}>
+      <Tooltip
+        content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
+        position={layout === 'LR' ? 'top' : 'right'}
+      >
         <button
           className={`${
             layout === 'LR' ? 'stepNode__Add' : 'stepNode__Add--vertical'

--- a/src/components/DeleteButtonEdge.tsx
+++ b/src/components/DeleteButtonEdge.tsx
@@ -107,7 +107,10 @@ const DeleteButtonEdge = ({
             hideOnOutsideClick={true}
             position={'right-start'}
           >
-            <Tooltip content={'Delete branch'}>
+            <Tooltip
+              content={'Delete branch'}
+              position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
+            >
               <button className="deleteButton" data-testid={'stepNode__deleteBranch-btn'}>
                 <MinusIcon />
               </button>

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -111,6 +111,7 @@ const PlusButtonEdge = ({
           >
             <Tooltip
               content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
+              position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
             >
               <button className="plusButton" data-testid={'stepNode__insertStep-btn'}>
                 <PlusIcon />

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -22,6 +22,13 @@
     height: calc(100vh - 77px);
 }
 
+.stepHandle {
+    width: 8px !important;
+    height: 8px !important;
+    background: var(--pf-global--BorderColor--200) !important;
+    border-radius: 100% !important;
+}
+
 .stepNode {
     align-items: center;
     background: var(--pf-global--BackgroundColor--100);

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -51,6 +51,12 @@
     top: 38%;
 }
 
+.stepNode__Add--vertical {
+    position: absolute;
+    right: 30px;
+    bottom: -63%;
+}
+
 .stepNode__Delete {
     position: absolute;
     left: 0;
@@ -97,6 +103,12 @@
     position: absolute;
     left: -24px;
     top: 38%;
+}
+
+.stepNode__Prepend--vertical {
+    position: absolute;
+    left: 30px;
+    top: -30%;
 }
 
 .stepNode__Slot {

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -169,11 +169,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
           {!StepsService.isStartStep(data.step) && (
             <Handle
+              className={'stepHandle'}
               isConnectable={false}
               type="target"
               position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
               id="a"
-              style={{ borderRadius: 0 }}
             />
           )}
 
@@ -199,11 +199,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
           {!StepsService.isEndStep(data.step) && (
             <Handle
+              className={'stepHandle'}
               isConnectable={false}
               type="source"
               position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
-              style={{ borderRadius: 0 }}
             />
           )}
 
@@ -263,11 +263,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             {(!StepsService.isStartStep(data.step) || data.branchInfo) && (
               <Handle
+                className={'stepHandle'}
                 isConnectable={false}
                 type="target"
                 position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
                 id="a"
-                style={{ borderRadius: 0 }}
               />
             )}
 
@@ -278,10 +278,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
             {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             <Handle
+              className={'stepHandle'}
               type="source"
               position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
-              style={{ borderRadius: 0 }}
               isConnectable={false}
             />
             <div className={'stepNode__Label stepNode__clickable'}>{data.label}</div>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -157,7 +157,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             >
               <Tooltip content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}>
                 <button
-                  className="stepNode__Prepend plusButton nodrag"
+                  className={`${
+                    visualizationStore.layout === 'LR'
+                      ? 'stepNode__Prepend'
+                      : 'stepNode__Prepend--vertical'
+                  } plusButton nodrag`}
                   data-testid={'stepNode__prependStep-btn'}
                 >
                   <PlusIcon />

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,3 +1,4 @@
+import { AppendStepButton } from './AppendStepButton';
 import { BranchBuilder } from './BranchBuilder';
 import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
@@ -13,7 +14,6 @@ import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { AppendStepButton } from './AppendStepButton';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -208,16 +208,17 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* ADD/APPEND STEP BUTTON */}
-          {VisualizationService.showAppendStepButton(data, endStep)
-            && <AppendStepButton
+          {VisualizationService.showAppendStepButton(data, endStep) && (
+            <AppendStepButton
               handleAddBranch={handleAddBranch}
               handleSelectStep={onMiniCatalogClickAppend}
+              layout={visualizationStore.layout}
               step={data.step}
               showBranchesTab={showBranchesTab}
               showStepsTab={showStepsTab}
               supportsBranching={supportsBranching}
             />
-          }
+          )}
         </div>
       ) : (
         <Popover

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -155,7 +155,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               position={'left-start'}
               showClose={false}
             >
-              <Tooltip content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}>
+              <Tooltip
+                content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+                position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
+              >
                 <button
                   className={`${
                     visualizationStore.layout === 'LR'
@@ -182,7 +185,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* DELETE STEP BUTTON */}
-          <Tooltip content={'Delete step'}>
+          <Tooltip
+            content={'Delete step'}
+            position={visualizationStore.layout === 'LR' ? 'top' : 'left'}
+          >
             <button
               className="stepNode__Delete trashButton nodrag"
               data-testid={'configurationTab__deleteBtn'}


### PR DESCRIPTION
This PR fixes an issue where, in vertical mode, the append/prepend step buttons were showing to the left and right of a step, instead of above and below, respectively. fixes https://github.com/KaotoIO/kaoto-ui/issues/1184

## Changes
- Move append step button to below steps in vertical mode
- Mode prepend step button to above steps in vertical mode
- Bonus bug: Position tooltips to the left or right instead of top/bottom in vertical mode
- Improve handle aesthetics to match the rest of the step node

## Screenshots

Prepend and append step button before:
![Screen Shot 2023-03-15 at 12 27 05 pm copy](https://user-images.githubusercontent.com/3844502/225371156-f00ece3e-ee94-4b62-94c9-4f95bb67aa52.png)

Prepend and append step after:
![Screen Shot 2023-03-15 at 2 56 57 pm](https://user-images.githubusercontent.com/3844502/225368551-a2a5af81-6c39-4c4b-ba42-75833c8bc759.png)

Tooltips in vertical mode before:
![Screen Shot 2023-03-15 at 3 58 14 pm](https://user-images.githubusercontent.com/3844502/225368596-d3972291-a36f-436f-b43b-ddb227c2680f.png)

Tooltips in vertical mode after:
![Screen Shot 2023-03-15 at 3 06 46 pm](https://user-images.githubusercontent.com/3844502/225368709-abbf5dbb-1e4d-4c34-ba24-416e57ad0656.png)

![Screen Shot 2023-03-15 at 3 09 32 pm](https://user-images.githubusercontent.com/3844502/225368687-d23a0e7c-8794-431b-b41f-1d929ae62739.png)


Handle before (top) and after (bottom):
![Screen Shot 2023-03-15 at 1 18 42 pm](https://user-images.githubusercontent.com/3844502/225368062-8f829fc8-cb7e-4395-87d4-893129426702.png)


Handle after:

![Screen Shot 2023-03-15 at 2 56 49 pm](https://user-images.githubusercontent.com/3844502/225369059-577b441d-1ee6-41d7-aa8e-e929b703367a.png)

![Screen Shot 2023-03-15 at 3 22 20 pm](https://user-images.githubusercontent.com/3844502/225368866-2ae75c67-c1c2-4a86-a61a-f107f1bc9023.png)
