### PR TITLE
fix(steps-details): Required object type's parameters are lost

### DIFF
--- a/src/components/CustomJsonSchemaBridge.tsx
+++ b/src/components/CustomJsonSchemaBridge.tsx
@@ -7,10 +7,6 @@ import JSONSchemaBridge from 'uniforms-bridge-json-schema';
  * based on the incoming model data
  */
 export class CustomJsonSchemaBridge extends JSONSchemaBridge {
-  constructor(schema: any, validator: any) {
-    super(schema, validator);
-  }
-
   getField(name: string): Record<string, any> {
     const field = super.getField(name);
     const { defaultValue, description, ...props } = field;

--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -202,6 +202,7 @@ const VisualizationStepViews = ({
                         type: 'object',
                         properties: stepPropertySchema,
                         required: step.required,
+                        default: stepPropertyModel,
                       }}
                       configuration={stepPropertyModel}
                       parametersOrder={parametersOrder}


### PR DESCRIPTION
### Description
Currently, having a step with a required object type parameter gets removed from the Code Editor upon opening the step's details panel.

This issue occurs because we're instructing `uniforms` that we have a required object property without a default or initial value.

Once `uniforms` tries to build the initial form value, it returns an empty object. [This happens here](https://github.com/vazco/uniforms/blob/ecb1785468bfe2508399a48e13bdb921549ab91a/packages/uniforms-bridge-json-schema/src/JSONSchemaBridge.ts#L267-L276).

### Changes
Considering that there are no current plans to support object property definitions, the workaround is to provide a default value alongside the schema to feed the initial value of object properties.

### Before
[Screencast from 2023-03-31 13-11-26.webm](https://user-images.githubusercontent.com/16512618/229105222-71b39d69-7ea4-4db3-995d-e2d78339c3f5.webm)

### After
[Screencast from 2023-03-31 13-10-26.webm](https://user-images.githubusercontent.com/16512618/229105046-cae364a8-1167-44fb-9f84-421ecc2080cc.webm)

Fixes: https://github.com/KaotoIO/kaoto-ui/issues/1603