### PR TITLE
chore: Rename .stepNode--TB class to .stepNode--vertical

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -58,7 +58,7 @@
     top: 38%;
 }
 
-.stepNode.stepNode--TB .stepNode__Add {
+.stepNode.stepNode--vertical .stepNode__Add {
     right: 30px;
     bottom: -63%;
     top: auto;
@@ -112,7 +112,7 @@
     top: 38%;
 }
 
-.stepNode.stepNode--TB .stepNode__Prepend {
+.stepNode.stepNode--vertical .stepNode__Prepend {
     left: 30px;
     top: -30%;
 }

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -32,7 +32,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
   const supportsBranching = StepsService.supportsBranching(data.step);
 
   const {
-    layout,
+    layoutCssClass,
     plusIconPosition,
     minusIconPosition,
     leftHandlePosition,
@@ -124,7 +124,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     <>
       {!data.isPlaceholder ? (
         <div
-          className={`stepNode stepNode--${layout}` + getSelectedClass() + getHoverClass()}
+          className={`stepNode stepNode--${layoutCssClass}` + getSelectedClass() + getHoverClass()}
           onDrop={onDropReplace}
           onMouseEnter={() => {
             if (data.branchInfo || supportsBranching) {

--- a/src/hooks/position.hook.ts
+++ b/src/hooks/position.hook.ts
@@ -5,6 +5,9 @@ import { Position } from 'reactflow';
 
 export const usePosition = () => {
   const layout = useVisualizationStore((state) => state.layout);
+
+  const [layoutCssClass, setLayoutCssClass] = useState(layout === 'LR' ? 'horizontal' : 'vertical');
+
   const [plusIconPosition, setPlusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Right);
   const [minusIconPosition, setMinusIconPosition] = useState(layout === 'LR' ? Position.Top : Position.Left);
 
@@ -14,6 +17,7 @@ export const usePosition = () => {
   const [tooltipPosition, setTooltipPosition] = useState(layout === 'LR' ? TooltipPosition.top : TooltipPosition.right);
 
   useEffect(() => {
+    setLayoutCssClass(layout === 'LR' ? 'horizontal' : 'vertical');
     setPlusIconPosition(layout === 'LR' ? Position.Top : Position.Right);
     setMinusIconPosition(layout === 'LR' ? Position.Top : Position.Left);
 
@@ -25,6 +29,7 @@ export const usePosition = () => {
 
   return {
     layout,
+    layoutCssClass,
     plusIconPosition,
     minusIconPosition,
     leftHandlePosition,


### PR DESCRIPTION
### Description
Currently we're using `TB` and `LR` tokens as part of CSS classes' name, in order to be a little bit more agnostic, we're switching to `vertical` and `horizontal` respectively

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/16512618/226301708-be064cc2-8140-4964-ba94-3dbdb946af62.png) | ![image](https://user-images.githubusercontent.com/16512618/226301516-6dff40c7-298b-4ab7-bcd2-b93ffaa11f0d.png) |
| ![image](https://user-images.githubusercontent.com/16512618/226302661-c46326e4-3862-45a4-889b-c3e6149f8fd1.png) | ![image](https://user-images.githubusercontent.com/16512618/226302803-d33581e3-05e9-4610-9353-2edfa125101f.png) |


