### PR TITLE
fix(stepDetail): show prop default values in popover & placeholder

### DIFF
--- a/src/components/CustomJsonSchemaBridge.tsx
+++ b/src/components/CustomJsonSchemaBridge.tsx
@@ -13,11 +13,13 @@ export class CustomJsonSchemaBridge extends JSONSchemaBridge {
 
   getField(name: string): Record<string, any> {
     const field = super.getField(name);
-    const { description, ...props } = field;
+    const { defaultValue, description, ...props } = field;
 
     const isDisabled = field.type === 'object';
     const revisedField: Record<string, any> = {
-      labelIcon: description ? FieldLabelIcon({ description, disabled: isDisabled }) : undefined,
+      labelIcon: description
+        ? FieldLabelIcon({ defaultValue, description, disabled: isDisabled })
+        : undefined,
       ...props,
     };
     if (isDisabled) {

--- a/src/components/FieldLabelIcon.stories.tsx
+++ b/src/components/FieldLabelIcon.stories.tsx
@@ -1,0 +1,21 @@
+import { FieldLabelIcon } from './FieldLabelIcon';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Step Views/FieldLabelIcon',
+  component: FieldLabelIcon,
+  decorators: [
+    (Story) => (
+      <div style={{ margin: '3em' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as ComponentMeta<typeof FieldLabelIcon>;
+
+const Template: ComponentStory<typeof FieldLabelIcon> = (args) => {
+  return <FieldLabelIcon {...args} disabled={false} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/FieldLabelIcon.test.tsx
+++ b/src/components/FieldLabelIcon.test.tsx
@@ -1,0 +1,20 @@
+import { AlertProvider } from '../layout';
+import { FieldLabelIcon } from './FieldLabelIcon';
+import { screen } from '@testing-library/dom';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+describe('FieldLabelIcon.tsx', () => {
+  test('component renders if open', async () => {
+    render(
+      <AlertProvider>
+        <FieldLabelIcon disabled={false} />
+      </AlertProvider>
+    );
+    const element = screen.getByTestId('field-label-icon');
+    expect(element).toBeInTheDocument();
+    fireEvent.click(element);
+    await waitFor(() =>
+      expect(screen.getByTestId('property-description-popover')).toBeInTheDocument()
+    );
+  });
+});

--- a/src/components/FieldLabelIcon.tsx
+++ b/src/components/FieldLabelIcon.tsx
@@ -16,28 +16,27 @@ export const FieldLabelIcon = (props: FieldLabelIconProps) => {
   const headerContent = props.disabled
     ? 'Please use the source code editor to configure this property.'
     : '';
-  const bodyContent = () => {
-    return props.description ? (
-      <>
-        {props.description}
-        <>
-          <br />
-          <br />
-          <Text component={TextVariants.small}>Default: {props.defaultValue ?? 'null'}</Text>
-        </>
-      </>
-    ) : (
-      ''
-    );
+  const bodyContent = props.description ? props.description : '';
+
+  const footerContent = () => {
+    return <Text component={TextVariants.small}>Default: {props.defaultValue ?? 'null'}</Text>;
   };
+
   return (
-    <Popover headerContent={headerContent} bodyContent={bodyContent}>
+    <Popover
+      aria-label={'Property description'}
+      headerContent={headerContent}
+      bodyContent={bodyContent}
+      data-testid={'property-description-popover'}
+      footerContent={footerContent}
+    >
       <Button
         variant="plain"
         type="button"
         aria-label="More info for field"
         aria-describedby="form-group-label-info"
         className="pf-c-form__group-label-help"
+        data-testid={'field-label-icon'}
       >
         <HelpIcon />
       </Button>

--- a/src/components/FieldLabelIcon.tsx
+++ b/src/components/FieldLabelIcon.tsx
@@ -1,21 +1,35 @@
-import { Button, Popover } from '@patternfly/react-core';
+import { Button, Popover, Text, TextVariants } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
 type FieldLabelIconProps = {
+  defaultValue?: any;
   description?: string;
   disabled: boolean;
 };
 
 /**
  * Returns a label tooltip element for the form or undefined if the field has no description
- * @param description
  * @returns
+ * @param props
  */
 export const FieldLabelIcon = (props: FieldLabelIconProps) => {
   const headerContent = props.disabled
     ? 'Please use the source code editor to configure this property.'
     : '';
-  const bodyContent = props.description ? props.description : '';
+  const bodyContent = () => {
+    return props.description ? (
+      <>
+        {props.description}
+        <>
+          <br />
+          <br />
+          <Text component={TextVariants.small}>Default: {props.defaultValue ?? 'null'}</Text>
+        </>
+      </>
+    ) : (
+      ''
+    );
+  };
   return (
     <Popover headerContent={headerContent} bodyContent={bodyContent}>
       <Button

--- a/src/components/JsonSchemaConfigurator.tsx
+++ b/src/components/JsonSchemaConfigurator.tsx
@@ -45,6 +45,7 @@ export const JsonSchemaConfigurator = ({
         previousModel.current = model;
       }}
       data-testid={'json-schema-configurator'}
+      placeholder={true}
     >
       <AutoFields />
       <ErrorsField />

--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -1,3 +1,4 @@
+import { dynamicImport } from './import';
 import { Extension, JsonSchemaConfigurator, StepErrorBoundary } from '@kaoto/components';
 import { StepsService } from '@kaoto/services';
 import { useIntegrationJsonStore } from '@kaoto/store';
@@ -17,7 +18,6 @@ import {
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import debounce from 'lodash.debounce';
 import { lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { dynamicImport } from './import';
 
 export interface IStepViewsProps {
   isPanelExpanded: boolean;
@@ -80,8 +80,9 @@ const VisualizationStepViews = ({
 
   useEffect(() => {
     setActiveTabKey(configTabIndex);
-    let tempSchemaObject: { [label: string]: { type: string; value?: any; description?: string } } =
-      {};
+    let tempSchemaObject: {
+      [label: string]: { type: string; value?: any; description?: string };
+    } = {};
 
     let tempModelObject = {} as IStepPropsParameters;
 
@@ -97,11 +98,14 @@ const VisualizationStepViews = ({
     setActiveTabKey(tabIndex);
   }, []);
 
-  const onChangeModel = useCallback((configuration: unknown, isValid: boolean): void => {
-    if (isValid) {
-      debouncedSaveConfig.current(configuration);
-    }
-  }, [debouncedSaveConfig]);
+  const onChangeModel = useCallback(
+    (configuration: unknown, isValid: boolean): void => {
+      if (isValid) {
+        debouncedSaveConfig.current(configuration);
+      }
+    },
+    [debouncedSaveConfig]
+  );
 
   return (
     <>
@@ -147,10 +151,10 @@ const VisualizationStepViews = ({
                     {step.type === 'START'
                       ? 'Source'
                       : step.type === 'MIDDLE'
-                        ? 'Action'
-                        : step.type === 'END'
-                          ? 'Sink'
-                          : ''}
+                      ? 'Action'
+                      : step.type === 'END'
+                      ? 'Sink'
+                      : ''}
                   </GridItem>
                 </Grid>
                 <br />

--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -80,9 +80,8 @@ const VisualizationStepViews = ({
 
   useEffect(() => {
     setActiveTabKey(configTabIndex);
-    let tempSchemaObject: {
-      [label: string]: { type: string; value?: any; description?: string };
-    } = {};
+    let tempSchemaObject: { [label: string]: { type: string; value?: any; description?: string } } =
+      {};
 
     let tempModelObject = {} as IStepPropsParameters;
 

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -515,7 +515,6 @@ export class StepsService {
     return !!(step.minBranches || step.maxBranches);
   }
 
-
   /**
    * Determines if a given step has a custom step extension
    * @param step
@@ -573,7 +572,7 @@ export class StepsService {
   }
 
   /**
-   * Add records to provded model and the schema for Config views
+   * Add records to provided model and the schema for Config views
    * @param parameter config parameter of the step
    * @param modelObjectRef reference to the model object
    * @param schemaObjectRef reference to the schema object
@@ -581,12 +580,14 @@ export class StepsService {
   static buildStepSchemaAndModel(
     parameter: IStepPropsParameters,
     modelObjectRef: IStepPropsParameters,
-    schemaObjectRef: { [label: string]: { type: string; value?: any; description?: string } }
+    schemaObjectRef: {
+      [label: string]: { type: string; defaultValue?: any; value?: any; description?: string };
+    }
   ) {
     const propKey = parameter.id;
-    const { type, description } = parameter;
+    const { type, defaultValue, description } = parameter;
     if (type !== 'array' || (type === 'array' && parameter.value && parameter.value.length > 0)) {
-      schemaObjectRef[propKey] = { type, description };
+      schemaObjectRef[propKey] = { type, defaultValue, description };
       modelObjectRef[propKey] = parameter.value ?? parameter.defaultValue;
     }
   }

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -581,13 +581,24 @@ export class StepsService {
     parameter: IStepPropsParameters,
     modelObjectRef: IStepPropsParameters,
     schemaObjectRef: {
-      [label: string]: { type: string; defaultValue?: any; value?: any; description?: string };
+      [label: string]: {
+        type: string;
+        defaultValue?: any;
+        value?: any;
+        description?: string;
+        uniforms?: { placeholder: any };
+      };
     }
   ) {
     const propKey = parameter.id;
     const { type, defaultValue, description } = parameter;
     if (type !== 'array' || (type === 'array' && parameter.value && parameter.value.length > 0)) {
-      schemaObjectRef[propKey] = { type, defaultValue, description };
+      schemaObjectRef[propKey] = {
+        type,
+        defaultValue,
+        description,
+        uniforms: { placeholder: defaultValue },
+      };
       modelObjectRef[propKey] = parameter.value ?? parameter.defaultValue;
     }
   }


### PR DESCRIPTION
The PR adds the default property value to the existing popover for its description. It also shows the default value as a placeholder in the input field when empty. Fixes #1307 

## Changes
- Add popover footer with reference to `defaultValue`
- Add `placeholder` property to be included in schema object
- Set `placeholder` to `true` in `JsonSchemaConfigurator` component
- Add `data-testid` to action button and its popover for easier testing
- Add unit test and story for `FieldInputLabel`

## Screenshots

Property description popover when there is a default value:

<img width="525" alt="Screen Shot 2023-03-23 at 6 52 11 pm" src="https://user-images.githubusercontent.com/3844502/227520625-a713e995-d7d5-43d3-a855-51e713ebffa5.png">

Property description popover when there is no default value:

<img width="562" alt="Screen Shot 2023-03-23 at 6 28 52 pm" src="https://user-images.githubusercontent.com/3844502/227520684-52369dd4-bfdc-4f15-87c2-43d172025238.png">

Input field placeholder when field is empty and it contains a default value:

![Screen Shot 2023-03-24 at 10 46 39 am](https://user-images.githubusercontent.com/3844502/227520577-302f3680-1474-4d30-89d3-914ca7807697.png)

