### PR TITLE
[2-3] fix(viz): Avoid showing the MiniCatalog popup for PlusButtonEdge.tsx

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '@kaoto/assets': path.resolve(__dirname, './src/assets'),
     '@kaoto/components': path.resolve(__dirname, './src/components'),
     '@kaoto/constants': path.resolve(__dirname, './src/store/constants'),
+    '@kaoto/hooks': path.resolve(__dirname, './src/hooks'),
     '@kaoto/layout': path.resolve(__dirname, './src/layout'),
     '@kaoto/types': path.resolve(__dirname, './src/types'),
     '@kaoto/routes': path.resolve(__dirname, './src/routes'),

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -5,13 +5,16 @@ import { StepsService } from '@kaoto/services';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 describe('AppendStepButton.tsx', () => {
+  let supportsBranchingSpy: jest.SpyInstance;
   const noopFn = jest.fn();
 
   beforeEach(() => {
     jest.useFakeTimers();
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(true);
   });
 
   afterEach(() => {
+    supportsBranchingSpy.mockRestore();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -24,7 +27,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -42,7 +44,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -65,7 +66,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={{
             ...kameletSourceStepStub,
             maxBranches: 1,
@@ -96,6 +96,8 @@ describe('AppendStepButton.tsx', () => {
   });
 
   test('should disable branches tab when supportsBranching={false}', async () => {
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(false);
+
     render(
       <AlertProvider>
         <AppendStepButton
@@ -103,7 +105,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={false}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -139,7 +140,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -169,6 +169,7 @@ describe('AppendStepButton.tsx', () => {
 
   test('should disable the plus button when showStepsTab={false} and supportsBranching={false}', async () => {
     const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(true);
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(false);
 
     render(
       <AlertProvider>
@@ -177,7 +178,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={false}
-          supportsBranching={false}
           step={kameletSourceStepStub}
         />
       </AlertProvider>

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -1,8 +1,8 @@
-import { StepsService } from '@kaoto/services';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { kameletSourceStepStub } from '../__mocks__/steps';
 import { AlertProvider } from '../layout';
 import { AppendStepButton } from './AppendStepButton';
+import { StepsService } from '@kaoto/services';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 describe('AppendStepButton.tsx', () => {
   const noopFn = jest.fn();
@@ -22,6 +22,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
@@ -40,6 +41,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
@@ -63,10 +65,15 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={true}
-          step={{ ...kameletSourceStepStub, maxBranches: 1, branches: [{ branchUuid: 'random-uuid', identifier: 'branch-1', steps: [] }] }}
+          step={{
+            ...kameletSourceStepStub,
+            maxBranches: 1,
+            branches: [{ branchUuid: 'random-uuid', identifier: 'branch-1', steps: [] }],
+          }}
         />
       </AlertProvider>
     );
@@ -86,7 +93,7 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/Max number of branches reached/,);
+      const tooltip = screen.getByText(/Max number of branches reached/);
       expect(tooltip).toBeInTheDocument();
     });
   });
@@ -97,6 +104,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={false}
@@ -120,7 +128,7 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/step doesn't support branching/,);
+      const tooltip = screen.getByText(/step doesn't support branching/);
       expect(tooltip).toBeInTheDocument();
     });
   });
@@ -133,6 +141,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
+          layout={'LR'}
           showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
@@ -156,11 +165,10 @@ describe('AppendStepButton.tsx', () => {
     });
 
     await waitFor(() => {
-      const tooltip = screen.getByText(/Please click on the step to configure branches for it./,);
+      const tooltip = screen.getByText(/Please click on the step to configure branches for it./);
       expect(tooltip).toBeInTheDocument();
     });
 
     spy.mockReset();
   });
-
 });

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -23,7 +23,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
           step={kameletSourceStepStub}
@@ -42,7 +41,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
           step={kameletSourceStepStub}
@@ -66,7 +64,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={true}
           step={{
@@ -98,14 +95,13 @@ describe('AppendStepButton.tsx', () => {
     });
   });
 
-  test('should disable branches tab when showBranchesTab={false} and supportsBranching={false}', async () => {
+  test('should disable branches tab when supportsBranching={false}', async () => {
     render(
       <AlertProvider>
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={false}
           step={kameletSourceStepStub}
@@ -142,7 +138,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
           step={kameletSourceStepStub}
@@ -161,6 +156,38 @@ describe('AppendStepButton.tsx', () => {
 
     act(() => {
       fireEvent.mouseEnter(branchTab);
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(/Please click on the step to configure branches for it./);
+      expect(tooltip).toBeInTheDocument();
+    });
+
+    spy.mockReset();
+  });
+
+  test('should disable the plus button when showStepsTab={false} and supportsBranching={false}', async () => {
+    const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(true);
+
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          layout={'LR'}
+          showStepsTab={false}
+          supportsBranching={false}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    expect(plusIcon).toBeDisabled();
+
+    act(() => {
+      fireEvent.mouseEnter(plusIcon);
       jest.runAllTimers();
     });
 

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -1,4 +1,5 @@
-import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
+import { useShowBranchTab } from '@kaoto/hooks';
+import { ValidationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
 import { Popover, Tooltip } from '@patternfly/react-core';
@@ -13,7 +14,6 @@ interface IAddStepButton {
   layout: string;
   step: IStepProps;
   showStepsTab: boolean;
-  supportsBranching: boolean;
 }
 
 export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
@@ -22,41 +22,13 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
   layout,
   step,
   showStepsTab,
-  supportsBranching,
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
   const views = useIntegrationJsonStore((state) => state.views);
-  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(
-    StepsService.hasCustomStepExtension(step, views)
-  );
-  const [disableBranchesTab, setDisableBranchesTab] = useState(false);
-  const [disableBranchesTabMsg, setDisableBranchesTabMsg] = useState('');
+  const { disableBranchesTab, disableBranchesTabMsg } = useShowBranchTab(step, views);
+
   const [tooltipText, setTooltipText] = useState('');
   const [disableButton, setDisableButton] = useState(false);
-
-  useEffect(() => {
-    setHasCustomStepExtension(StepsService.hasCustomStepExtension(step, views));
-  }, [step, views]);
-
-  useEffect(() => {
-    const showBranchesTab = VisualizationService.showBranchesTab(step);
-    setDisableBranchesTab(hasCustomStepExtension || !showBranchesTab || !supportsBranching);
-  }, [step, hasCustomStepExtension, supportsBranching]);
-
-  useEffect(() => {
-    if (hasCustomStepExtension) {
-      setDisableBranchesTabMsg('Please click on the step to configure branches for it.');
-      return;
-    }
-
-    setDisableBranchesTabMsg(
-      ValidationService.getBranchTabTooltipMsg(
-        supportsBranching,
-        step.maxBranches,
-        step.branches?.length
-      )
-    );
-  }, [hasCustomStepExtension, step, supportsBranching]);
 
   useEffect(() => {
     setDisableButton(!showStepsTab && disableBranchesTab);

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -1,15 +1,16 @@
+import { BranchBuilder } from './BranchBuilder';
+import { MiniCatalog } from './MiniCatalog';
 import { StepsService, ValidationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
 import { Popover, Tooltip } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useEffect, useState } from 'react';
-import { BranchBuilder } from './BranchBuilder';
-import { MiniCatalog } from './MiniCatalog';
 
 interface IAddStepButton {
   handleAddBranch: () => void;
   handleSelectStep: (selectedStep: IStepProps) => void;
+  layout: string;
   step: IStepProps;
   showBranchesTab: boolean;
   showStepsTab: boolean;
@@ -19,6 +20,7 @@ interface IAddStepButton {
 export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
   handleAddBranch,
   handleSelectStep,
+  layout,
   step,
   showBranchesTab,
   showStepsTab,
@@ -26,25 +28,29 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
   const views = useIntegrationJsonStore((state) => state.views);
-  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(StepsService.hasCustomStepExtension(step, views));
+  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(
+    StepsService.hasCustomStepExtension(step, views)
+  );
   const [disableBranchesTabMsg, setDisableBranchesTabMsg] = useState('');
 
   useEffect(() => {
     setHasCustomStepExtension(StepsService.hasCustomStepExtension(step, views));
-  }, [step, views])
+  }, [step, views]);
 
   useEffect(() => {
     if (hasCustomStepExtension) {
-      setDisableBranchesTabMsg("Please click on the step to configure branches for it.");
+      setDisableBranchesTabMsg('Please click on the step to configure branches for it.');
       return;
     }
 
-    setDisableBranchesTabMsg(ValidationService.getBranchTabTooltipMsg(
-      supportsBranching,
-      step.maxBranches,
-      step.branches?.length
-    ));
-  }, [hasCustomStepExtension, step, supportsBranching, views])
+    setDisableBranchesTabMsg(
+      ValidationService.getBranchTabTooltipMsg(
+        supportsBranching,
+        step.maxBranches,
+        step.branches?.length
+      )
+    );
+  }, [hasCustomStepExtension, step, supportsBranching, views]);
 
   return (
     <Popover
@@ -75,11 +81,11 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
       position="right-start"
       showClose={false}
     >
-      <Tooltip
-        content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
-      >
+      <Tooltip content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}>
         <button
-          className="stepNode__Add plusButton nodrag"
+          className={`${
+            layout === 'LR' ? 'stepNode__Add' : 'stepNode__Add--vertical'
+          } plusButton nodrag`}
           data-testid="stepNode__appendStep-btn"
         >
           <PlusIcon />
@@ -87,4 +93,4 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
       </Tooltip>
     </Popover>
   );
-}
+};

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -81,7 +81,10 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
       position="right-start"
       showClose={false}
     >
-      <Tooltip content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}>
+      <Tooltip
+        content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
+        position={layout === 'LR' ? 'top' : 'right'}
+      >
         <button
           className={`${
             layout === 'LR' ? 'stepNode__Add' : 'stepNode__Add--vertical'

--- a/src/components/DeleteButtonEdge.tsx
+++ b/src/components/DeleteButtonEdge.tsx
@@ -107,7 +107,10 @@ const DeleteButtonEdge = ({
             hideOnOutsideClick={true}
             position={'right-start'}
           >
-            <Tooltip content={'Delete branch'}>
+            <Tooltip
+              content={'Delete branch'}
+              position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
+            >
               <button className="deleteButton" data-testid={'stepNode__deleteBranch-btn'}>
                 <MinusIcon />
               </button>

--- a/src/components/MiniCatalog.test.tsx
+++ b/src/components/MiniCatalog.test.tsx
@@ -1,27 +1,23 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { AlertProvider } from '../layout';
 import { MiniCatalog } from './MiniCatalog';
-import { screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
 
 describe('MiniCatalog.tsx', () => {
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <MiniCatalog />
-      </AlertProvider>
-    );
+  test('component renders correctly', async () => {
+    act(() => {
+      render(
+        <AlertProvider>
+          <MiniCatalog />
+        </AlertProvider>
+      );
+    });
 
-    const element = screen.getByTestId('miniCatalog');
-    expect(element).toBeInTheDocument();
-  });
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <MiniCatalog />
-      </AlertProvider>
-    );
+    await waitFor(() => {
+      const element = screen.getByTestId('miniCatalog');
+      expect(element).toBeInTheDocument();
 
-    const element = screen.getByText('start');
-    expect(element).toBeInTheDocument();
+      const startButton = screen.getByText('start');
+      expect(startButton).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -45,7 +45,7 @@ const PlusButtonEdge = ({
   const nestedStepsStore = useNestedStepsStore();
   const visualizationStore = useVisualizationStore();
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
-  const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data);
+  const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data.step);
   const showStepsTab = VisualizationService.showStepsTab(sourceNode?.data);
 
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -111,6 +111,7 @@ const PlusButtonEdge = ({
           >
             <Tooltip
               content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
+              position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
             >
               <button className="plusButton" data-testid={'stepNode__insertStep-btn'}>
                 <PlusIcon />

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -1,0 +1,72 @@
+import { Popover, Tooltip } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+import { ValidationService } from '@kaoto/services';
+import { useSettingsStore } from '@kaoto/store';
+import { IStepProps } from '@kaoto/types';
+import { BranchBuilder } from './BranchBuilder';
+import { MiniCatalog } from './MiniCatalog';
+
+interface IPrependStepButton {
+  handleAddBranch: () => void;
+  onMiniCatalogClickPrepend: (selectedStep: IStepProps) => void;
+  layout: string;
+  step: IStepProps;
+  showStepsTab: boolean;
+}
+
+export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
+  handleAddBranch,
+  onMiniCatalogClickPrepend,
+  layout,
+  step,
+  showStepsTab,
+}) => {
+  const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
+
+  return (
+    <Popover
+    id="popover-prepend-step"
+    appendTo={() => document.body}
+    aria-label="Add a step"
+    bodyContent={
+      <MiniCatalog
+        children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+        disableBranchesTab={true}
+        disableBranchesTabMsg={"You can't add a branch from here."}
+        disableStepsTab={false}
+        handleSelectStep={onMiniCatalogClickPrepend}
+        queryParams={{
+          dsl: currentDSL,
+          type: ValidationService.prependableStepTypes(),
+        }}
+        step={step}
+      />
+    }
+    className={'miniCatalog__popover'}
+    data-testid={'miniCatalog__popover'}
+    enableFlip={true}
+    flipBehavior={['top-start', 'left-start']}
+    hasAutoWidth
+    hideOnOutsideClick={true}
+    position={'left-start'}
+    showClose={false}
+  >
+    <Tooltip
+      content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+      position={layout === 'LR' ? 'top' : 'right'}
+    >
+      <button
+        className={`${
+          layout === 'LR'
+            ? 'stepNode__Prepend'
+            : 'stepNode__Prepend--vertical'
+        } plusButton nodrag`}
+        data-testid={'stepNode__prependStep-btn'}
+      >
+        <PlusIcon />
+      </button>
+    </Tooltip>
+  </Popover>
+  )
+};

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -26,47 +26,46 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
 
   return (
     <Popover
-    id="popover-prepend-step"
-    appendTo={() => document.body}
-    aria-label="Add a step"
-    bodyContent={
-      <MiniCatalog
-        children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-        disableBranchesTab={true}
-        disableBranchesTabMsg={"You can't add a branch from here."}
-        disableStepsTab={false}
-        handleSelectStep={onMiniCatalogClickPrepend}
-        queryParams={{
-          dsl: currentDSL,
-          type: ValidationService.prependableStepTypes(),
-        }}
-        step={step}
-      />
-    }
-    className={'miniCatalog__popover'}
-    data-testid={'miniCatalog__popover'}
-    enableFlip={true}
-    flipBehavior={['top-start', 'left-start']}
-    hasAutoWidth
-    hideOnOutsideClick={true}
-    position={'left-start'}
-    showClose={false}
-  >
-    <Tooltip
-      content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
-      position={layout === 'LR' ? 'top' : 'right'}
+      id="popover-prepend-step"
+      aria-label="Add a step"
+      bodyContent={
+        <MiniCatalog
+          disableBranchesTab={true}
+          disableBranchesTabMsg="You can't add a branch from here."
+          disableStepsTab={false}
+          handleSelectStep={onMiniCatalogClickPrepend}
+          queryParams={{
+            dsl: currentDSL,
+            type: ValidationService.prependableStepTypes(),
+          }}
+          step={step}
+        >
+          <BranchBuilder handleAddBranch={handleAddBranch} />
+        </MiniCatalog>
+      }
+      className="miniCatalog__popover"
+      data-testid="miniCatalog__popover"
+      enableFlip={true}
+      flipBehavior={['top-start', 'left-start']}
+      hasAutoWidth
+      hideOnOutsideClick={true}
+      position="left-start"
+      showClose={false}
     >
-      <button
-        className={`${
-          layout === 'LR'
+      <Tooltip
+        content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+        position={layout === 'LR' ? 'top' : 'right'}
+      >
+        <button
+          className={`${layout === 'LR'
             ? 'stepNode__Prepend'
             : 'stepNode__Prepend--vertical'
-        } plusButton nodrag`}
-        data-testid={'stepNode__prependStep-btn'}
-      >
-        <PlusIcon />
-      </button>
-    </Tooltip>
-  </Popover>
+            } plusButton nodrag`}
+          data-testid="stepNode__prependStep-btn"
+        >
+          <PlusIcon />
+        </button>
+      </Tooltip>
+    </Popover>
   )
 };

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -4,23 +4,18 @@ import { FunctionComponent } from 'react';
 import { ValidationService } from '@kaoto/services';
 import { useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
-import { BranchBuilder } from './BranchBuilder';
 import { MiniCatalog } from './MiniCatalog';
 
 interface IPrependStepButton {
-  handleAddBranch: () => void;
   onMiniCatalogClickPrepend: (selectedStep: IStepProps) => void;
   layout: string;
   step: IStepProps;
-  showStepsTab: boolean;
 }
 
 export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
-  handleAddBranch,
   onMiniCatalogClickPrepend,
   layout,
   step,
-  showStepsTab,
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
 
@@ -39,9 +34,7 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
             type: ValidationService.prependableStepTypes(),
           }}
           step={step}
-        >
-          <BranchBuilder handleAddBranch={handleAddBranch} />
-        </MiniCatalog>
+        />
       }
       className="miniCatalog__popover"
       data-testid="miniCatalog__popover"
@@ -53,7 +46,7 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
       showClose={false}
     >
       <Tooltip
-        content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+        content="Add a step"
         position={layout === 'LR' ? 'top' : 'right'}
       >
         <button

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -22,6 +22,13 @@
     height: calc(100vh - 77px);
 }
 
+.stepHandle {
+    width: 8px !important;
+    height: 8px !important;
+    background: var(--pf-global--BorderColor--200) !important;
+    border-radius: 100% !important;
+}
+
 .stepNode {
     align-items: center;
     background: var(--pf-global--BackgroundColor--100);

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -51,6 +51,12 @@
     top: 38%;
 }
 
+.stepNode__Add--vertical {
+    position: absolute;
+    right: 30px;
+    bottom: -63%;
+}
+
 .stepNode__Delete {
     position: absolute;
     left: 0;
@@ -97,6 +103,12 @@
     position: absolute;
     left: -24px;
     top: 38%;
+}
+
+.stepNode__Prepend--vertical {
+    position: absolute;
+    left: 30px;
+    top: -30%;
 }
 
 .stepNode__Slot {

--- a/src/components/Visualization.test.tsx
+++ b/src/components/Visualization.test.tsx
@@ -1,5 +1,6 @@
 import { IIntegrationJsonStore, RFState, useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { AlertProvider } from '../layout';
 import { integrationJSONStub, stepsStub } from '../__mocks__/steps';
 import { Visualization } from './Visualization';
@@ -33,14 +34,19 @@ beforeAll(() => {
 });
 
 describe('Visualization.tsx', () => {
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <Visualization />
-      </AlertProvider>
-    );
-    const element = screen.getByTestId('react-flow-wrapper');
-    expect(element).toBeInTheDocument();
+  test('component renders correctly', async () => {
+    act(() => {
+      render(
+        <AlertProvider>
+          <Visualization />
+        </AlertProvider>
+      );
+    });
+
+    await waitFor(() => {
+      const element = screen.getByTestId('react-flow-wrapper');
+      expect(element).toBeInTheDocument();
+    });
   });
 
   test('should expands the details panel upon clicking on a step', async () => {

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -169,11 +169,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
           {!StepsService.isStartStep(data.step) && (
             <Handle
+              className={'stepHandle'}
               isConnectable={false}
               type="target"
               position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
               id="a"
-              style={{ borderRadius: 0 }}
             />
           )}
 
@@ -199,11 +199,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
           {!StepsService.isEndStep(data.step) && (
             <Handle
+              className={'stepHandle'}
               isConnectable={false}
               type="source"
               position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
-              style={{ borderRadius: 0 }}
             />
           )}
 
@@ -263,11 +263,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             {(!StepsService.isStartStep(data.step) || data.branchInfo) && (
               <Handle
+                className={'stepHandle'}
                 isConnectable={false}
                 type="target"
                 position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
                 id="a"
-                style={{ borderRadius: 0 }}
               />
             )}
 
@@ -278,10 +278,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
 
             {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
             <Handle
+              className={'stepHandle'}
               type="source"
               position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
-              style={{ borderRadius: 0 }}
               isConnectable={false}
             />
             <div className={'stepNode__Label stepNode__clickable'}>{data.label}</div>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -2,7 +2,7 @@ import { AppendStepButton } from './AppendStepButton';
 import { BranchBuilder } from './BranchBuilder';
 import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
-import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
+import { StepsService, VisualizationService } from '@kaoto/services';
 import {
   useIntegrationJsonStore,
   useNestedStepsStore,
@@ -11,9 +11,10 @@ import {
 } from '@kaoto/store';
 import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
-import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
+import { CubesIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
+import { PrependStepButton } from './PrependStepButton';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -128,49 +129,13 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
         >
           {/* PREPEND STEP BUTTON */}
           {visualizationService.showPrependStepButton(data) && (
-            <Popover
-              id="popover-prepend-step"
-              appendTo={() => document.body}
-              aria-label="Add a step"
-              bodyContent={
-                <MiniCatalog
-                  children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-                  disableBranchesTab={true}
-                  disableBranchesTabMsg={"You can't add a branch from here."}
-                  disableStepsTab={!visualizationService.showPrependStepButton(data)}
-                  handleSelectStep={onMiniCatalogClickPrepend}
-                  queryParams={{
-                    dsl: currentDSL,
-                    type: ValidationService.prependableStepTypes(),
-                  }}
-                  step={data.step}
-                />
-              }
-              className={'miniCatalog__popover'}
-              data-testid={'miniCatalog__popover'}
-              enableFlip={true}
-              flipBehavior={['top-start', 'left-start']}
-              hasAutoWidth
-              hideOnOutsideClick={true}
-              position={'left-start'}
-              showClose={false}
-            >
-              <Tooltip
-                content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
-                position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
-              >
-                <button
-                  className={`${
-                    visualizationStore.layout === 'LR'
-                      ? 'stepNode__Prepend'
-                      : 'stepNode__Prepend--vertical'
-                  } plusButton nodrag`}
-                  data-testid={'stepNode__prependStep-btn'}
-                >
-                  <PlusIcon />
-                </button>
-              </Tooltip>
-            </Popover>
+            <PrependStepButton
+              handleAddBranch={handleAddBranch}
+              onMiniCatalogClickPrepend={onMiniCatalogClickPrepend}
+              layout={visualizationStore.layout}
+              step={data.step}
+              showStepsTab={showStepsTab}
+            />
           )}
 
           {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -157,7 +157,11 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             >
               <Tooltip content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}>
                 <button
-                  className="stepNode__Prepend plusButton nodrag"
+                  className={`${
+                    visualizationStore.layout === 'LR'
+                      ? 'stepNode__Prepend'
+                      : 'stepNode__Prepend--vertical'
+                  } plusButton nodrag`}
                   data-testid={'stepNode__prependStep-btn'}
                 >
                   <PlusIcon />

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -188,7 +188,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               layout={visualizationStore.layout}
               step={data.step}
               showStepsTab={showStepsTab}
-              supportsBranching={supportsBranching}
             />
           )}
         </div>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -26,7 +26,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const integrationJsonStore = useIntegrationJsonStore();
   const visualizationService = new VisualizationService(integrationJsonStore, visualizationStore);
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
-  const showBranchesTab = VisualizationService.showBranchesTab(data);
+  const showBranchesTab = VisualizationService.showBranchesTab(data.step);
   const showStepsTab = VisualizationService.showStepsTab(data);
   const supportsBranching = StepsService.supportsBranching(data.step);
 
@@ -187,7 +187,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               handleSelectStep={onMiniCatalogClickAppend}
               layout={visualizationStore.layout}
               step={data.step}
-              showBranchesTab={showBranchesTab}
               showStepsTab={showStepsTab}
               supportsBranching={supportsBranching}
             />

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -130,11 +130,9 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* PREPEND STEP BUTTON */}
           {visualizationService.showPrependStepButton(data) && (
             <PrependStepButton
-              handleAddBranch={handleAddBranch}
               onMiniCatalogClickPrepend={onMiniCatalogClickPrepend}
               layout={visualizationStore.layout}
               step={data.step}
-              showStepsTab={showStepsTab}
             />
           )}
 

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,3 +1,4 @@
+import { AppendStepButton } from './AppendStepButton';
 import { BranchBuilder } from './BranchBuilder';
 import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
@@ -13,7 +14,6 @@ import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { AppendStepButton } from './AppendStepButton';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -208,16 +208,17 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* ADD/APPEND STEP BUTTON */}
-          {VisualizationService.showAppendStepButton(data, endStep)
-            && <AppendStepButton
+          {VisualizationService.showAppendStepButton(data, endStep) && (
+            <AppendStepButton
               handleAddBranch={handleAddBranch}
               handleSelectStep={onMiniCatalogClickAppend}
+              layout={visualizationStore.layout}
               step={data.step}
               showBranchesTab={showBranchesTab}
               showStepsTab={showStepsTab}
               supportsBranching={supportsBranching}
             />
-          }
+          )}
         </div>
       ) : (
         <Popover

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -155,7 +155,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               position={'left-start'}
               showClose={false}
             >
-              <Tooltip content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}>
+              <Tooltip
+                content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+                position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
+              >
                 <button
                   className={`${
                     visualizationStore.layout === 'LR'
@@ -182,7 +185,10 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           )}
 
           {/* DELETE STEP BUTTON */}
-          <Tooltip content={'Delete step'}>
+          <Tooltip
+            content={'Delete step'}
+            position={visualizationStore.layout === 'LR' ? 'top' : 'left'}
+          >
             <button
               className="stepNode__Delete trashButton nodrag"
               data-testid={'configurationTab__deleteBtn'}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './show-branch-tab.hook';

--- a/src/hooks/show-branch-tab.hook.ts
+++ b/src/hooks/show-branch-tab.hook.ts
@@ -1,0 +1,40 @@
+import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
+import { IStepProps, IViewProps } from '@kaoto/types';
+import { useEffect, useState } from 'react';
+
+export const useShowBranchTab = (step: IStepProps, views: IViewProps[]) => {
+  const supportsBranching = StepsService.supportsBranching(step);
+
+  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(
+    StepsService.hasCustomStepExtension(step, views)
+  );
+
+  const [disableBranchesTab, setDisableBranchesTab] = useState(false);
+  const [disableBranchesTabMsg, setDisableBranchesTabMsg] = useState('');
+
+  useEffect(() => {
+    setHasCustomStepExtension(StepsService.hasCustomStepExtension(step, views));
+  }, [step, views]);
+
+  useEffect(() => {
+    const showBranchesTab = VisualizationService.showBranchesTab(step);
+    setDisableBranchesTab(hasCustomStepExtension || !showBranchesTab || !supportsBranching);
+  }, [step, hasCustomStepExtension, supportsBranching]);
+
+  useEffect(() => {
+    if (hasCustomStepExtension) {
+      setDisableBranchesTabMsg('Please click on the step to configure branches for it.');
+      return;
+    }
+
+    setDisableBranchesTabMsg(
+      ValidationService.getBranchTabTooltipMsg(
+        supportsBranching,
+        step.maxBranches,
+        step.branches?.length
+      )
+    );
+  }, [hasCustomStepExtension, step, supportsBranching]);
+
+  return { disableBranchesTab, disableBranchesTabMsg };
+};

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -84,11 +84,7 @@ export class StepsService {
    * @param step
    */
   static containsBranches(step: IStepProps): boolean {
-    let containsBranching = false;
-    if (step.branches && step.branches.length > 0) {
-      containsBranching = true;
-    }
-    return containsBranching;
+    return Array.isArray(step.branches) && step.branches.length > 0;
   }
 
   deleteBranch(step: IStepProps, branchUuid: string) {

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -108,7 +108,7 @@ describe('validationService', () => {
     expect(ValidationService.getPlusButtonTooltipMsg(true, true)).toBe('Add a step or branch');
     expect(ValidationService.getPlusButtonTooltipMsg(true, false)).toBe('Add a branch');
     expect(ValidationService.getPlusButtonTooltipMsg(false, true)).toBe('Add a step');
-    expect(ValidationService.getPlusButtonTooltipMsg(false, false)).toBe('');
+    expect(ValidationService.getPlusButtonTooltipMsg(false, false)).toBe('Please click on the step to configure branches for it.');
   });
 
   it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -116,7 +116,7 @@ export class ValidationService {
     } else if (showStepsTab) {
       return 'Add a step';
     } else {
-      return '';
+      return 'Please click on the step to configure branches for it.';
     }
   }
 

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -519,24 +519,23 @@ describe('visualizationService', () => {
   });
 
   it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
-    const step: IVizStepNodeData = {
-      label: '',
-      step: {} as IStepProps,
-    };
+    const step = {} as IStepProps;
 
     expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
     // has branches but not branch support
     expect(
       VisualizationService.showBranchesTab({
         ...step,
-        step: { ...step.step, branches: [] },
+        branches: [],
       })
     ).toBeFalsy();
 
     expect(
       VisualizationService.showBranchesTab({
         ...step,
-        step: { ...step.step, branches: [], minBranches: 0, maxBranches: -1 },
+        branches: [],
+        minBranches: 0,
+        maxBranches: -1,
       })
     ).toBeTruthy();
 
@@ -544,12 +543,9 @@ describe('visualizationService', () => {
     expect(
       VisualizationService.showBranchesTab({
         ...step,
-        step: {
-          ...step.step,
-          branches: [{}, {}] as IStepPropsBranch[],
-          minBranches: 0,
-          maxBranches: 2,
-        },
+        branches: [{}, {}] as IStepPropsBranch[],
+        minBranches: 0,
+        maxBranches: 2,
       })
     ).toBeFalsy();
   });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -635,7 +635,7 @@ export class VisualizationService {
   static showStepsTab(nodeData: IVizStepNodeData): boolean {
     // if it contains branches and no next step, show the steps tab
     if (StepsService.containsBranches(nodeData.step) && !nodeData.nextStepUuid) return true;
-    // if it contains branches, don't show the steps tab
+    // if it doesn't contains branches, don't show the steps tab
     return !StepsService.containsBranches(nodeData.step);
   }
 }

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -621,10 +621,10 @@ export class VisualizationService {
    * Determines whether to show the Branches tab in the mini catalog
    * @param nodeData
    */
-  static showBranchesTab(nodeData: IVizStepNodeData): boolean {
+  static showBranchesTab(step: IStepProps): boolean {
     return (
-      StepsService.supportsBranching(nodeData.step) &&
-      nodeData.step.branches?.length !== nodeData.step.maxBranches
+      StepsService.supportsBranching(step) &&
+      step.branches?.length !== step.maxBranches
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@kaoto/assets": ["./src/assets"],
       "@kaoto/components": ["./src/components"],
       "@kaoto/constants": ["./src/store/constants"],
+      "@kaoto/hooks": ["./src/hooks"],
       "@kaoto/layout": ["./src/layout"],
       "@kaoto/routes": ["./src/routes"],
       "@kaoto/services": ["./src/services"],


### PR DESCRIPTION
### Context
This pull request is the second of three pull requests:
1. #1497
2. #1498 **(This pull request)**
3. #1502

These pull requests are built on top of https://github.com/KaotoIO/kaoto-ui/pull/1485

### Description
Based on https://github.com/KaotoIO/kaoto-ui/issues/1473, when a step has an associated custom extension available and there's no next step available to pick,  **From the PlusButtonEdge** component, the MiniCatalog was still displayed to the user, with both tabs disabled but with a visible `Add Branch` button completely interactive.
![image](https://user-images.githubusercontent.com/16512618/225844186-cd0c1131-0212-45ba-9c71-475c29dba71d.png)

### Changes
By extracting the show/hide branch logic from the `AppendStepButton` into a custom hook, we now leverage the same logic inside the `PlusButtonEdge` component as well.

fixes the remaining bit of https://github.com/KaotoIO/kaoto-ui/issues/1473
