### PR TITLE
chore: Add AppendStepButton disable state

### DIFF
--- a/src/components/AppendStepButton.test.tsx
+++ b/src/components/AppendStepButton.test.tsx
@@ -199,4 +199,82 @@ describe('AppendStepButton.tsx', () => {
 
     spy.mockReset();
   });
+
+  test('should assign [data-disable-branchestab=true] when the branch tab is disabled', async () => {
+    const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(true);
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(false);
+
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          position={Position.Top}
+          showStepsTab={true}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    expect(plusIcon).toHaveAttribute('data-disable-branchestab', 'true');
+
+    spy.mockReset();
+  });
+
+  test('should assign [data-disable-branchestab=false] when the branch tab is enabled', async () => {
+    const spy = jest.spyOn(StepsService, 'hasCustomStepExtension').mockReturnValue(false);
+    supportsBranchingSpy = jest.spyOn(StepsService, 'supportsBranching').mockReturnValue(true);
+
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          position={Position.Top}
+          showStepsTab={true}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    expect(plusIcon).toHaveAttribute('data-disable-branchestab', 'false');
+
+    spy.mockReset();
+  });
+
+  test('should assign [data-disable-stepstab=true] when the step tab is disabled', async () => {
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          position={Position.Top}
+          showStepsTab={false}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    expect(plusIcon).toHaveAttribute('data-disable-stepstab', 'true');
+  });
+
+  test('should assign [data-disable-stepstab=false] when the step tab is enabled', async () => {
+    render(
+      <AlertProvider>
+        <AppendStepButton
+          handleAddBranch={noopFn}
+          handleSelectStep={noopFn}
+          position={Position.Top}
+          showStepsTab={true}
+          step={kameletSourceStepStub}
+        />
+      </AlertProvider>
+    );
+
+    const plusIcon = screen.getByTestId('stepNode__appendStep-btn');
+    expect(plusIcon).toHaveAttribute('data-disable-stepstab', 'false');
+  });
 });

--- a/src/components/AppendStepButton.tsx
+++ b/src/components/AppendStepButton.tsx
@@ -77,6 +77,8 @@ export const AppendStepButton: FunctionComponent<IAddStepButton> = ({
           data-testid="stepNode__appendStep-btn"
           disabled={disableButton}
           aria-disabled={disableButton}
+          data-disable-branchestab={disableBranchesTab}
+          data-disable-stepstab={!showStepsTab}
         >
           <PlusIcon />
         </button>

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -64,6 +64,15 @@
     top: auto;
 }
 
+button[data-disable-branchestab="true"][data-disable-stepstab="true"] {
+    cursor: not-allowed;
+    color:rgb(210, 210, 210)
+}
+
+button[data-disable-branchestab="true"][data-disable-stepstab="true"]:hover {
+    background: var(--pf-global--Color--light-200)
+}
+
 .stepNode__Delete {
     position: absolute;
     left: 0;


### PR DESCRIPTION
### Description
At the moment, when the AppendStepButton component is disabled, the only difference to the user is that the button does not react to click events and also displays a Tooltip explaining the situation.

### Changes
This commit adds a Disabled concept around the AppendStepButton component by disabling the hovering, slightly dimming the background color, and lastly, changing the cursor to a Block icon to clearly signal that it is disabled

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/16512618/226297727-3e53760c-e870-4af1-8a68-8d327e89e289.png) | ![image](https://user-images.githubusercontent.com/16512618/226297670-e95533fe-a90b-49e3-8c1d-e6b053f557b8.png) |

### A bigger example

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/16512618/226297999-e642a042-13f1-4abe-a6ef-c9f29eee9f6f.png) | ![image](https://user-images.githubusercontent.com/16512618/226297958-061423de-6317-4ffb-8a6d-ddf0f9b7141a.png) |

