### PR TITLE
E2E finish refactoring

### DIFF
--- a/cypress/e2e/01-settings/appearance.cy.js
+++ b/cypress/e2e/01-settings/appearance.cy.js
@@ -1,29 +1,31 @@
 describe('Settings: Appearance', () => {
   beforeEach(() => {
-    let url = Cypress.config().baseUrl;
-    cy.visit(url);
-    cy.get('.pf-c-toolbar__content-section').click();
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
+    cy.intercept('/v1/integrations/dsls').as('getDSLs');
+    cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+    cy.intercept('/v1/integrations*').as('getIntegration');
+
+    cy.openHomePage();
+    cy.openAppearanceModal();
   });
 
   it('Close and reopen appearance modal', () => {
-    // close
-    cy.get('#pf-modal-part-3 > .pf-c-button').click();
+    cy.closeAppearanceModal();
+    cy.openAppearanceModal();
 
-    // reopen
-    cy.get('.pf-c-toolbar__content-section').click();
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
+    // Check that the modal is open
     cy.get('[data-testid="appearance-modal"').should('be.visible');
   });
 
   it('enables dark mode in Kaoto', () => {
-    cy.get('[data-testid="appearance--theme-switch"]').click({ force: true });
+    cy.switchAppearanceTheme()
+
+    // Check that theme is dark
     cy.get('.pf-theme-dark').should('exist');
     cy.get('html').should('have.class', 'pf-theme-dark').and('have.css', 'color-scheme', 'dark');
 
-    cy.get('[data-testid="appearance--theme-switch"]').click({ force: true });
+    cy.switchAppearanceTheme()
+
+    // Check that theme is not dark
     cy.get('.pf-theme-dark').should('not.exist');
     cy.get('html')
       .should('not.have.class', 'pf-theme-dark')
@@ -31,17 +33,18 @@ describe('Settings: Appearance', () => {
   });
 
   it('enables light mode in code editor', () => {
-    cy.get('[data-testid="appearance--theme-editor-switch"]').click({ force: true });
-    cy.get('#pf-modal-part-3 > .pf-c-button').click();
+    cy.switchAppearanceTheme('editor')
+    cy.closeAppearanceModal();
+    cy.openCodeEditor();
 
-    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    // Check that theme is not dark
     cy.get('.monaco-scrollable-element').should('not.have.class', 'vs-dark');
 
-    cy.get('.pf-c-toolbar__content-section').click();
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
-    cy.get('[data-testid="appearance--theme-editor-switch"]').click({ force: true });
-    cy.get('#pf-modal-part-3 > .pf-c-button').click();
+    cy.openAppearanceModal();
+    cy.switchAppearanceTheme('editor')
+    cy.closeAppearanceModal();
+
+    // Check that theme is dark
     cy.get('.monaco-scrollable-element').should('have.class', 'vs-dark');
   });
 });

--- a/cypress/e2e/01-settings/settings.cy.js
+++ b/cypress/e2e/01-settings/settings.cy.js
@@ -1,91 +1,62 @@
 describe('Settings', () => {
   beforeEach(() => {
-    let url = Cypress.config().baseUrl;
     cy.intercept('/v1/integrations/dsls').as('getDSLs');
     cy.intercept('/v1/view-definitions').as('getViewDefinitions');
-    cy.intercept('/v1/integrations?dsl=*').as('getIntegration');
-    cy.intercept('/v1/deployments*').as('getDeployments');
+    cy.intercept('/v1/integrations*').as('getIntegration');
 
-    cy.visit(url);
+    cy.openHomePage();
 
-    cy.get('.pf-c-toolbar__content-section').click();
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+    cy.openSettingsModal();
   });
 
-  // MODAL ACTIONS (e.g. opening, closing)
-  it('loads the settings modal', () => {
+  it('Open/Close/Cancel settings menu', () => {
+    cy.closeMenuModal();
+
+    // CHECK settings modal is closed with close button
+    cy.get('[data-testid="settings-modal"]').should('not.exist');
+
+    cy.openSettingsModal();
+
+    // CHECK settings modal is open
     cy.get('[data-testid="settings-modal"]').should('be.visible');
-    cy.get('[data-ouia-component-id="OUIA-Generated-Modal-small-2-ModalBoxCloseButton"]').click();
 
-    // to test something isn't visible, we need to be able to select it
-    // so, we must use 'not.exist' instead of 'not.be.visible'
-    // see: https://github.com/cypress-io/cypress/issues/9348
-    cy.get('[data-testid="settings-modal"]').should('not.exist');
+    cy.cancelMenuModal();
 
-    // reopen to test other close button
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
-    cy.get('[data-testid="settings-modal--cancel"]').click();
+    // CHECK settings modal is closed with cancel button
     cy.get('[data-testid="settings-modal"]').should('not.exist');
   });
 
-  // FIELDS
-  it('updates the fields', () => {
-    // close modal
-    cy.get('[data-testid="settings-modal--cancel"]').click();
-    cy.get('[data-testid="settings-modal"]').should('not.exist');
-
-    // add a step
-    cy.get('.stepNode').contains('ADD A STEP').click({ force: true });
-    cy.get('#stepSearch').type('timer');
-    cy.get('[data-testid="miniCatalog__stepItem--timer"]').click();
-
-    cy.wait('@getDSLs');
-    cy.wait('@getViewDefinitions');
-
-    // reopen modal
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+  it('Updates the fields', () => {
+    cy.cancelMenuModal();
+    cy.replaceEmptyStepMiniCatalog('timer');
+    cy.openSettingsModal();
 
     // test validation
     cy.get('[data-testid="settings--integration-name"]').click().clear();
     cy.get('#integration-name-helper').should('be.visible');
     cy.get('[data-testid="settings--namespace"]').click().clear();
     cy.get('#namespace-helper').should('be.visible');
-
     cy.get('[data-testid="settings-modal--save"]').should('be.disabled');
 
     // make changes
-    cy.get('[data-testid="settings--integration-name"]')
-      .click()
-      .clear({ timeout: 6000 })
-      .type('cherry', { delay: 500 });
-    cy.get('[data-testid="settings--namespace"]')
-      .click()
-      .clear({ timeout: 6000 })
-      .type('example', { delay: 500 });
+    cy.get('[data-testid="settings--integration-name"]').click().clear().type('cherry');
+    cy.get('[data-testid="settings--namespace"]').click().clear().type('example');
 
     // save changes
-    cy.get('[data-testid="settings-modal--save"]').click();
+    cy.saveMenuModal();
 
-    // verify that steps are still there
+    // CHECK that steps are still there and toolbar contains new name
     cy.get('[data-testid="viz-step-timer"]').should('be.visible');
-
-    // verify that toolbar contains new name
     cy.get('[data-testid="kaoto-toolbar--name"]').should('have.text', 'cherry');
 
     // verify that source code editor contains new values
-    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    cy.openCodeEditor();
     cy.get('.code-editor').contains('timer');
 
-    // reopen modal, verify that value is changed accordingly
-    cy.wait('@getIntegration');
-    cy.get('.pf-c-alert__action > .pf-c-button').click();
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+    // reopen modal
+    cy.openSettingsModal();
 
-    // field assertion
+    // CHECK that value is changed accordingly
     cy.get('[data-testid="settings--integration-name"]').should('have.value', 'cherry');
     cy.get('[data-testid="settings--namespace"]').should('have.value', 'example');
   });
@@ -95,7 +66,6 @@ describe('Settings', () => {
     cy.get('[data-testid="settings--integration-type-helper-btn"]').click();
     cy.get('[data-testid="settings--integration-type-helper"]').should('be.visible');
     cy.get('[data-testid="settings--integration-type-helper-btn"]').click();
-    // close modal
     cy.get('[data-testid="settings-modal--cancel"]').click();
     cy.get('[data-testid="settings-modal"]').should('not.exist');
   });
@@ -103,78 +73,51 @@ describe('Settings', () => {
   it('Insert description', () => {
     const description = 'Sample description';
     cy.get('[data-testid="settings--description"]').type(description);
-    cy.get('[data-testid="settings-modal--save"]').click();
+    cy.saveMenuModal();
+    cy.openSettingsModal();
 
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+    // CHECK that value is changed accordingly
     cy.get('[data-testid="settings--description"]').should('have.text', description);
   });
 
-  // DSL ("INTEGRATION TYPE")
-  // for example, if using anything other than 'kamelet' as a step, KameletBinding
-  // should not be available in the DSL dropdown
-  it('only shows relevant DSLs', () => {
+  it('Only shows relevant DSLs', () => {
     cy.get('[data-testid="settings--integration-type"]')
       .select('Integration')
       .should('have.value', 'Integration');
-    cy.get('[data-testid="settings-modal--save"]').click();
-    cy.get('[data-testid="settings-modal"]').should('not.exist');
+    cy.saveMenuModal(true);
+    cy.replaceEmptyStepMiniCatalog('timer');
+    cy.openSettingsModal();
 
-    // add a non-Kamelet step
-    cy.get('.stepNode').contains('ADD A STEP').click({ force: true });
-    cy.get('#stepSearch').type('timer');
-    cy.get('[data-testid="miniCatalog__stepItem--timer"]').click();
-
-    cy.wait('@getDSLs');
-    cy.wait('@getViewDefinitions');
-
-    // reopen modal, make changes, save and close again
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
-
-    // KameletBinding DSL should not be available to select
+    // CHECK that KameletBinding DSL should not be available to select
     cy.get('[data-testid="settings--integration-type__KameletBinding"]').should('not.exist');
   });
 
-  // UPDATE THE DSL ("INTEGRATION TYPE")
   it('updates the DSL', () => {
     // close modal
     cy.get('[data-testid="settings--integration-type"]')
       .select('Integration')
       .should('have.value', 'Integration');
-    cy.get('[data-testid="settings-modal--save"]').click();
-    cy.get('[data-testid="settings-modal"]').should('not.exist');
+    cy.saveMenuModal(true);
 
-    // add a Kamelet step
-    cy.get('.stepNode').contains('ADD A STEP').click({ force: true });
-    cy.get('#stepSearch').type('kamelet');
-    cy.get('[data-testid="miniCatalog__stepItem--kamelet"]').click();
-
-    cy.wait('@getDSLs');
-    cy.wait('@getViewDefinitions');
-
-    cy.get('[data-testid="viz-step-kamelet"]').should('be.visible');
+    cy.replaceEmptyStepMiniCatalog('kamelet');
 
     // reopen modal, make changes, save and close again
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+    cy.openSettingsModal();
 
     // select Kamelet
     cy.get('[data-testid="settings--integration-type"]')
       .select('Kamelet')
       .should('have.value', 'Kamelet');
 
-    cy.get('[data-testid="settings-modal--save"]').click();
-    cy.get('.pf-c-alert__action > .pf-c-button').click();
+    cy.saveMenuModal(true);
 
-    // verify that steps are still there
+    // CHECK that steps are still there
     cy.get('[data-testid="viz-step-kamelet"]').should('be.visible');
 
-    // reopen modal, verify that value is still changed accordingly
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+    // reopen modal, 
+    cy.openSettingsModal();
 
-    // assert that DSL is still Kamelet
+    // CHECK that value is still Kamelet
     cy.get('[data-testid="settings--integration-type"]').should('have.value', 'Kamelet');
   });
 });

--- a/cypress/e2e/02-editing_properties/editing.cy.js
+++ b/cypress/e2e/02-editing_properties/editing.cy.js
@@ -7,8 +7,7 @@ describe('editing properties', () => {
     cy.openHomePage();
   });
 
-  // Blocked by issue #1576 -> https://github.com/KaotoIO/kaoto-ui/issues/1576
-  it.skip('loads the YAML editor', () => {
+  it('loads the YAML editor', () => {
     cy.uploadFixture('TimerKafka.yaml');
 
     // Configure timer - source step
@@ -35,6 +34,8 @@ describe('editing properties', () => {
     cy.checkCodeSpanLine('password', 'password');
 
     cy.closeStepConfigurationTab();
+
+    // CHECK that previous change is still there
     cy.checkCodeSpanLine('period:', '3000');
   });
 });

--- a/cypress/e2e/02-editing_properties/editing.cy.js
+++ b/cypress/e2e/02-editing_properties/editing.cy.js
@@ -1,64 +1,40 @@
 describe('editing properties', () => {
-  before(() => {
-    let url = Cypress.config().baseUrl;
-
+  beforeEach(() => {
     cy.intercept('/v1/integrations/dsls').as('getDSLs');
     cy.intercept('/v1/view-definitions').as('getViewDefinitions');
     cy.intercept('/v1/integrations*').as('getIntegration');
-    cy.intercept('/v1/deployments*').as('getDeployments');
 
-    cy.visit(url);
+    cy.openHomePage();
   });
 
-  it('loads the YAML editor', () => {
-    // LOAD FIXTURE
-    // attaches the file as an input, NOT drag-and-drop, as that will
-    // create a dropzone overlay that then prevents you from typing
-    cy.get('[data-testid="toolbar-show-code-btn"]').click();
-    cy.get('.pf-c-code-editor__main').should('be.visible');
-    cy.get('.pf-c-code-editor__main > input').attachFile('TimerKafka.yaml');
+  // Blocked by issue #1576 -> https://github.com/KaotoIO/kaoto-ui/issues/1576
+  it.skip('loads the YAML editor', () => {
+    cy.uploadFixture('TimerKafka.yaml');
 
-    // trigger the visualization to update
-    cy.get('[data-testid="sourceCode--applyButton"]').click();
+    // Configure timer - source step
+    cy.openStepConfigurationTab('timer-source');
+    cy.interactWithConfigInputObject('period', '3000');
+    cy.checkCodeSpanLine('period:', '3000');
+    cy.closeStepConfigurationTab();
 
-    // wait until the API returns the updated visualization
-    cy.wait('@getIntegration');
-    cy.wait('@getDSLs');
-    cy.wait('@getViewDefinitions');
+    // Configure kafka-sink step
+    cy.openStepConfigurationTab('kafka-sink');
+    cy.interactWithConfigInputObject('topic', 'topicname');
+    cy.interactWithConfigInputObject('bootstrapServers', 'bootstrap');
+    cy.interactWithConfigInputObject('securityProtocol', 'security');
+    cy.interactWithConfigInputObject('saslMechanism', 'sasl');
+    cy.interactWithConfigInputObject('user', 'user');
+    cy.interactWithConfigInputObject('password', 'password');
 
-    // verify the visualization & code editor both contain the
-    // new step (timer-source)
-    cy.get('[data-testid="viz-step-timer-source"]').click();
-    cy.get('[data-testid="configurationTab"]').click();
-    cy.get('input[name="period"]').type('3000');
+    // CHECK they are reflected in the code editor
+    cy.checkCodeSpanLine('topic', 'topicname');
+    cy.checkCodeSpanLine('bootstrapServers', 'bootstrap');
+    cy.checkCodeSpanLine('securityProtocol', 'security');
+    cy.checkCodeSpanLine('saslMechanism', 'sasl');
+    cy.checkCodeSpanLine('user', 'user');
+    cy.checkCodeSpanLine('password', 'password');
 
-    cy.get('.code-editor').should('contain.text', 'period');
-    cy.get('.pf-c-drawer__close > .pf-c-button').click();
-
-    // verify the visualization contains kafka-sink
-    cy.get('[data-testid="viz-step-kafka-sink"]').click();
-    cy.get('[data-testid="configurationTab"]').click();
-    cy.get('[data-testid="json-schema-configurator"]').click();
-
-    // update properties
-    cy.get('input[name="topic"]').clear().type('topicname');
-    cy.get('input[name="bootstrapServers"]').clear().type('bootstrap');
-    cy.get('input[name="securityProtocol"]').clear().type('security');
-    cy.get('input[name="saslMechanism"]').clear().type('sasl');
-    cy.get('input[name="user"]').clear().type('user');
-    cy.get('input[name="password"]').clear().type('password');
-
-    // verify they are reflected in the code editor
-    cy.get('.code-editor')
-      .should('contain.text', 'topicname')
-      .and('contain.text', 'bootstrap')
-      .and('contain.text', 'security')
-      .and('contain.text', 'sasl')
-      .and('contain.text', 'user')
-      .and('contain.text', 'password');
-
-    cy.get('.pf-c-drawer__close > .pf-c-button > svg').click();
-
-    cy.get('.code-editor').contains('period');
+    cy.closeStepConfigurationTab();
+    cy.checkCodeSpanLine('period:', '3000');
   });
 });

--- a/cypress/e2e/03-step_integration/step_integration.cy.js
+++ b/cypress/e2e/03-step_integration/step_integration.cy.js
@@ -1,76 +1,74 @@
 describe('3 step integration', () => {
   beforeEach(() => {
-    let url = Cypress.config().baseUrl;
-    cy.visit(url);
+    cy.intercept('/v1/integrations/dsls').as('getDSLs');
+    cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+    cy.intercept('/v1/integrations*').as('getIntegration');
+
+    cy.openHomePage();
   });
 
   it('add the step integration', () => {
-    cy.get('.stepNode').contains('ADD A STEP').click({ force: true });
-
     // add timer via drag and drop from the catalog
-    const dataTransfer = new DataTransfer();
-    cy.get('#stepSearch').type('timer');
-    cy.get('[data-testid="miniCatalog__stepItem--timer"]').click();
+    cy.dragAndDropFromCatalog('timer', 'slot', 'start');
 
-    // verify the code editor contains the new timer step
+    // CHECK the code editor contains the new timer step
     cy.get('[data-testid="toolbar-show-code-btn"]').click();
     cy.get('.code-editor').should('contain.text', 'timer');
 
     // add an action from the mini catalog
-    cy.get('[data-testid="stepNode__appendStep-btn"]').click();
-    cy.get('#stepSearch').type('aggre').wait(1000);
-    cy.get('[data-testid="miniCatalog__stepItem--aggregate"]').click();
+    cy.appendStepMiniCatalog('timer', 'aggregate');
+
+    // CHECK the code editor contains the new timer aggregate
     cy.get('.code-editor').should('contain.text', 'aggregate');
 
     // add kafka from the mini catalog
-    cy.get('[data-testid="stepNode__appendStep-btn"]').click();
-    cy.get('[data-testid="miniCatalog"]').should('be.visible');
-    cy.get('#END').click({ force: true });
-    cy.get('.pf-c-text-input-group__text-input').type('kafka');
-    cy.get('[data-testid="miniCatalog__stepItem--kafka"]').click();
+    cy.appendStepMiniCatalog('aggregate', 'kafka');
 
-    // verify the code editor contains the new kafka step
+    // CHECK the code editor contains the new kafka step
     cy.get('.code-editor').should('contain.text', 'kafka');
 
     // delete middle step
-    cy.get('[data-testid="viz-step-aggregate"]').trigger('mouseover');
-    cy.get(
-      '[data-testid="viz-step-aggregate"] > [data-testid="configurationTab__deleteBtn"]'
-    ).click({ force: true });
+    cy.deleteStep('aggregate');
 
     // open step catalog, replace timer with debezium-postgres
-    cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
-    cy.get('#stepSearch').click().clear();
-    cy.get('.pf-l-gallery').scrollTo('0%', '75%');
-    cy.get('.pf-c-card__title').contains('debezium-postgres').trigger('dragstart', {
-      dataTransfer,
-    });
-    cy.get('[data-testid="react-flow-wrapper"]').contains('timer').trigger('drop', {
-      dataTransfer,
-    });
+    cy.dragAndDropFromCatalog('debezium-postgres', 'timer', 'start');
 
     // verify the visualization has the correct steps (debezium-postgres)
     // and configuration loads as expected
-    cy.get('[data-testid="viz-step-debezium-postgres"]').click();
-    cy.get('[data-testid="configurationTab"]').should('be.visible');
-    cy.get('[data-testid="kaoto-left-drawer"]').within(() => {
-      cy.get('.pf-c-drawer__close > .pf-c-button').click();
-    });
-    cy.get('[data-testid="kaoto-right-drawer"]').within(() => {
-      cy.get('.pf-c-drawer__close > .pf-c-button').click();
-    });
-    // verify inserting a step updates both the visualization and code editor,
-    // and opens the mini catalog without issues
-    cy.get('[data-testid="stepNode__insertStep-btn"]').click();
-    cy.get('[data-testid="miniCatalog"]').should('be.visible');
-    cy.get('[data-testid="miniCatalog__search--input"]').type('chunk');
-    cy.get('[data-testid="miniCatalog__stepItem--chunk"]').click();
+    cy.openStepConfigurationTab('debezium-postgres');
+    cy.closeCatalogOrCodeEditor();
+    cy.closeStepConfigurationTab();
 
-    // verify the code editor has the correct steps (debezium-postgres, chunk, kafka)
-    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    // insert a step into the middle of the integration
+    // and opens the mini catalog without issues
+    cy.insertStepMiniCatalog('chunk');
+    cy.openCodeEditor();
+
+    // CHECK the code editor has the correct steps (debezium-postgres, chunk, kafka)
     cy.get('.code-editor')
       .should('contain.text', 'debezium-postgres')
       .and('contain.text', 'chunk')
       .and('contain.text', 'kafka');
+    // CHECK that stepNodes contains of the three steps
+    cy.get('.stepNode').should('have.length', 3);
+    // CHECK that stepNodes are in the correct order
+    cy.get('.stepNode').eq(0).should('have.attr', 'data-testid', 'viz-step-debezium-postgres');
+    cy.get('.stepNode').eq(1).should('have.attr', 'data-testid', 'viz-step-chunk');
+    cy.get('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-kafka');
+
+    // Sync up code editor
+    cy.syncUpCodeChanges();
+
+    // CHECK the code editor has the correct steps (debezium-postgres, chunk, kafka)
+    cy.get('.code-editor')
+      .should('contain.text', 'debezium-postgres')
+      .and('contain.text', 'chunk')
+      .and('contain.text', 'kafka');
+    // CHECK that stepNodes contains of the three steps
+    cy.get('.stepNode').should('have.length', 3);
+    // CHECK that stepNodes are in the correct order
+    cy.get('.stepNode').eq(0).should('have.attr', 'data-testid', 'viz-step-debezium-postgres');
+    cy.get('.stepNode').eq(1).should('have.attr', 'data-testid', 'viz-step-chunk');
+    cy.get('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-kafka');
   });
 });

--- a/cypress/e2e/06-undo_redo_actions/undo_redo_actions.cy.js
+++ b/cypress/e2e/06-undo_redo_actions/undo_redo_actions.cy.js
@@ -1,5 +1,5 @@
 describe('Test for undo/redo actions on code-editor', () => {
-  before(() => {
+  beforeEach(() => {
     cy.intercept('/v1/integrations/dsls').as('getDSLs');
     cy.intercept('/v1/view-definitions').as('getViewDefinitions');
     cy.intercept('/v1/integrations*').as('getIntegration');

--- a/cypress/e2e/07-catalog_actions/catalog_actions.cy.js
+++ b/cypress/e2e/07-catalog_actions/catalog_actions.cy.js
@@ -11,7 +11,7 @@ describe('Test for catalog actions', () => {
     });
 
     it("User drags and drops an invalid step onto a nested branch step", () => {
-        cy.dragAndDropFromCatalog('timer', 'digitalocean', 'start');
+        cy.dragAndDropFromCatalog('timer', 'digitalocean', 'start', 0, true);
 
         // CHECK digitalocean step is visible
         cy.get('[data-testid="viz-step-digitalocean"]').should('be.visible');

--- a/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
@@ -25,18 +25,22 @@ describe('User completes normal actions on steps in a branch', () => {
     it('User configures a step in a branch', () => {
         cy.openStepConfigurationTab('amqp');
 
-        cy.interactWithConfigInputObject('includeSentJMSMessageID');
-        cy.interactWithConfigInputObject('password', 'qwerty');
+        cy.interactWithConfigInputObject('allowNullBody');
+        cy.interactWithConfigInputObject('acknowledgementModeName', 'test-value');
 
         // CHECK that the step yaml is updated
-        cy.checkCodeSpanLine('includeSentJMSMessageID', 'true');
-        cy.checkCodeSpanLine('password', 'qwerty');
+        cy.checkCodeSpanLine('allowNullBody', 'false');
+        cy.checkCodeSpanLine('acknowledgementModeName', 'test-value');
     });
 
     it(' User deletes a step in a branch', () => {
         cy.deleteStep('amqp');
-        // Blocked due to: https://github.com/KaotoIO/kaoto-ui/issues/1381
-        // cy.syncUpCodeChanges();
+
+        // CHECK that amqp step is deleted and empty step is added
+        cy.get('[data-testid="viz-step-amqp"]').should('not.exist');
+        cy.get('[data-testid="viz-step-slot"]').should('have.length', 2).and('be.visible');
+
+        cy.syncUpCodeChanges();
 
         // CHECK that amqp step is deleted and empty step is added
         cy.get('[data-testid="viz-step-amqp"]').should('not.exist');

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -8,7 +8,7 @@ Cypress.Commands.add('openHomePage', () => {
 
 Cypress.Commands.add('zoomOutXTimes', (times) => {
     times = times ?? 1;
-    Array.from({ length: times }).map((_, i) => {
+    Array.from({ length: times }).forEach(() => {
         cy.get('.react-flow__controls-button.react-flow__controls-zoomout').click()
     });
 });

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -3,8 +3,7 @@ import 'cypress-file-upload';
 Cypress.Commands.add('openHomePage', () => {
     let url = Cypress.config().baseUrl;
     cy.visit(url);
-    cy.wait('@getDSLs');
-    cy.wait('@getViewDefinitions');
+    cy.waitVisualizationUpdate();
 });
 
 Cypress.Commands.add('zoomOutXTimes', (times) => {
@@ -15,7 +14,64 @@ Cypress.Commands.add('zoomOutXTimes', (times) => {
 });
 
 Cypress.Commands.add('waitVisualizationUpdate', () => {
+    cy.get('body').then((body) => {
+        if (body.find('.code-editor').length > 0) {
+            cy.wait('@getIntegration');
+        }
+        cy.wait('@getDSLs');
+        cy.wait('@getViewDefinitions');
+    });
+});
+
+Cypress.Commands.add('closeCatalogOrCodeEditor', () => {
+    cy.get('[data-testid="kaoto-left-drawer"]').within(() => {
+        cy.get('.pf-c-drawer__close > .pf-c-button').click();
+    });
+});
+
+Cypress.Commands.add('openMenuDropDown', () => {
+    cy.get('.pf-c-toolbar__content-section').click();
+    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
+});
+
+Cypress.Commands.add('openAppearanceModal', () => {
+    cy.openMenuDropDown();
+    cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
+});
+
+Cypress.Commands.add('openSettingsModal', () => {
+    cy.openMenuDropDown();
+    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+});
+
+Cypress.Commands.add('closeAppearanceModal', () => {
+    cy.get('#pf-modal-part-3 > .pf-c-button').click();
+});
+
+Cypress.Commands.add('closeMenuModal', () => {
+    cy.get('[data-ouia-component-id="OUIA-Generated-Modal-small-2-ModalBoxCloseButton"]').click();
+});
+
+Cypress.Commands.add('cancelMenuModal', () => {
+    cy.get('[data-testid="settings-modal--cancel"]').click();
+});
+
+Cypress.Commands.add('saveMenuModal', (integrationChanged) => {
+    integrationChanged = integrationChanged ?? false;
+    cy.get('[data-testid="settings-modal--save"]').click();
+    cy.get('.pf-c-alert').should('contain.text', 'Configuration settings saved successfully.');
+    cy.get('.pf-c-alert__action').children('button').click();
     cy.wait('@getIntegration');
-    cy.wait('@getDSLs');
-    cy.wait('@getViewDefinitions');
+    if (integrationChanged) {
+        cy.waitVisualizationUpdate();
+    }
+});
+
+Cypress.Commands.add('switchAppearanceTheme', (object) => {
+    object = object ?? '';
+    if (object === 'editor') {
+        cy.get('[data-testid="appearance--theme-editor-switch"]').click({ force: true });
+    } else {
+        cy.get('[data-testid="appearance--theme-switch"]').click({ force: true });
+    }
 });

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -8,7 +8,7 @@ Cypress.Commands.add('openHomePage', () => {
 
 Cypress.Commands.add('zoomOutXTimes', (times) => {
     times = times ?? 1;
-    Cypress._.times(times, () => {
+    Array.from({ length: times }, (_, i) => {
         cy.get('.react-flow__controls-button.react-flow__controls-zoomout').click()
     })
 });

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -8,9 +8,9 @@ Cypress.Commands.add('openHomePage', () => {
 
 Cypress.Commands.add('zoomOutXTimes', (times) => {
     times = times ?? 1;
-    Array.from({ length: times }, (_, i) => {
+    Array.from({ length: times }).map((_, i) => {
         cy.get('.react-flow__controls-button.react-flow__controls-zoomout').click()
-    })
+    });
 });
 
 Cypress.Commands.add('waitVisualizationUpdate', () => {

--- a/cypress/support/kaoto-ui-commands/editor.js
+++ b/cypress/support/kaoto-ui-commands/editor.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('openCodeEditor', () => {
 
 Cypress.Commands.add('editorAddText', (line, text) => {
     const arr = text.split('\n');
-    Cypress._.times(arr.length, (i) => {
+    Array.from({ length: arr.length }, (_, i) => {
         cy.get('.code-editor')
             .click()
             .type('{pageUp}{pageUp}' + '{downArrow}'.repeat(line + i) + '{enter}{upArrow}' + arr[i], {
@@ -45,7 +45,7 @@ Cypress.Commands.add('editorDeleteLine', (line, repeatCount) => {
 
 Cypress.Commands.add('editorClickUndoXTimes', (times) => {
     times = times ?? 1;
-    Cypress._.times(times, () => {
+    Array.from({ length: times }, (_, i) => {
         cy.get('[data-testid="sourceCode--undoButton"]').click();
     })
 });

--- a/cypress/support/kaoto-ui-commands/editor.js
+++ b/cypress/support/kaoto-ui-commands/editor.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('openCodeEditor', () => {
 
 Cypress.Commands.add('editorAddText', (line, text) => {
     const arr = text.split('\n');
-    Array.from({ length: arr.length }, (_, i) => {
+    Array.from({ length: arr.length }).map((_, i) => {
         cy.get('.code-editor')
             .click()
             .type('{pageUp}{pageUp}' + '{downArrow}'.repeat(line + i) + '{enter}{upArrow}' + arr[i], {
@@ -45,9 +45,9 @@ Cypress.Commands.add('editorDeleteLine', (line, repeatCount) => {
 
 Cypress.Commands.add('editorClickUndoXTimes', (times) => {
     times = times ?? 1;
-    Array.from({ length: times }, (_, i) => {
-        cy.get('[data-testid="sourceCode--undoButton"]').click();
-    })
+    Array.from({ length: times }).map((_, i) => {
+        return cy.get('[data-testid="sourceCode--undoButton"]').click();
+    });
 });
 
 Cypress.Commands.add('syncUpCodeChanges', () => {

--- a/cypress/support/kaoto-ui-commands/editor.js
+++ b/cypress/support/kaoto-ui-commands/editor.js
@@ -20,7 +20,7 @@ Cypress.Commands.add('openCodeEditor', () => {
 
 Cypress.Commands.add('editorAddText', (line, text) => {
     const arr = text.split('\n');
-    Array.from({ length: arr.length }).map((_, i) => {
+    Array.from({ length: arr.length }).forEach((_, i) => {
         cy.get('.code-editor')
             .click()
             .type('{pageUp}{pageUp}' + '{downArrow}'.repeat(line + i) + '{enter}{upArrow}' + arr[i], {
@@ -45,7 +45,7 @@ Cypress.Commands.add('editorDeleteLine', (line, repeatCount) => {
 
 Cypress.Commands.add('editorClickUndoXTimes', (times) => {
     times = times ?? 1;
-    Array.from({ length: times }).map((_, i) => {
+    Array.from({ length: times }).forEach(() => {
         return cy.get('[data-testid="sourceCode--undoButton"]').click();
     });
 });

--- a/cypress/support/kaoto-ui-commands/editor.js
+++ b/cypress/support/kaoto-ui-commands/editor.js
@@ -1,16 +1,21 @@
 import 'cypress-file-upload';
 
-Cypress.Commands.add('uploadFixture', (fixture, initial) => {
-    initial = initial ?? true;
-    if (initial) {
-        cy.get('[data-testid="toolbar-show-code-btn"]').click();
-        cy.wait('@getIntegration');
+Cypress.Commands.add('uploadFixture', (fixture, open) => {
+    open = open ?? true;
+    if (open) {
+        cy.openCodeEditor();
     }
     cy.get('[data-testid="sourceCode--clearButton"]').should('be.visible').click({ force: true });
     cy.get('.pf-c-code-editor__main').should('be.visible');
     cy.get('.pf-c-code-editor__main > input').attachFile(fixture);
     cy.syncUpCodeChanges();
     cy.waitVisualizationUpdate();
+});
+
+Cypress.Commands.add('openCodeEditor', () => {
+    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    cy.get('[data-testid="toolbar-show-code-btn"]').trigger('mouseleave');
+    cy.wait('@getIntegration');
 });
 
 Cypress.Commands.add('editorAddText', (line, text) => {

--- a/cypress/support/kaoto-ui-commands/steps.js
+++ b/cypress/support/kaoto-ui-commands/steps.js
@@ -1,8 +1,9 @@
 import 'cypress-file-upload';
 
-Cypress.Commands.add('dragAndDropFromCatalog', (source, target, catalog, targetIndex) => {
+Cypress.Commands.add('dragAndDropFromCatalog', (source, target, catalog, targetIndex, testError) => {
     targetIndex = targetIndex ?? 0;
     catalog = catalog ?? 'actions';
+    testError = testError ?? false;
     const dataTransfer = new DataTransfer();
     cy.get('[data-testid="toolbar-step-catalog-btn"]').click();
     cy.get(`[data-testid="catalog-step-${catalog}"]`).click();
@@ -13,6 +14,9 @@ Cypress.Commands.add('dragAndDropFromCatalog', (source, target, catalog, targetI
     cy.get(`[data-testid="viz-step-${target}"]`).eq(targetIndex).trigger('drop', {
         dataTransfer,
     });
+    if (!testError) {
+        cy.waitVisualizationUpdate();
+    }
 });
 
 Cypress.Commands.add('replaceEmptyStepMiniCatalog', (step, stepIndex) => {
@@ -60,7 +64,9 @@ Cypress.Commands.add('openStepConfigurationTab', (step, stepIndex) => {
 });
 
 Cypress.Commands.add('closeStepConfigurationTab', () => {
-    cy.get('.pf-c-button.pf-m-plain').eq(0).click();
+    cy.get('[data-testid="kaoto-right-drawer"]').within(() => {
+        cy.get('.pf-c-drawer__close > .pf-c-button').click();
+    });
 });
 
 Cypress.Commands.add('interactWithConfigInputObject', (inputName, value) => {


### PR DESCRIPTION
Hi, 

With that PR I would like to finish E2E tests refactoring iteration:

- All test are refactored with common function
- All API calls waits now lays in functions that create requests (for example) (unfortunatelly interception can not be global needed to be repeated in the each Before section)
- All lodash.times method faced in tests were replaced 
- Unlocked all tests except one: ` 06-undo_redo_actions/undo_redo_actions.cy.js` blocked by [Issue-1275](https://github.com/KaotoIO/kaoto-ui/issues/1275)