### PR TITLE
[1-3] fix(viz): Avoid showing the MiniCatalog popup when there's no step nor branches available

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '@kaoto/assets': path.resolve(__dirname, './src/assets'),
     '@kaoto/components': path.resolve(__dirname, './src/components'),
     '@kaoto/constants': path.resolve(__dirname, './src/store/constants'),
+    '@kaoto/hooks': path.resolve(__dirname, './src/hooks'),
     '@kaoto/layout': path.resolve(__dirname, './src/layout'),
     '@kaoto/types': path.resolve(__dirname, './src/types'),
     '@kaoto/routes': path.resolve(__dirname, './src/routes'),

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -3,6 +3,7 @@ import { AlertProvider } from '../layout';
 import { AppendStepButton } from './AppendStepButton';
 import { StepsService } from '@kaoto/services';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Position } from 'reactflow';
 
 describe('AppendStepButton.tsx', () => {
   let supportsBranchingSpy: jest.SpyInstance;
@@ -25,7 +26,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
-          layout={'LR'}
+          position={Position.Top}
           showStepsTab={true}
           step={kameletSourceStepStub}
         />
@@ -42,7 +43,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
-          layout={'LR'}
+          position={Position.Top}
           showStepsTab={true}
           step={kameletSourceStepStub}
         />
@@ -64,7 +65,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
-          layout={'LR'}
+          position={Position.Top}
           showStepsTab={true}
           step={{
             ...kameletSourceStepStub,
@@ -103,7 +104,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
-          layout={'LR'}
+          position={Position.Top}
           showStepsTab={true}
           step={kameletSourceStepStub}
         />
@@ -138,7 +139,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
-          layout={'LR'}
+          position={Position.Top}
           showStepsTab={true}
           step={kameletSourceStepStub}
         />
@@ -176,7 +177,7 @@ describe('AppendStepButton.tsx', () => {
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
-          layout={'LR'}
+          position={Position.Top}
           showStepsTab={false}
           step={kameletSourceStepStub}
         />

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -5,13 +5,16 @@ import { StepsService } from '@kaoto/services';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 describe('AppendStepButton.tsx', () => {
+  let supportsBranchingSpy: jest.SpyInstance;
   const noopFn = jest.fn();
 
   beforeEach(() => {
     jest.useFakeTimers();
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(true);
   });
 
   afterEach(() => {
+    supportsBranchingSpy.mockRestore();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -24,7 +27,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -42,7 +44,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -65,7 +66,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={{
             ...kameletSourceStepStub,
             maxBranches: 1,
@@ -96,6 +96,8 @@ describe('AppendStepButton.tsx', () => {
   });
 
   test('should disable branches tab when supportsBranching={false}', async () => {
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(false);
+
     render(
       <AlertProvider>
         <AppendStepButton
@@ -103,7 +105,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={false}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -139,7 +140,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={true}
-          supportsBranching={true}
           step={kameletSourceStepStub}
         />
       </AlertProvider>
@@ -169,6 +169,7 @@ describe('AppendStepButton.tsx', () => {
 
   test('should disable the plus button when showStepsTab={false} and supportsBranching={false}', async () => {
     const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(true);
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(false);
 
     render(
       <AlertProvider>
@@ -177,7 +178,6 @@ describe('AppendStepButton.tsx', () => {
           handleSelectStep={noopFn}
           layout={'LR'}
           showStepsTab={false}
-          supportsBranching={false}
           step={kameletSourceStepStub}
         />
       </AlertProvider>

--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -23,7 +23,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
           step={kameletSourceStepStub}
@@ -42,7 +41,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
           step={kameletSourceStepStub}
@@ -66,7 +64,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={true}
           step={{
@@ -98,14 +95,13 @@ describe('AppendStepButton.tsx', () => {
     });
   });
 
-  test('should disable branches tab when showBranchesTab={false} and supportsBranching={false}', async () => {
+  test('should disable branches tab when supportsBranching={false}', async () => {
     render(
       <AlertProvider>
         <AppendStepButton
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={false}
           showStepsTab={true}
           supportsBranching={false}
           step={kameletSourceStepStub}
@@ -142,7 +138,6 @@ describe('AppendStepButton.tsx', () => {
           handleAddBranch={noopFn}
           handleSelectStep={noopFn}
           layout={'LR'}
-          showBranchesTab={true}
           showStepsTab={true}
           supportsBranching={true}
           step={kameletSourceStepStub}
@@ -161,6 +156,38 @@ describe('AppendStepButton.tsx', () => {
 
     act(() => {
       fireEvent.mouseEnter(branchTab);
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(/Please click on the step to configure branches for it./);
+      expect(tooltip).toBeInTheDocument();
+    });
+
+    spy.mockReset();
+  });
+
+  test('should disable the plus button when showStepsTab={false} and supportsBranching={false}', async () => {
+    const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(true);
+
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          layout={'LR'}
+          showStepsTab={false}
+          supportsBranching={false}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    expect(plusIcon).toBeDisabled();
+
+    act(() => {
+      fireEvent.mouseEnter(plusIcon);
       jest.runAllTimers();
     });
 

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -72,8 +72,7 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
         position={layout === 'LR' ? 'top' : 'right'}
       >
         <button
-          className={`${layout === 'LR' ? 'stepNode__Add' : 'stepNode__Add--vertical'
-            } plusButton nodrag`}
+          className="stepNode__Add plusButton nodrag"
           data-testid="stepNode__appendStep-btn"
           disabled={disableButton}
           aria-disabled={disableButton}

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -1,4 +1,5 @@
-import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
+import { useShowBranchTab } from '@kaoto/hooks';
+import { ValidationService } from '@kaoto/services';
 import { useIntegrationJsonStore, useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
 import { Popover, Tooltip } from '@patternfly/react-core';
@@ -13,7 +14,6 @@ interface IAddStepButton {
   layout: string;
   step: IStepProps;
   showStepsTab: boolean;
-  supportsBranching: boolean;
 }
 
 export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
@@ -22,41 +22,13 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
   layout,
   step,
   showStepsTab,
-  supportsBranching,
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
   const views = useIntegrationJsonStore((state) => state.views);
-  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(
-    StepsService.hasCustomStepExtension(step, views)
-  );
-  const [disableBranchesTab, setDisableBranchesTab] = useState(false);
-  const [disableBranchesTabMsg, setDisableBranchesTabMsg] = useState('');
+  const { disableBranchesTab, disableBranchesTabMsg } = useShowBranchTab(step, views);
+
   const [tooltipText, setTooltipText] = useState('');
   const [disableButton, setDisableButton] = useState(false);
-
-  useEffect(() => {
-    setHasCustomStepExtension(StepsService.hasCustomStepExtension(step, views));
-  }, [step, views]);
-
-  useEffect(() => {
-    const showBranchesTab = VisualizationService.showBranchesTab(step);
-    setDisableBranchesTab(hasCustomStepExtension || !showBranchesTab || !supportsBranching);
-  }, [step, hasCustomStepExtension, supportsBranching]);
-
-  useEffect(() => {
-    if (hasCustomStepExtension) {
-      setDisableBranchesTabMsg('Please click on the step to configure branches for it.');
-      return;
-    }
-
-    setDisableBranchesTabMsg(
-      ValidationService.getBranchTabTooltipMsg(
-        supportsBranching,
-        step.maxBranches,
-        step.branches?.length
-      )
-    );
-  }, [hasCustomStepExtension, step, supportsBranching]);
 
   useEffect(() => {
     setDisableButton(!showStepsTab && disableBranchesTab);

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -5,13 +5,14 @@ import { IStepProps } from '@kaoto/types';
 import { Popover, Tooltip } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useEffect, useState } from 'react';
+import { Position } from 'reactflow';
 import { BranchBuilder } from './BranchBuilder';
 import { MiniCatalog } from './MiniCatalog';
 
 interface IAddStepButton {
   handleAddBranch: () => void;
   handleSelectStep: (selectedStep: IStepProps) => void;
-  layout: string;
+  position: Position;
   step: IStepProps;
   showStepsTab: boolean;
 }
@@ -19,7 +20,7 @@ interface IAddStepButton {
 export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
   handleAddBranch,
   handleSelectStep,
-  layout,
+  position,
   step,
   showStepsTab,
 }) => {
@@ -69,7 +70,7 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
     >
       <Tooltip
         content={tooltipText}
-        position={layout === 'LR' ? 'top' : 'right'}
+        position={position}
       >
         <button
           className="stepNode__Add plusButton nodrag"

--- a/src/components/DeleteButtonEdge.tsx
+++ b/src/components/DeleteButtonEdge.tsx
@@ -1,5 +1,4 @@
-import './CustomEdge.css';
-import { OrangeExclamationTriangleIcon } from './Icons';
+import { usePosition } from '@kaoto/hooks';
 import { StepsService } from '@kaoto/services';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
 import { IVizStepNode } from '@kaoto/types';
@@ -7,6 +6,8 @@ import { Button, Popover, Tooltip } from '@patternfly/react-core';
 import { MinusIcon } from '@patternfly/react-icons';
 import { ReactNode } from 'react';
 import { EdgeText, getBezierPath, Position, useReactFlow } from 'reactflow';
+import './CustomEdge.css';
+import { OrangeExclamationTriangleIcon } from './Icons';
 
 const foreignObjectSize = 40;
 
@@ -46,6 +47,7 @@ const DeleteButtonEdge = ({
   const visualizationStore = useVisualizationStore();
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
 
+  const { tooltipPosition } = usePosition();
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({
     sourceX,
     sourceY,
@@ -109,7 +111,7 @@ const DeleteButtonEdge = ({
           >
             <Tooltip
               content={'Delete branch'}
-              position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
+              position={tooltipPosition}
             >
               <button className="deleteButton" data-testid={'stepNode__deleteBranch-btn'}>
                 <MinusIcon />

--- a/src/components/MiniCatalog.test.tsx
+++ b/src/components/MiniCatalog.test.tsx
@@ -1,27 +1,23 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { AlertProvider } from '../layout';
 import { MiniCatalog } from './MiniCatalog';
-import { screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
 
 describe('MiniCatalog.tsx', () => {
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <MiniCatalog />
-      </AlertProvider>
-    );
+  test('component renders correctly', async () => {
+    act(() => {
+      render(
+        <AlertProvider>
+          <MiniCatalog />
+        </AlertProvider>
+      );
+    });
 
-    const element = screen.getByTestId('miniCatalog');
-    expect(element).toBeInTheDocument();
-  });
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <MiniCatalog />
-      </AlertProvider>
-    );
+    await waitFor(() => {
+      const element = screen.getByTestId('miniCatalog');
+      expect(element).toBeInTheDocument();
 
-    const element = screen.getByText('start');
-    expect(element).toBeInTheDocument();
+      const startButton = screen.getByText('start');
+      expect(startButton).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -45,7 +45,7 @@ const PlusButtonEdge = ({
   const nestedStepsStore = useNestedStepsStore();
   const visualizationStore = useVisualizationStore();
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
-  const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data);
+  const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data.step);
   const showStepsTab = VisualizationService.showStepsTab(sourceNode?.data);
 
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -1,7 +1,7 @@
 import { BranchBuilder, MiniCatalog } from '@kaoto/components';
-import { useShowBranchTab } from '@kaoto/hooks';
+import { usePosition, useShowBranchTab } from '@kaoto/hooks';
 import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
-import { useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
+import { useIntegrationJsonStore } from '@kaoto/store';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { Popover, Tooltip } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
@@ -46,7 +46,7 @@ const PlusButtonEdge = ({
   const showBranchesTab = VisualizationService.showBranchesTab(sourceNode?.data.step);
   const showStepsTab = VisualizationService.showStepsTab(sourceNode?.data);
 
-  const layout = useVisualizationStore((state) => state.layout);
+  const { tooltipPosition } = usePosition();
   const views = useIntegrationJsonStore((state) => state.views);
   const { disableBranchesTab, disableBranchesTabMsg } = useShowBranchTab(sourceNode?.data.step, views);
 
@@ -114,7 +114,7 @@ const PlusButtonEdge = ({
           >
             <Tooltip
               content={ValidationService.getPlusButtonTooltipMsg(showBranchesTab, showStepsTab)}
-              position={layout === 'LR' ? 'top' : 'right'}
+              position={tooltipPosition}
             >
               <button className="plusButton" data-testid={'stepNode__insertStep-btn'}>
                 <PlusIcon />

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -50,10 +50,7 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
         position={layout === 'LR' ? 'top' : 'right'}
       >
         <button
-          className={`${layout === 'LR'
-            ? 'stepNode__Prepend'
-            : 'stepNode__Prepend--vertical'
-            } plusButton nodrag`}
+          className="stepNode__Prepend plusButton nodrag"
           data-testid="stepNode__prependStep-btn"
         >
           <PlusIcon />

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -1,20 +1,21 @@
-import { Popover, Tooltip } from '@patternfly/react-core';
-import { PlusIcon } from '@patternfly/react-icons';
-import { FunctionComponent } from 'react';
 import { ValidationService } from '@kaoto/services';
 import { useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
+import { Popover, Tooltip } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+import { Position } from 'reactflow';
 import { MiniCatalog } from './MiniCatalog';
 
 interface IPrependStepButton {
   onMiniCatalogClickPrepend: (selectedStep: IStepProps) => void;
-  layout: string;
+  position: Position;
   step: IStepProps;
 }
 
 export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
   onMiniCatalogClickPrepend,
-  layout,
+  position,
   step,
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
@@ -47,7 +48,7 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
     >
       <Tooltip
         content="Add a step"
-        position={layout === 'LR' ? 'top' : 'right'}
+        position={position}
       >
         <button
           className="stepNode__Prepend plusButton nodrag"

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -1,0 +1,72 @@
+import { Popover, Tooltip } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent } from 'react';
+import { ValidationService } from '@kaoto/services';
+import { useSettingsStore } from '@kaoto/store';
+import { IStepProps } from '@kaoto/types';
+import { BranchBuilder } from './BranchBuilder';
+import { MiniCatalog } from './MiniCatalog';
+
+interface IPrependStepButton {
+  handleAddBranch: () => void;
+  onMiniCatalogClickPrepend: (selectedStep: IStepProps) => void;
+  layout: string;
+  step: IStepProps;
+  showStepsTab: boolean;
+}
+
+export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
+  handleAddBranch,
+  onMiniCatalogClickPrepend,
+  layout,
+  step,
+  showStepsTab,
+}) => {
+  const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
+
+  return (
+    <Popover
+    id="popover-prepend-step"
+    appendTo={() => document.body}
+    aria-label="Add a step"
+    bodyContent={
+      <MiniCatalog
+        children={<BranchBuilder handleAddBranch={handleAddBranch} />}
+        disableBranchesTab={true}
+        disableBranchesTabMsg={"You can't add a branch from here."}
+        disableStepsTab={false}
+        handleSelectStep={onMiniCatalogClickPrepend}
+        queryParams={{
+          dsl: currentDSL,
+          type: ValidationService.prependableStepTypes(),
+        }}
+        step={step}
+      />
+    }
+    className={'miniCatalog__popover'}
+    data-testid={'miniCatalog__popover'}
+    enableFlip={true}
+    flipBehavior={['top-start', 'left-start']}
+    hasAutoWidth
+    hideOnOutsideClick={true}
+    position={'left-start'}
+    showClose={false}
+  >
+    <Tooltip
+      content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+      position={layout === 'LR' ? 'top' : 'right'}
+    >
+      <button
+        className={`${
+          layout === 'LR'
+            ? 'stepNode__Prepend'
+            : 'stepNode__Prepend--vertical'
+        } plusButton nodrag`}
+        data-testid={'stepNode__prependStep-btn'}
+      >
+        <PlusIcon />
+      </button>
+    </Tooltip>
+  </Popover>
+  )
+};

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -26,47 +26,46 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
 
   return (
     <Popover
-    id="popover-prepend-step"
-    appendTo={() => document.body}
-    aria-label="Add a step"
-    bodyContent={
-      <MiniCatalog
-        children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-        disableBranchesTab={true}
-        disableBranchesTabMsg={"You can't add a branch from here."}
-        disableStepsTab={false}
-        handleSelectStep={onMiniCatalogClickPrepend}
-        queryParams={{
-          dsl: currentDSL,
-          type: ValidationService.prependableStepTypes(),
-        }}
-        step={step}
-      />
-    }
-    className={'miniCatalog__popover'}
-    data-testid={'miniCatalog__popover'}
-    enableFlip={true}
-    flipBehavior={['top-start', 'left-start']}
-    hasAutoWidth
-    hideOnOutsideClick={true}
-    position={'left-start'}
-    showClose={false}
-  >
-    <Tooltip
-      content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
-      position={layout === 'LR' ? 'top' : 'right'}
+      id="popover-prepend-step"
+      aria-label="Add a step"
+      bodyContent={
+        <MiniCatalog
+          disableBranchesTab={true}
+          disableBranchesTabMsg="You can't add a branch from here."
+          disableStepsTab={false}
+          handleSelectStep={onMiniCatalogClickPrepend}
+          queryParams={{
+            dsl: currentDSL,
+            type: ValidationService.prependableStepTypes(),
+          }}
+          step={step}
+        >
+          <BranchBuilder handleAddBranch={handleAddBranch} />
+        </MiniCatalog>
+      }
+      className="miniCatalog__popover"
+      data-testid="miniCatalog__popover"
+      enableFlip={true}
+      flipBehavior={['top-start', 'left-start']}
+      hasAutoWidth
+      hideOnOutsideClick={true}
+      position="left-start"
+      showClose={false}
     >
-      <button
-        className={`${
-          layout === 'LR'
+      <Tooltip
+        content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+        position={layout === 'LR' ? 'top' : 'right'}
+      >
+        <button
+          className={`${layout === 'LR'
             ? 'stepNode__Prepend'
             : 'stepNode__Prepend--vertical'
-        } plusButton nodrag`}
-        data-testid={'stepNode__prependStep-btn'}
-      >
-        <PlusIcon />
-      </button>
-    </Tooltip>
-  </Popover>
+            } plusButton nodrag`}
+          data-testid="stepNode__prependStep-btn"
+        >
+          <PlusIcon />
+        </button>
+      </Tooltip>
+    </Popover>
   )
 };

--- a/src/components/PrependStepButton.tsx
+++ b/src/components/PrependStepButton.tsx
@@ -4,23 +4,18 @@ import { FunctionComponent } from 'react';
 import { ValidationService } from '@kaoto/services';
 import { useSettingsStore } from '@kaoto/store';
 import { IStepProps } from '@kaoto/types';
-import { BranchBuilder } from './BranchBuilder';
 import { MiniCatalog } from './MiniCatalog';
 
 interface IPrependStepButton {
-  handleAddBranch: () => void;
   onMiniCatalogClickPrepend: (selectedStep: IStepProps) => void;
   layout: string;
   step: IStepProps;
-  showStepsTab: boolean;
 }
 
 export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
-  handleAddBranch,
   onMiniCatalogClickPrepend,
   layout,
   step,
-  showStepsTab,
 }) => {
   const currentDSL = useSettingsStore((state) => state.settings.dsl.name);
 
@@ -39,9 +34,7 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
             type: ValidationService.prependableStepTypes(),
           }}
           step={step}
-        >
-          <BranchBuilder handleAddBranch={handleAddBranch} />
-        </MiniCatalog>
+        />
       }
       className="miniCatalog__popover"
       data-testid="miniCatalog__popover"
@@ -53,7 +46,7 @@ export const PrependStepButton: FunctionComponent<IPrependStepButton> = ({
       showClose={false}
     >
       <Tooltip
-        content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
+        content="Add a step"
         position={layout === 'LR' ? 'top' : 'right'}
       >
         <button

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -52,16 +52,16 @@
     border: 3px solid rgb(0, 136, 206);
 }
 
-.stepNode__Add {
+.stepNode .stepNode__Add {
     position: absolute;
     right: -24px;
     top: 38%;
 }
 
-.stepNode__Add--vertical {
-    position: absolute;
+.stepNode.stepNode--TB .stepNode__Add {
     right: 30px;
     bottom: -63%;
+    top: auto;
 }
 
 .stepNode__Delete {
@@ -112,8 +112,7 @@
     top: 38%;
 }
 
-.stepNode__Prepend--vertical {
-    position: absolute;
+.stepNode.stepNode--TB .stepNode__Prepend {
     left: 30px;
     top: -30%;
 }

--- a/src/components/Visualization.test.tsx
+++ b/src/components/Visualization.test.tsx
@@ -1,5 +1,6 @@
 import { IIntegrationJsonStore, RFState, useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { AlertProvider } from '../layout';
 import { integrationJSONStub, stepsStub } from '../__mocks__/steps';
 import { Visualization } from './Visualization';
@@ -33,14 +34,19 @@ beforeAll(() => {
 });
 
 describe('Visualization.tsx', () => {
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <Visualization />
-      </AlertProvider>
-    );
-    const element = screen.getByTestId('react-flow-wrapper');
-    expect(element).toBeInTheDocument();
+  test('component renders correctly', async () => {
+    act(() => {
+      render(
+        <AlertProvider>
+          <Visualization />
+        </AlertProvider>
+      );
+    });
+
+    await waitFor(() => {
+      const element = screen.getByTestId('react-flow-wrapper');
+      expect(element).toBeInTheDocument();
+    });
   });
 
   test('should expands the details panel upon clicking on a step', async () => {

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,20 +1,21 @@
-import { AppendStepButton } from './AppendStepButton';
-import { BranchBuilder } from './BranchBuilder';
-import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
 import { StepsService, VisualizationService } from '@kaoto/services';
 import {
   useIntegrationJsonStore,
   useNestedStepsStore,
   useSettingsStore,
-  useVisualizationStore,
+  useVisualizationStore
 } from '@kaoto/store';
 import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
+import { useEffect, useState } from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
+import { AppendStepButton } from './AppendStepButton';
+import { BranchBuilder } from './BranchBuilder';
 import { PrependStepButton } from './PrependStepButton';
+import './Visualization.css';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -31,6 +32,16 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const supportsBranching = StepsService.supportsBranching(data.step);
 
   const layout = useVisualizationStore((state) => state.layout);
+  const [plusIconPosition, setPlusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Right);
+  const [minusIconPosition, setMinusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Left);
+  const [leftHandlePosition, setLeftHandlePosition] = useState(layout === 'LR' ? Position.Left : Position.Top);
+  const [rightHandlePosition, setRightHandlePosition] = useState(layout === 'LR' ? Position.Right : Position.Bottom);
+  useEffect(() => {
+    setPlusIconPosition(layout === 'LR' ? Position.Top : Position.Right);
+    setMinusIconPosition(layout === 'LR' ? Position.Top : Position.Left);
+    setLeftHandlePosition(layout === 'LR' ? Position.Left : Position.Top);
+    setRightHandlePosition(layout === 'LR' ? Position.Right : Position.Bottom);
+  }, [layout]);
 
   const { addAlert } = useAlert() || {};
 
@@ -133,7 +144,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {visualizationService.showPrependStepButton(data) && (
             <PrependStepButton
               onMiniCatalogClickPrepend={onMiniCatalogClickPrepend}
-              layout={layout}
+              position={plusIconPosition}
               step={data.step}
             />
           )}
@@ -144,7 +155,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               className={'stepHandle'}
               isConnectable={false}
               type="target"
-              position={layout === 'LR' ? Position.Left : Position.Top}
+              position={leftHandlePosition}
               id="a"
             />
           )}
@@ -152,7 +163,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* DELETE STEP BUTTON */}
           <Tooltip
             content={'Delete step'}
-            position={layout === 'LR' ? 'top' : 'left'}
+            position={minusIconPosition}
           >
             <button
               className="stepNode__Delete trashButton nodrag"
@@ -177,7 +188,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               className={'stepHandle'}
               isConnectable={false}
               type="source"
-              position={layout === 'LR' ? Position.Right : Position.Bottom}
+              position={rightHandlePosition}
               id="b"
             />
           )}
@@ -187,7 +198,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <AppendStepButton
               handleAddBranch={handleAddBranch}
               handleSelectStep={onMiniCatalogClickAppend}
-              layout={layout}
+              position={plusIconPosition}
               step={data.step}
               showStepsTab={showStepsTab}
             />
@@ -239,7 +250,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
                 className={'stepHandle'}
                 isConnectable={false}
                 type="target"
-                position={layout === 'LR' ? Position.Left : Position.Top}
+                position={leftHandlePosition}
                 id="a"
               />
             )}
@@ -253,7 +264,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <Handle
               className={'stepHandle'}
               type="source"
-              position={layout === 'LR' ? Position.Right : Position.Bottom}
+              position={rightHandlePosition}
               id="b"
               isConnectable={false}
             />

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -30,6 +30,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const showStepsTab = VisualizationService.showStepsTab(data);
   const supportsBranching = StepsService.supportsBranching(data.step);
 
+  const layout = useVisualizationStore((state) => state.layout);
+
   const { addAlert } = useAlert() || {};
 
   const onMiniCatalogClickAppend = (selectedStep: IStepProps) => {
@@ -115,7 +117,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     <>
       {!data.isPlaceholder ? (
         <div
-          className={`stepNode` + getSelectedClass() + getHoverClass()}
+          className={`stepNode stepNode--${layout}` + getSelectedClass() + getHoverClass()}
           onDrop={onDropReplace}
           onMouseEnter={() => {
             if (data.branchInfo || supportsBranching) {
@@ -131,7 +133,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {visualizationService.showPrependStepButton(data) && (
             <PrependStepButton
               onMiniCatalogClickPrepend={onMiniCatalogClickPrepend}
-              layout={visualizationStore.layout}
+              layout={layout}
               step={data.step}
             />
           )}
@@ -142,7 +144,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               className={'stepHandle'}
               isConnectable={false}
               type="target"
-              position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
+              position={layout === 'LR' ? Position.Left : Position.Top}
               id="a"
             />
           )}
@@ -150,7 +152,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* DELETE STEP BUTTON */}
           <Tooltip
             content={'Delete step'}
-            position={visualizationStore.layout === 'LR' ? 'top' : 'left'}
+            position={layout === 'LR' ? 'top' : 'left'}
           >
             <button
               className="stepNode__Delete trashButton nodrag"
@@ -175,7 +177,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               className={'stepHandle'}
               isConnectable={false}
               type="source"
-              position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
+              position={layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
             />
           )}
@@ -185,7 +187,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <AppendStepButton
               handleAddBranch={handleAddBranch}
               handleSelectStep={onMiniCatalogClickAppend}
-              layout={visualizationStore.layout}
+              layout={layout}
               step={data.step}
               showStepsTab={showStepsTab}
             />
@@ -237,7 +239,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
                 className={'stepHandle'}
                 isConnectable={false}
                 type="target"
-                position={visualizationStore.layout === 'LR' ? Position.Left : Position.Top}
+                position={layout === 'LR' ? Position.Left : Position.Top}
                 id="a"
               />
             )}
@@ -251,7 +253,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <Handle
               className={'stepHandle'}
               type="source"
-              position={visualizationStore.layout === 'LR' ? Position.Right : Position.Bottom}
+              position={layout === 'LR' ? Position.Right : Position.Bottom}
               id="b"
               isConnectable={false}
             />

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -2,7 +2,7 @@ import { AppendStepButton } from './AppendStepButton';
 import { BranchBuilder } from './BranchBuilder';
 import './Visualization.css';
 import { MiniCatalog } from '@kaoto/components';
-import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
+import { StepsService, VisualizationService } from '@kaoto/services';
 import {
   useIntegrationJsonStore,
   useNestedStepsStore,
@@ -11,9 +11,10 @@ import {
 } from '@kaoto/store';
 import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
-import { CubesIcon, PlusIcon, MinusIcon } from '@patternfly/react-icons';
+import { CubesIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { Handle, NodeProps, Position } from 'reactflow';
+import { PrependStepButton } from './PrependStepButton';
 
 const currentDSL = useSettingsStore.getState().settings.dsl.name;
 
@@ -128,49 +129,13 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
         >
           {/* PREPEND STEP BUTTON */}
           {visualizationService.showPrependStepButton(data) && (
-            <Popover
-              id="popover-prepend-step"
-              appendTo={() => document.body}
-              aria-label="Add a step"
-              bodyContent={
-                <MiniCatalog
-                  children={<BranchBuilder handleAddBranch={handleAddBranch} />}
-                  disableBranchesTab={true}
-                  disableBranchesTabMsg={"You can't add a branch from here."}
-                  disableStepsTab={!visualizationService.showPrependStepButton(data)}
-                  handleSelectStep={onMiniCatalogClickPrepend}
-                  queryParams={{
-                    dsl: currentDSL,
-                    type: ValidationService.prependableStepTypes(),
-                  }}
-                  step={data.step}
-                />
-              }
-              className={'miniCatalog__popover'}
-              data-testid={'miniCatalog__popover'}
-              enableFlip={true}
-              flipBehavior={['top-start', 'left-start']}
-              hasAutoWidth
-              hideOnOutsideClick={true}
-              position={'left-start'}
-              showClose={false}
-            >
-              <Tooltip
-                content={ValidationService.getPlusButtonTooltipMsg(false, showStepsTab)}
-                position={visualizationStore.layout === 'LR' ? 'top' : 'right'}
-              >
-                <button
-                  className={`${
-                    visualizationStore.layout === 'LR'
-                      ? 'stepNode__Prepend'
-                      : 'stepNode__Prepend--vertical'
-                  } plusButton nodrag`}
-                  data-testid={'stepNode__prependStep-btn'}
-                >
-                  <PlusIcon />
-                </button>
-              </Tooltip>
-            </Popover>
+            <PrependStepButton
+              handleAddBranch={handleAddBranch}
+              onMiniCatalogClickPrepend={onMiniCatalogClickPrepend}
+              layout={visualizationStore.layout}
+              step={data.step}
+              showStepsTab={showStepsTab}
+            />
           )}
 
           {/* LEFT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,4 +1,5 @@
 import { MiniCatalog } from '@kaoto/components';
+import { useLayout } from '@kaoto/hooks';
 import { StepsService, VisualizationService } from '@kaoto/services';
 import {
   useIntegrationJsonStore,
@@ -10,8 +11,7 @@ import { IStepProps, IVizStepNodeData } from '@kaoto/types';
 import { AlertVariant, Popover, Tooltip } from '@patternfly/react-core';
 import { CubesIcon, MinusIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { useEffect, useState } from 'react';
-import { Handle, NodeProps, Position } from 'reactflow';
+import { Handle, NodeProps } from 'reactflow';
 import { AppendStepButton } from './AppendStepButton';
 import { BranchBuilder } from './BranchBuilder';
 import { PrependStepButton } from './PrependStepButton';
@@ -31,17 +31,13 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const showStepsTab = VisualizationService.showStepsTab(data);
   const supportsBranching = StepsService.supportsBranching(data.step);
 
-  const layout = useVisualizationStore((state) => state.layout);
-  const [plusIconPosition, setPlusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Right);
-  const [minusIconPosition, setMinusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Left);
-  const [leftHandlePosition, setLeftHandlePosition] = useState(layout === 'LR' ? Position.Left : Position.Top);
-  const [rightHandlePosition, setRightHandlePosition] = useState(layout === 'LR' ? Position.Right : Position.Bottom);
-  useEffect(() => {
-    setPlusIconPosition(layout === 'LR' ? Position.Top : Position.Right);
-    setMinusIconPosition(layout === 'LR' ? Position.Top : Position.Left);
-    setLeftHandlePosition(layout === 'LR' ? Position.Left : Position.Top);
-    setRightHandlePosition(layout === 'LR' ? Position.Right : Position.Bottom);
-  }, [layout]);
+  const {
+    layout,
+    plusIconPosition,
+    minusIconPosition,
+    leftHandlePosition,
+    rightHandlePosition,
+  } = useLayout();
 
   const { addAlert } = useAlert() || {};
 

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -188,7 +188,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               layout={visualizationStore.layout}
               step={data.step}
               showStepsTab={showStepsTab}
-              supportsBranching={supportsBranching}
             />
           )}
         </div>

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -26,7 +26,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const integrationJsonStore = useIntegrationJsonStore();
   const visualizationService = new VisualizationService(integrationJsonStore, visualizationStore);
   const stepsService = new StepsService(integrationJsonStore, nestedStepsStore, visualizationStore);
-  const showBranchesTab = VisualizationService.showBranchesTab(data);
+  const showBranchesTab = VisualizationService.showBranchesTab(data.step);
   const showStepsTab = VisualizationService.showStepsTab(data);
   const supportsBranching = StepsService.supportsBranching(data.step);
 
@@ -187,7 +187,6 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               handleSelectStep={onMiniCatalogClickAppend}
               layout={visualizationStore.layout}
               step={data.step}
-              showBranchesTab={showBranchesTab}
               showStepsTab={showStepsTab}
               supportsBranching={supportsBranching}
             />

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -130,11 +130,9 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
           {/* PREPEND STEP BUTTON */}
           {visualizationService.showPrependStepButton(data) && (
             <PrependStepButton
-              handleAddBranch={handleAddBranch}
               onMiniCatalogClickPrepend={onMiniCatalogClickPrepend}
               layout={visualizationStore.layout}
               step={data.step}
-              showStepsTab={showStepsTab}
             />
           )}
 

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,5 +1,5 @@
 import { MiniCatalog } from '@kaoto/components';
-import { useLayout } from '@kaoto/hooks';
+import { usePosition } from '@kaoto/hooks';
 import { StepsService, VisualizationService } from '@kaoto/services';
 import {
   useIntegrationJsonStore,
@@ -37,7 +37,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     minusIconPosition,
     leftHandlePosition,
     rightHandlePosition,
-  } = useLayout();
+  } = usePosition();
 
   const { addAlert } = useAlert() || {};
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './layout.hook';
 export * from './show-branch-tab.hook';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,2 @@
-export * from './layout.hook';
+export * from './position.hook';
 export * from './show-branch-tab.hook';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './show-branch-tab.hook';

--- a/src/hooks/layout.hook.ts
+++ b/src/hooks/layout.hook.ts
@@ -1,0 +1,28 @@
+import { useVisualizationStore } from '@kaoto/store';
+import { useEffect, useState } from 'react';
+import { Position } from 'reactflow';
+
+export const useLayout = () => {
+  const layout = useVisualizationStore((state) => state.layout);
+  const [plusIconPosition, setPlusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Right);
+  const [minusIconPosition, setMinusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Left);
+
+  const [leftHandlePosition, setLeftHandlePosition] = useState(layout === 'LR' ? Position.Left : Position.Top);
+  const [rightHandlePosition, setRightHandlePosition] = useState(layout === 'LR' ? Position.Right : Position.Bottom);
+
+  useEffect(() => {
+    setPlusIconPosition(layout === 'LR' ? Position.Top : Position.Right);
+    setMinusIconPosition(layout === 'LR' ? Position.Top : Position.Left);
+
+    setLeftHandlePosition(layout === 'LR' ? Position.Left : Position.Top);
+    setRightHandlePosition(layout === 'LR' ? Position.Right : Position.Bottom);
+  }, [layout]);
+
+  return {
+    layout,
+    plusIconPosition,
+    minusIconPosition,
+    leftHandlePosition,
+    rightHandlePosition,
+  };
+}

--- a/src/hooks/position.hook.ts
+++ b/src/hooks/position.hook.ts
@@ -1,8 +1,9 @@
 import { useVisualizationStore } from '@kaoto/store';
+import { TooltipPosition } from '@patternfly/react-core';
 import { useEffect, useState } from 'react';
 import { Position } from 'reactflow';
 
-export const useLayout = () => {
+export const usePosition = () => {
   const layout = useVisualizationStore((state) => state.layout);
   const [plusIconPosition, setPlusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Right);
   const [minusIconPosition, setMinusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Left);
@@ -10,12 +11,16 @@ export const useLayout = () => {
   const [leftHandlePosition, setLeftHandlePosition] = useState(layout === 'LR' ? Position.Left : Position.Top);
   const [rightHandlePosition, setRightHandlePosition] = useState(layout === 'LR' ? Position.Right : Position.Bottom);
 
+  const [tooltipPosition, setTooltipPosition] = useState(layout === 'LR' ? TooltipPosition.top : TooltipPosition.right);
+
   useEffect(() => {
     setPlusIconPosition(layout === 'LR' ? Position.Top : Position.Right);
     setMinusIconPosition(layout === 'LR' ? Position.Top : Position.Left);
 
     setLeftHandlePosition(layout === 'LR' ? Position.Left : Position.Top);
     setRightHandlePosition(layout === 'LR' ? Position.Right : Position.Bottom);
+
+    setTooltipPosition(layout === 'LR' ? TooltipPosition.top : TooltipPosition.right);
   }, [layout]);
 
   return {
@@ -24,5 +29,6 @@ export const useLayout = () => {
     minusIconPosition,
     leftHandlePosition,
     rightHandlePosition,
+    tooltipPosition,
   };
 }

--- a/src/hooks/show-branch-tab.hook.ts
+++ b/src/hooks/show-branch-tab.hook.ts
@@ -1,0 +1,40 @@
+import { StepsService, ValidationService, VisualizationService } from '@kaoto/services';
+import { IStepProps, IViewProps } from '@kaoto/types';
+import { useEffect, useState } from 'react';
+
+export const useShowBranchTab = (step: IStepProps, views: IViewProps[]) => {
+  const supportsBranching = StepsService.supportsBranching(step);
+
+  const [hasCustomStepExtension, setHasCustomStepExtension] = useState(
+    StepsService.hasCustomStepExtension(step, views)
+  );
+
+  const [disableBranchesTab, setDisableBranchesTab] = useState(false);
+  const [disableBranchesTabMsg, setDisableBranchesTabMsg] = useState('');
+
+  useEffect(() => {
+    setHasCustomStepExtension(StepsService.hasCustomStepExtension(step, views));
+  }, [step, views]);
+
+  useEffect(() => {
+    const showBranchesTab = VisualizationService.showBranchesTab(step);
+    setDisableBranchesTab(hasCustomStepExtension || !showBranchesTab || !supportsBranching);
+  }, [step, hasCustomStepExtension, supportsBranching]);
+
+  useEffect(() => {
+    if (hasCustomStepExtension) {
+      setDisableBranchesTabMsg('Please click on the step to configure branches for it.');
+      return;
+    }
+
+    setDisableBranchesTabMsg(
+      ValidationService.getBranchTabTooltipMsg(
+        supportsBranching,
+        step.maxBranches,
+        step.branches?.length
+      )
+    );
+  }, [hasCustomStepExtension, step, supportsBranching]);
+
+  return { disableBranchesTab, disableBranchesTabMsg };
+};

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -84,11 +84,7 @@ export class StepsService {
    * @param step
    */
   static containsBranches(step: IStepProps): boolean {
-    let containsBranching = false;
-    if (step.branches && step.branches.length > 0) {
-      containsBranching = true;
-    }
-    return containsBranching;
+    return Array.isArray(step.branches) && step.branches.length > 0;
   }
 
   deleteBranch(step: IStepProps, branchUuid: string) {

--- a/src/services/validationService.test.ts
+++ b/src/services/validationService.test.ts
@@ -108,7 +108,7 @@ describe('validationService', () => {
     expect(ValidationService.getPlusButtonTooltipMsg(true, true)).toBe('Add a step or branch');
     expect(ValidationService.getPlusButtonTooltipMsg(true, false)).toBe('Add a branch');
     expect(ValidationService.getPlusButtonTooltipMsg(false, true)).toBe('Add a step');
-    expect(ValidationService.getPlusButtonTooltipMsg(false, false)).toBe('');
+    expect(ValidationService.getPlusButtonTooltipMsg(false, false)).toBe('Please click on the step to configure branches for it.');
   });
 
   it('prependableStepTypes(): should return a comma-separated string of step types that can be prepended to a step', () => {

--- a/src/services/validationService.ts
+++ b/src/services/validationService.ts
@@ -116,7 +116,7 @@ export class ValidationService {
     } else if (showStepsTab) {
       return 'Add a step';
     } else {
-      return '';
+      return 'Please click on the step to configure branches for it.';
     }
   }
 

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -519,24 +519,23 @@ describe('visualizationService', () => {
   });
 
   it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
-    const step: IVizStepNodeData = {
-      label: '',
-      step: {} as IStepProps,
-    };
+    const step = {} as IStepProps;
 
     expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
     // has branches but not branch support
     expect(
       VisualizationService.showBranchesTab({
         ...step,
-        step: { ...step.step, branches: [] },
+        branches: [],
       })
     ).toBeFalsy();
 
     expect(
       VisualizationService.showBranchesTab({
         ...step,
-        step: { ...step.step, branches: [], minBranches: 0, maxBranches: -1 },
+        branches: [],
+        minBranches: 0,
+        maxBranches: -1,
       })
     ).toBeTruthy();
 
@@ -544,12 +543,9 @@ describe('visualizationService', () => {
     expect(
       VisualizationService.showBranchesTab({
         ...step,
-        step: {
-          ...step.step,
-          branches: [{}, {}] as IStepPropsBranch[],
-          minBranches: 0,
-          maxBranches: 2,
-        },
+        branches: [{}, {}] as IStepPropsBranch[],
+        minBranches: 0,
+        maxBranches: 2,
       })
     ).toBeFalsy();
   });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -635,7 +635,7 @@ export class VisualizationService {
   static showStepsTab(nodeData: IVizStepNodeData): boolean {
     // if it contains branches and no next step, show the steps tab
     if (StepsService.containsBranches(nodeData.step) && !nodeData.nextStepUuid) return true;
-    // if it contains branches, don't show the steps tab
+    // if it doesn't contains branches, don't show the steps tab
     return !StepsService.containsBranches(nodeData.step);
   }
 }

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -621,10 +621,10 @@ export class VisualizationService {
    * Determines whether to show the Branches tab in the mini catalog
    * @param nodeData
    */
-  static showBranchesTab(nodeData: IVizStepNodeData): boolean {
+  static showBranchesTab(step: IStepProps): boolean {
     return (
-      StepsService.supportsBranching(nodeData.step) &&
-      nodeData.step.branches?.length !== nodeData.step.maxBranches
+      StepsService.supportsBranching(step) &&
+      step.branches?.length !== step.maxBranches
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@kaoto/assets": ["./src/assets"],
       "@kaoto/components": ["./src/components"],
       "@kaoto/constants": ["./src/store/constants"],
+      "@kaoto/hooks": ["./src/hooks"],
       "@kaoto/layout": ["./src/layout"],
       "@kaoto/routes": ["./src/routes"],
       "@kaoto/services": ["./src/services"],

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -21,6 +21,7 @@
       "@kaoto/assets": ["./src/assets"],
       "@kaoto/components": ["./src/components"],
       "@kaoto/constants": ["./src/store/constants"],
+      "@kaoto/hooks": ["./src/hooks"],
       "@kaoto/layout": ["./src/layout"],
       "@kaoto/routes": ["./src/routes"],
       "@kaoto/services": ["./src/services"],


### PR DESCRIPTION
### Context
This pull request is the first of three pull requests:
1. #1503 **(This pull request)**
2. lordrip/kaoto-ui#1
3. lordrip/kaoto-ui#2

These pull requests are built on top of https://github.com/KaotoIO/kaoto-ui/pull/1485

### Description
Based on https://github.com/KaotoIO/kaoto-ui/issues/1473, when a step has an associated custom extension available and there's no next step available to pick, the MiniCatalog was still displayed to the user, with both tabs disabled but with a visible `Add Branch` button completely interactive.
![image](https://user-images.githubusercontent.com/16512618/225842969-2f734d2f-5593-4293-95ae-962465331e98.png)

### Changes
This commit disables the plus icon to avoid displaying a non-interactive popup to the user and provides a tooltip instead explaining what to do in order to configure the step.

This commit also targets small improvements in related tests, like changing the API signature of one of the services to only receive a step instead of a whole node.

fixes part of https://github.com/KaotoIO/kaoto-ui/issues/1473
