### PR TITLE
Revert "Fix the UI theme switch - add to local storage"

### DIFF
--- a/src/components/AppearanceModal.tsx
+++ b/src/components/AppearanceModal.tsx
@@ -1,6 +1,5 @@
-import { useEffect } from 'react';
-
-import { constants } from '@kaoto/constants';
+import { ThemeSwitcher } from './ThemeSwitcher';
+import LOCAL_STORAGE_EDITOR_THEME_KEY from '@kaoto/constants';
 import { useSettingsStore } from '@kaoto/store';
 import {
   Form,
@@ -11,9 +10,7 @@ import {
   Switch,
 } from '@patternfly/react-core';
 import { MoonIcon, SunIcon } from '@patternfly/react-icons';
-
-import { ThemeSwitcher } from './ThemeSwitcher';
-
+import { useEffect } from 'react';
 
 export interface IAppearanceModal {
   handleCloseModal: () => void;
@@ -27,19 +24,19 @@ export interface IAppearanceModal {
  * @constructor
  */
 const AppearanceModal = ({ handleCloseModal, isModalOpen }: IAppearanceModal) => {
-  const storedTheme = localStorage.getItem(constants.LOCAL_STORAGE_EDITOR_THEME_KEY);
+  const storedTheme = localStorage.getItem(LOCAL_STORAGE_EDITOR_THEME_KEY);
   const { settings, setSettings } = useSettingsStore();
 
   useEffect(() => {
     localStorage.setItem(
-      constants.LOCAL_STORAGE_EDITOR_THEME_KEY,
+      LOCAL_STORAGE_EDITOR_THEME_KEY,
       storedTheme ?? settings.editorIsLightMode.toString()
     );
   }, [settings.editorIsLightMode, storedTheme]);
 
-  const onToggleSwitchEditorTheme = (newEditorCheckedState: boolean) => {
-    setSettings({ ...settings, editorIsLightMode: newEditorCheckedState });
-    localStorage.setItem(constants.LOCAL_STORAGE_EDITOR_THEME_KEY, `${newEditorCheckedState}`);
+  const onToggleSwitchEditorTheme = (newCheckedState: boolean) => {
+    setSettings({ ...settings, editorIsLightMode: newCheckedState });
+    localStorage.setItem(LOCAL_STORAGE_EDITOR_THEME_KEY, `${newCheckedState}`);
   };
 
   return (
@@ -60,7 +57,7 @@ const AppearanceModal = ({ handleCloseModal, isModalOpen }: IAppearanceModal) =>
             <MoonIcon size="md" />
             <Switch
               aria-label="theme-editor-switch"
-              className="switch-editor-theme"
+              className="switch-theme"
               isChecked={settings.editorIsLightMode}
               onChange={onToggleSwitchEditorTheme}
               data-testid={'appearance--theme-editor-switch'}

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -7,7 +7,6 @@ import {
   DeploymentsModal,
   SettingsModal,
 } from '@kaoto/components';
-import { constants } from '@kaoto/constants';
 import { ValidationService } from '@kaoto/services';
 import {
   useDeploymentStore,
@@ -59,7 +58,6 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel }:
   const { settings, setSettings } = useSettingsStore((state) => state);
   const { sourceCode, setSourceCode } = useIntegrationSourceStore((state) => state);
   const deleteIntegration = useIntegrationJsonStore((state) => state.deleteIntegration);
-  const htmlTagElement = document.documentElement;
 
   const { deployment, setDeploymentCrd } = useDeploymentStore();
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
@@ -103,16 +101,6 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel }:
       setSettings(newSettings);
     });
   }, []);
-
-  // configure UI theme
-  useEffect(() => {
-    const uiTheme = localStorage.getItem(constants.LOCAL_STORAGE_UI_THEME_KEY) ?? "true";
-    if (uiTheme === "true") {
-      htmlTagElement?.classList.remove(constants.THEME_DARK_CLASS);
-    } else {
-      htmlTagElement?.classList.add(constants.THEME_DARK_CLASS);
-    }
-  }, [settings.uiLightMode]);
 
   const handleDeployStartClick = () => {
     startDeployment(sourceCode, settings.name, settings.namespace)

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,26 +1,44 @@
 import './ThemeSwitcher.css';
-import { constants } from '@kaoto/constants';
 import { PageHeaderTools, Switch } from '@patternfly/react-core';
 import { MoonIcon, SunIcon } from '@patternfly/react-icons';
-import { useSettingsStore } from '@kaoto/store';
+import { useEffect, useState } from 'react';
+
+const THEME_DARK_CLASS = 'pf-theme-dark';
+const LOCAL_STORAGE_THEME_KEY = 'KAOTO_UI_THEME_IS_LIGHT';
 
 export const ThemeSwitcher = () => {
-  const { settings, setSettings } = useSettingsStore();
+  const storedTheme = localStorage.getItem(LOCAL_STORAGE_THEME_KEY);
+  const localThemeisLight = !storedTheme || storedTheme === 'true';
+  const [isLightTheme, setIsLightTheme] = useState(localThemeisLight);
+  const htmlTagElement = document.documentElement;
 
-  const onToggleSwitchTheme = (newUiCheckedState: boolean) => {
-    setSettings({ ...settings, uiLightMode: newUiCheckedState });
-    localStorage.setItem(constants.LOCAL_STORAGE_UI_THEME_KEY, `${newUiCheckedState}`);
+  useEffect(() => {
+    loadThemeClass(localThemeisLight);
+  }, []);
+
+  const loadThemeClass = (isThemeLight: boolean) => {
+    if (isThemeLight) {
+      htmlTagElement?.classList.remove(THEME_DARK_CLASS);
+    } else {
+      htmlTagElement?.classList.add(THEME_DARK_CLASS);
+    }
+  };
+
+  const onToggleSwitchTheme = (newCheckedState: boolean) => {
+    setIsLightTheme(newCheckedState);
+    loadThemeClass(newCheckedState);
+    localStorage.setItem(LOCAL_STORAGE_THEME_KEY, `${newCheckedState}`);
   };
 
   return (
     <PageHeaderTools className="header-tools">
       <MoonIcon size="md" />
       <Switch
-        aria-label="theme-ui-switch"
-        className="switch-ui-theme"
-        isChecked={settings.uiLightMode}
+        aria-label="theme-switch"
+        className="switch-theme"
+        isChecked={isLightTheme}
         onChange={onToggleSwitchTheme}
-        data-testid={'appearance--theme-ui-switch'}
+        data-testid={'appearance--theme-switch'}
       />
       <SunIcon size="md" color="var(--pf-global--palette--gold-400)" />
     </PageHeaderTools>

--- a/src/store/constants.ts
+++ b/src/store/constants.ts
@@ -1,5 +1,3 @@
-export namespace constants {
-    export const LOCAL_STORAGE_EDITOR_THEME_KEY = "KAOTO_EDITOR_THEME_IS_LIGHT";
-    export const LOCAL_STORAGE_UI_THEME_KEY = "KAOTO_UI_THEME_IS_LIGHT";
-    export const THEME_DARK_CLASS = "pf-theme-dark";
-}
+const LOCAL_STORAGE_EDITOR_THEME_KEY = 'KAOTO_EDITOR_THEME_IS_LIGHT';
+
+export { LOCAL_STORAGE_EDITOR_THEME_KEY as default };

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import svg from '../assets/images/kaoto.svg';
-import { constants } from '@kaoto/constants';
+import LOCAL_STORAGE_EDITOR_THEME_KEY from '@kaoto/constants';
 import { CodeEditorMode, IDsl, ISettings } from '@kaoto/types';
 import { create } from 'zustand';
 
@@ -25,8 +25,7 @@ export const initialSettings: ISettings = {
   icon: svg,
   name: 'integration',
   namespace: '',
-  editorIsLightMode: localStorage.getItem(constants.LOCAL_STORAGE_EDITOR_THEME_KEY) === 'true',
-  uiLightMode: localStorage.getItem(constants.LOCAL_STORAGE_UI_THEME_KEY) == null ? true : localStorage.getItem(constants.LOCAL_STORAGE_UI_THEME_KEY) === 'true',
+  editorIsLightMode: localStorage.getItem(LOCAL_STORAGE_EDITOR_THEME_KEY) === 'true',
   editorMode: CodeEditorMode.FREE_EDIT,
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,6 @@ export interface ISettings {
   // e.g. 'KameletBinding'
   dsl: IDsl;
   editorIsLightMode: boolean;
-  uiLightMode: boolean;
   editorMode: CodeEditorMode;
 
   icon?: string;


### PR DESCRIPTION
Reverts KaotoIO/kaoto-ui#1531

This is breaking in VS Code. The kaoto Ui is not displayed anymore

There is this error in console log:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'LOCAL_STORAGE_EDITOR_THEME_KEY')
    at ../kaoto-ui/dist/lib/store/settingsStore.js (settingsStore.tsx:28:43)
    at __webpack_require__ (bootstrap:19:1)
    at ../kaoto-ui/dist/lib/store/deploymentStore.js (constants.ts:5:2)
    at __webpack_require__ (bootstrap:19:1)
    at ../kaoto-ui/dist/lib/store/index.js (deploymentStore.tsx:28:35)
    at __webpack_require__ (bootstrap:19:1)
    at ../kaoto-ui/dist/lib/components/AppearanceModal.js (request.ts:91:3)
    at __webpack_require__ (bootstrap:19:1)
    at ../kaoto-ui/dist/lib/components/index.js (import.ts:39:2)
    at __webpack_require__ (bootstrap:19:1)
 ```
 
 