### PR TITLE
chore(test): add unit tests for all stores

### DIFF
--- a/src/__mocks__/zustand.js
+++ b/src/__mocks__/zustand.js
@@ -1,0 +1,33 @@
+const { create: actualCreate, createStore } = jest.requireActual('zustand');
+const { act } = require('react-dom/test-utils');
+
+/**a variable to hold reset functions for all stores declared in the app */
+const storeResetFns = new Set();
+
+const create = (createState) => {
+  const store = actualCreate(createState);
+
+  /**
+   * if createState is empty, store won't have a getState function
+   * then we need to skip associating this value
+   * This happens whenever we use the following syntax
+   * create()(...) to help TS auto completion
+   */
+  if (typeof store.getState === 'function') {
+    /** when creating a store, we get its initial state, create a reset function and add it in the set */
+    const initialState = store.getState();
+    storeResetFns.add(() => store.setState(initialState, true));
+  }
+
+  return store;
+};
+
+/** Reset all stores after each test run */
+beforeEach(() => {
+  act(() => storeResetFns.forEach((resetFn) => resetFn()));
+});
+
+/** exporting the newly mocked create function */
+exports.create = create;
+/** exporting createStore since it's used by zundo */
+exports.createStore = createStore;

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -568,7 +568,7 @@ export class StepsService {
    */
   updateViews() {
     fetchViews(useIntegrationJsonStore.getState().integrationJson.steps).then((views) => {
-      useIntegrationJsonStore.getState().setViews(views);
+      useIntegrationJsonStore.getState().updateViews(views);
     });
   }
 

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -90,13 +90,13 @@ export class StepsService {
   deleteBranch(step: IStepProps, branchUuid: string) {
     const currentStepNested = this.getStepNested(step);
     if (currentStepNested) {
-      const newStep = {
+      const newParentStep = {
         ...step,
         branches: step.branches?.filter((b) => b.branchUuid !== branchUuid),
       };
       useIntegrationJsonStore
         .getState()
-        .replaceBranchParentStep(newStep, currentStepNested.pathToStep);
+        .replaceBranchParentStep(newParentStep, currentStepNested.pathToStep);
     } else {
       const oldStepIdx = this.findStepIdxWithUUID(
         step.UUID,
@@ -352,7 +352,7 @@ export class StepsService {
    * Handler for inserting a step, where `targetNode` is the
    * right-hand node. Ex: source -> {insert step here} -> target
    * @param targetNode
-   * @param newStep
+   * @param step
    */
   handleInsertStep(targetNode: IVizStepNode | undefined, step: IStepProps) {
     return fetchStepDetails(step.id).then((newStep) => {

--- a/src/store/deploymentStore.test.tsx
+++ b/src/store/deploymentStore.test.tsx
@@ -1,0 +1,19 @@
+import useDeploymentStore from './deploymentStore';
+import { act, renderHook } from '@testing-library/react';
+
+describe('deploymentStore', () => {
+  it('setDeploymentCrd', () => {
+    const { result } = renderHook(() => useDeploymentStore());
+
+    act(() => {
+      result.current.setDeploymentCrd('The best deployment ever');
+    });
+
+    // check parameters individually for accuracy
+    expect(result.current.deployment.crd).toEqual('The best deployment ever');
+    expect(result.current.deployment.errors).toHaveLength(0);
+    expect(result.current.deployment.name).toEqual('integration');
+    expect(result.current.deployment.status).toEqual('Stopped');
+    expect(result.current.deployment.type).toEqual('Camel Route');
+  });
+});

--- a/src/store/integrationJsonStore.test.tsx
+++ b/src/store/integrationJsonStore.test.tsx
@@ -22,8 +22,8 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'apple' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [{ name: 'apple' }] as IStepProps[],
       });
 
       result.current.appendStep({
@@ -40,13 +40,13 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
+        ...integrationJsonInitialState.integrationJson,
         steps: [
           {
             name: 'peach',
             branches: [{ steps: [{ name: 'a-branch-step' }] }],
           },
-        ],
+        ] as IStepProps[],
       });
     });
 
@@ -83,8 +83,12 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'cantaloupe' }, { name: 'watermelon' }, { name: 'strawberry' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [
+          { name: 'cantaloupe' },
+          { name: 'watermelon' },
+          { name: 'strawberry' },
+        ] as IStepProps[],
       });
       result.current.deleteStep(1);
     });
@@ -96,8 +100,8 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'kiwi' }, { name: 'mango' }, { name: 'papaya' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [{ name: 'kiwi' }, { name: 'mango' }, { name: 'papaya' }] as IStepProps[],
       });
 
       result.current.deleteSteps();
@@ -110,8 +114,8 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'pear' }, { name: 'pineapple' }, { name: 'grape' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [{ name: 'pear' }, { name: 'pineapple' }, { name: 'grape' }] as IStepProps[],
       });
       result.current.insertStep({ name: 'blackberry' } as IStepProps, 1);
     });
@@ -127,8 +131,8 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'banana' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [{ name: 'banana' }] as IStepProps[],
       });
 
       result.current.prependStep(0, { name: 'blueberry' } as IStepProps);
@@ -142,21 +146,18 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        integrationJson: {
-          ...integrationJsonInitialState.integrationJson,
-          steps: [
-            {
-              name: 'satsuma',
-            },
-            {
-              name: 'orange',
-              branches: [
-                { steps: [{ name: 'dragonfruit', branches: [{ steps: [{ name: 'guava' }] }] }] },
-              ],
-            },
-          ] as IStepProps[],
-        },
+        ...integrationJsonInitialState.integrationJson,
+        steps: [
+          {
+            name: 'satsuma',
+          },
+          {
+            name: 'orange',
+            branches: [
+              { steps: [{ name: 'dragonfruit', branches: [{ steps: [{ name: 'guava' }] }] }] },
+            ],
+          },
+        ] as IStepProps[],
       });
 
       // replace with an empty branch
@@ -182,8 +183,8 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'blackcurrant' }, { name: 'grapefruit' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [{ name: 'blackcurrant' }, { name: 'grapefruit' }] as IStepProps[],
       });
       result.current.replaceStep({ name: 'pomegranate' } as IStepProps, 1);
     });
@@ -192,10 +193,10 @@ describe('integrationJsonStore', () => {
     expect(result.current.integrationJson.steps[1].name).toEqual('pomegranate');
   });
 
-  it('setViews', () => {
+  it('updateViews', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      result.current.setViews([
+      result.current.updateViews([
         {
           name: 'Integration View',
           type: 'generic',
@@ -216,8 +217,8 @@ describe('integrationJsonStore', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
-        ...integrationJsonInitialState,
-        steps: [{ name: 'mulberry' }, { name: 'lemon' }, { name: 'cranberry' }],
+        ...integrationJsonInitialState.integrationJson,
+        steps: [{ name: 'mulberry' }, { name: 'lemon' }, { name: 'cranberry' }] as IStepProps[],
       });
     });
 

--- a/src/store/integrationJsonStore.test.tsx
+++ b/src/store/integrationJsonStore.test.tsx
@@ -1,0 +1,146 @@
+import { integrationJsonInitialState, useIntegrationJsonStore } from './integrationJsonStore';
+import { act, renderHook } from '@testing-library/react';
+
+describe('integrationJsonStore', () => {
+  it('store works', () => {
+    const { result } = renderHook(() => useIntegrationJsonStore());
+    expect(result.current.integrationJson).toMatchObject(
+      integrationJsonInitialState.integrationJson
+    );
+    expect(result.current.views).toEqual([]);
+  });
+
+  it('appendStep', () => {
+    const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ UUID: 'first', maxBranches: 0, minBranches: 0, name: '', type: '' }],
+      });
+
+      result.current.appendStep({
+        UUID: 'second',
+        maxBranches: 0,
+        minBranches: 0,
+        name: '',
+        type: '',
+      });
+    });
+
+    expect(result.current.integrationJson.steps).toHaveLength(2);
+  });
+
+  it('deleteBranchStep', () => {
+    const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [
+          {
+            UUID: 'first',
+            maxBranches: 0,
+            minBranches: 0,
+            name: '',
+            type: '',
+            branches: [{ steps: [{ UUID: 'a-branch-step' }] }],
+          },
+        ],
+      });
+    });
+
+    // result.current.deleteBranchStep();
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('deleteIntegration', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('deleteStep', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('deleteSteps', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('insertStep', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('prependStep', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('replaceBranchParentStep', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('replaceStep', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('setViews', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+
+  it('updateIntegration', () => {
+    // const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      //
+    });
+
+    // expect(result.current.integrationJson).toHaveLength(1);
+    // expect(result.current.integrationJson).toEqual(1);
+  });
+});

--- a/src/store/integrationJsonStore.test.tsx
+++ b/src/store/integrationJsonStore.test.tsx
@@ -1,7 +1,15 @@
 import { integrationJsonInitialState, useIntegrationJsonStore } from './integrationJsonStore';
+import { IStepProps, IStepPropsBranch } from '@kaoto/types';
 import { act, renderHook } from '@testing-library/react';
 
 describe('integrationJsonStore', () => {
+  beforeEach(() => {
+    const { result } = renderHook(() => useIntegrationJsonStore());
+    act(() => {
+      result.current.deleteIntegration();
+    });
+  });
+
   it('store works', () => {
     const { result } = renderHook(() => useIntegrationJsonStore());
     expect(result.current.integrationJson).toMatchObject(
@@ -15,132 +23,204 @@ describe('integrationJsonStore', () => {
     act(() => {
       result.current.updateIntegration({
         ...integrationJsonInitialState,
-        steps: [{ UUID: 'first', maxBranches: 0, minBranches: 0, name: '', type: '' }],
+        steps: [{ name: 'apple' }],
       });
 
       result.current.appendStep({
-        UUID: 'second',
-        maxBranches: 0,
-        minBranches: 0,
-        name: '',
-        type: '',
-      });
+        name: 'lychee',
+      } as IStepProps);
     });
 
     expect(result.current.integrationJson.steps).toHaveLength(2);
   });
 
   it('deleteBranchStep', () => {
+    // we should probably evaluate whether this method is needed, or
+    // at least rename or refactor it
     const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
       result.current.updateIntegration({
         ...integrationJsonInitialState,
         steps: [
           {
-            UUID: 'first',
-            maxBranches: 0,
-            minBranches: 0,
-            name: '',
-            type: '',
-            branches: [{ steps: [{ UUID: 'a-branch-step' }] }],
+            name: 'peach',
+            branches: [{ steps: [{ name: 'a-branch-step' }] }],
           },
         ],
       });
     });
 
-    // result.current.deleteBranchStep();
+    expect(result.current.integrationJson.steps[0].branches![0].steps).toHaveLength(1);
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    // replace with an empty branch
+    const newBranch = { steps: [] as IStepProps[] } as IStepPropsBranch;
+    act(() => {
+      result.current.deleteBranchStep(
+        {
+          name: 'peach',
+          branches: [newBranch] as IStepPropsBranch[],
+        } as IStepProps,
+        0
+      );
+    });
+
+    expect(result.current.integrationJson.steps[0].branches![0].steps).toHaveLength(0);
   });
 
   it('deleteIntegration', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
+
     act(() => {
-      //
+      result.current.deleteIntegration();
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson).toMatchObject(
+      integrationJsonInitialState.integrationJson
+    );
   });
 
   it('deleteStep', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ name: 'cantaloupe' }, { name: 'watermelon' }, { name: 'strawberry' }],
+      });
+      result.current.deleteStep(1);
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(2);
   });
 
   it('deleteSteps', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ name: 'kiwi' }, { name: 'mango' }, { name: 'papaya' }],
+      });
+
+      result.current.deleteSteps();
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(0);
   });
 
   it('insertStep', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ name: 'pear' }, { name: 'pineapple' }, { name: 'grape' }],
+      });
+      result.current.insertStep({ name: 'blackberry' } as IStepProps, 1);
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(4);
+    expect(result.current.integrationJson.steps[1]).toEqual({
+      UUID: 'blackberry-1',
+      name: 'blackberry',
+    });
   });
 
   it('prependStep', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ name: 'banana' }],
+      });
+
+      result.current.prependStep(0, { name: 'blueberry' } as IStepProps);
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(2);
+    expect(result.current.integrationJson.steps[0].name).toEqual('blueberry');
   });
 
   it('replaceBranchParentStep', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        integrationJson: {
+          ...integrationJsonInitialState.integrationJson,
+          steps: [
+            {
+              name: 'satsuma',
+            },
+            {
+              name: 'orange',
+              branches: [
+                { steps: [{ name: 'dragonfruit', branches: [{ steps: [{ name: 'guava' }] }] }] },
+              ],
+            },
+          ] as IStepProps[],
+        },
+      });
+
+      // replace with an empty branch
+      const newBranch = {
+        steps: [{ name: 'apricot', branches: [{ steps: [{ name: 'guava' }] }] }] as IStepProps[],
+      } as IStepPropsBranch;
+
+      // we want to replace the 'dragonfruit' step, but keep its branch the same
+      result.current.replaceBranchParentStep(
+        {
+          name: 'orange',
+          branches: [newBranch] as IStepPropsBranch[],
+        } as IStepProps,
+        ['1', 'branches', '0', 'steps', '0']
+      );
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(2);
+    expect(result.current.integrationJson.steps[1].branches![0].steps[0].name).toEqual('orange');
   });
 
   it('replaceStep', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ name: 'blackcurrant' }, { name: 'grapefruit' }],
+      });
+      result.current.replaceStep({ name: 'pomegranate' } as IStepProps, 1);
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(2);
+    expect(result.current.integrationJson.steps[1].name).toEqual('pomegranate');
   });
 
   it('setViews', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.setViews([
+        {
+          name: 'Integration View',
+          type: 'generic',
+          id: 'integration',
+          step: '',
+          url: '',
+          constraints: [],
+          scope: '',
+          module: '',
+        },
+      ]);
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.views).toHaveLength(1);
   });
 
   it('updateIntegration', () => {
-    // const { result } = renderHook(() => useIntegrationJsonStore());
+    const { result } = renderHook(() => useIntegrationJsonStore());
     act(() => {
-      //
+      result.current.updateIntegration({
+        ...integrationJsonInitialState,
+        steps: [{ name: 'mulberry' }, { name: 'lemon' }, { name: 'cranberry' }],
+      });
     });
 
-    // expect(result.current.integrationJson).toHaveLength(1);
-    // expect(result.current.integrationJson).toEqual(1);
+    expect(result.current.integrationJson.steps).toHaveLength(3);
   });
 });

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -20,7 +20,10 @@ export interface IIntegrationJsonStore {
   insertStep: (newStep: IStepProps, insertIndex: number) => void;
   integrationJson: IIntegration;
   prependStep: (currentStepIdx: number, newStep: IStepProps) => void;
-  replaceBranchParentStep: (newStep: IStepProps, pathToParentStep: string[] | undefined) => void;
+  replaceBranchParentStep: (
+    newParentStep: IStepProps,
+    pathToParentStep: string[] | undefined
+  ) => void;
   replaceStep: (newStep: IStepProps, oldStepIndex?: number) => void;
   setViews: (views: IViewProps[]) => void;
   updateIntegration: (newInt?: any) => void;
@@ -28,7 +31,6 @@ export interface IIntegrationJsonStore {
 }
 
 export const integrationJsonInitialState = {
-  branchSteps: {},
   integrationJson: {
     dsl: initDsl.name,
     metadata: { name: initialSettings.name, namespace: initialSettings.namespace },
@@ -124,9 +126,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           };
         });
       },
-      replaceBranchParentStep: (newStep, pathToParentStep) => {
+      replaceBranchParentStep: (newParentStep, pathToParentStep) => {
         let stepsCopy = get().integrationJson.steps.slice();
-        stepsCopy = setDeepValue(stepsCopy, pathToParentStep, newStep);
+        stepsCopy = setDeepValue(stepsCopy, pathToParentStep, newParentStep);
 
         const stepsWithNewUuids = StepsService.regenerateUuids(stepsCopy);
         const { updateSteps } = useNestedStepsStore.getState();

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -13,7 +13,7 @@ import { create } from 'zustand';
 
 export interface IIntegrationJsonStore {
   appendStep: (newStep: IStepProps) => void;
-  deleteBranchStep: (newStep: IStepProps, originalStepIndex: number) => void;
+  deleteBranchStep: (newRootStep: IStepProps, rootStepIndex: number) => void;
   deleteIntegration: () => void;
   deleteStep: (index: number) => void;
   deleteSteps: () => void;
@@ -27,7 +27,7 @@ export interface IIntegrationJsonStore {
   views: IViewProps[];
 }
 
-const initialState = {
+export const integrationJsonInitialState = {
   branchSteps: {},
   integrationJson: {
     dsl: initDsl.name,
@@ -41,7 +41,7 @@ const initialState = {
 export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
   temporal(
     (set, get) => ({
-      ...initialState,
+      ...integrationJsonInitialState,
       appendStep: (newStep) => {
         set((state) => {
           let newSteps = state.integrationJson.steps.slice();
@@ -56,11 +56,11 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           };
         });
       },
-      deleteIntegration: () => set(initialState),
-      deleteBranchStep: (newStep: IStepProps, originalStepIndex: number) => {
+      deleteIntegration: () => set(integrationJsonInitialState),
+      deleteBranchStep: (newRootStep: IStepProps, rootStepIndex: number) => {
         let newSteps = get().integrationJson.steps.slice();
-        // replacing the origin parent of a deeply nested step
-        newSteps[originalStepIndex] = newStep;
+        // replacing the root step of a deeply nested step
+        newSteps[rootStepIndex] = newRootStep;
 
         const stepsWithNewUuids = StepsService.regenerateUuids(newSteps);
         const { updateSteps } = useNestedStepsStore.getState();

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -25,8 +25,8 @@ export interface IIntegrationJsonStore {
     pathToParentStep: string[] | undefined
   ) => void;
   replaceStep: (newStep: IStepProps, oldStepIndex?: number) => void;
-  setViews: (views: IViewProps[]) => void;
-  updateIntegration: (newInt?: any) => void;
+  updateIntegration: (newInt: IIntegration) => void;
+  updateViews: (views: IViewProps[]) => void;
   views: IViewProps[];
 }
 
@@ -162,9 +162,6 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
           },
         }));
       },
-      setViews: (viewData: IViewProps[]) => {
-        set({ views: viewData });
-      },
       updateIntegration: (newInt: IIntegration) => {
         let newIntegration = { ...get().integrationJson, ...newInt };
         const uuidSteps = StepsService.regenerateUuids(newIntegration.steps);
@@ -172,6 +169,9 @@ export const useIntegrationJsonStore = create<IIntegrationJsonStore>()(
         updateSteps(StepsService.extractNestedSteps(uuidSteps));
 
         return set({ integrationJson: { ...newIntegration, steps: uuidSteps } });
+      },
+      updateViews: (viewData: IViewProps[]) => {
+        set({ views: viewData });
       },
     }),
     {

--- a/src/store/integrationSourceStore.test.tsx
+++ b/src/store/integrationSourceStore.test.tsx
@@ -1,0 +1,18 @@
+import YAML from './data/yaml';
+import { useIntegrationSourceStore } from './integrationSourceStore';
+import { act, renderHook } from '@testing-library/react';
+
+describe('integrationSourceStore', () => {
+  it('store works', () => {
+    const { result } = renderHook(() => useIntegrationSourceStore());
+    expect(result.current.sourceCode).toEqual('');
+  });
+
+  it('setSourceCode: updates store to provided YAML', () => {
+    const { result } = renderHook(() => useIntegrationSourceStore());
+    act(() => {
+      result.current.setSourceCode(YAML);
+    });
+    expect(result.current.sourceCode).toEqual(YAML);
+  });
+});

--- a/src/store/nestedStepsStore.test.tsx
+++ b/src/store/nestedStepsStore.test.tsx
@@ -39,7 +39,7 @@ describe('nestedStepsStore', () => {
     expect(result.current.nestedSteps).toHaveLength(1);
 
     act(() => {
-      result.current.deleteStep('example-step');
+      result.current.deleteStep('raspberry');
     });
 
     expect(result.current.nestedSteps).toHaveLength(0);

--- a/src/store/nestedStepsStore.test.tsx
+++ b/src/store/nestedStepsStore.test.tsx
@@ -1,4 +1,5 @@
 import { useNestedStepsStore } from './nestedStepsStore';
+import { INestedStep } from '@kaoto/types';
 import { act, renderHook } from '@testing-library/react';
 
 describe('nestedStepsStore', () => {
@@ -11,14 +12,8 @@ describe('nestedStepsStore', () => {
     const { result } = renderHook(() => useNestedStepsStore());
     act(() => {
       result.current.addStep({
-        branchIndex: 0,
-        branchUuid: '',
-        parentStepUuid: '',
-        pathToBranch: [''],
-        pathToParentStep: [''],
-        pathToStep: [''],
-        stepUuid: '',
-      });
+        stepUuid: 'durian',
+      } as INestedStep);
     });
 
     expect(result.current.nestedSteps).toHaveLength(1);
@@ -37,14 +32,8 @@ describe('nestedStepsStore', () => {
     const { result } = renderHook(() => useNestedStepsStore());
     act(() => {
       result.current.addStep({
-        branchIndex: 0,
-        branchUuid: '',
-        parentStepUuid: '',
-        pathToBranch: [''],
-        pathToParentStep: [''],
-        pathToStep: [''],
-        stepUuid: 'example-step',
-      });
+        stepUuid: 'raspberry',
+      } as INestedStep);
     });
 
     expect(result.current.nestedSteps).toHaveLength(1);
@@ -61,45 +50,21 @@ describe('nestedStepsStore', () => {
     act(() => {
       result.current.updateSteps([
         {
-          branchIndex: 0,
-          branchUuid: '',
-          parentStepUuid: '',
-          pathToBranch: [''],
-          pathToParentStep: [''],
-          pathToStep: [''],
-          stepUuid: 'cherry',
+          stepUuid: 'plum',
         },
         {
-          branchIndex: 0,
-          branchUuid: '',
-          parentStepUuid: '',
-          pathToBranch: [''],
-          pathToParentStep: [''],
-          pathToStep: [''],
-          stepUuid: 'banana',
+          stepUuid: 'prune',
         },
-      ]);
+      ] as INestedStep[]);
     });
 
     expect(result.current.nestedSteps).toHaveLength(2);
     expect(result.current.nestedSteps).toEqual([
       {
-        branchIndex: 0,
-        branchUuid: '',
-        parentStepUuid: '',
-        pathToBranch: [''],
-        pathToParentStep: [''],
-        pathToStep: [''],
-        stepUuid: 'cherry',
+        stepUuid: 'plum',
       },
       {
-        branchIndex: 0,
-        branchUuid: '',
-        parentStepUuid: '',
-        pathToBranch: [''],
-        pathToParentStep: [''],
-        pathToStep: [''],
-        stepUuid: 'banana',
+        stepUuid: 'prune',
       },
     ]);
   });

--- a/src/store/nestedStepsStore.test.tsx
+++ b/src/store/nestedStepsStore.test.tsx
@@ -1,0 +1,106 @@
+import { useNestedStepsStore } from './nestedStepsStore';
+import { act, renderHook } from '@testing-library/react';
+
+describe('nestedStepsStore', () => {
+  it('store works', () => {
+    const { result } = renderHook(() => useNestedStepsStore());
+    expect(result.current.nestedSteps).toHaveLength(0);
+  });
+
+  it('addStep: adds a nested step', () => {
+    const { result } = renderHook(() => useNestedStepsStore());
+    act(() => {
+      result.current.addStep({
+        branchIndex: 0,
+        branchUuid: '',
+        parentStepUuid: '',
+        pathToBranch: [''],
+        pathToParentStep: [''],
+        pathToStep: [''],
+        stepUuid: '',
+      });
+    });
+
+    expect(result.current.nestedSteps).toHaveLength(1);
+  });
+
+  it('clearNestedSteps: resets store state back to initial state', () => {
+    const { result } = renderHook(() => useNestedStepsStore());
+    act(() => {
+      result.current.clearNestedSteps();
+    });
+
+    expect(result.current.nestedSteps).toHaveLength(0);
+  });
+
+  it('deleteStep: removes step containing specified UUID', () => {
+    const { result } = renderHook(() => useNestedStepsStore());
+    act(() => {
+      result.current.addStep({
+        branchIndex: 0,
+        branchUuid: '',
+        parentStepUuid: '',
+        pathToBranch: [''],
+        pathToParentStep: [''],
+        pathToStep: [''],
+        stepUuid: 'example-step',
+      });
+    });
+
+    expect(result.current.nestedSteps).toHaveLength(1);
+
+    act(() => {
+      result.current.deleteStep('example-step');
+    });
+
+    expect(result.current.nestedSteps).toHaveLength(0);
+  });
+
+  it('updateSteps: updates store to provided array of nested steps', () => {
+    const { result } = renderHook(() => useNestedStepsStore());
+    act(() => {
+      result.current.updateSteps([
+        {
+          branchIndex: 0,
+          branchUuid: '',
+          parentStepUuid: '',
+          pathToBranch: [''],
+          pathToParentStep: [''],
+          pathToStep: [''],
+          stepUuid: 'cherry',
+        },
+        {
+          branchIndex: 0,
+          branchUuid: '',
+          parentStepUuid: '',
+          pathToBranch: [''],
+          pathToParentStep: [''],
+          pathToStep: [''],
+          stepUuid: 'banana',
+        },
+      ]);
+    });
+
+    expect(result.current.nestedSteps).toHaveLength(2);
+    expect(result.current.nestedSteps).toEqual([
+      {
+        branchIndex: 0,
+        branchUuid: '',
+        parentStepUuid: '',
+        pathToBranch: [''],
+        pathToParentStep: [''],
+        pathToStep: [''],
+        stepUuid: 'cherry',
+      },
+      {
+        branchIndex: 0,
+        branchUuid: '',
+        parentStepUuid: '',
+        pathToBranch: [''],
+        pathToParentStep: [''],
+        pathToStep: [''],
+        stepUuid: 'banana',
+      },
+    ]);
+  });
+});

--- a/src/store/settingsStore.test.tsx
+++ b/src/store/settingsStore.test.tsx
@@ -1,0 +1,25 @@
+import useSettingsStore, { initialSettings } from './settingsStore';
+import { act, renderHook } from '@testing-library/react';
+
+describe('settingsStore', () => {
+  it('setSettings', () => {
+    const { result } = renderHook(() => useSettingsStore());
+    expect(result.current.settings).toEqual(initialSettings);
+
+    act(() => {
+      result.current.setSettings({
+        ...initialSettings,
+        description: 'The best description ever',
+        editorIsLightMode: false,
+        name: 'Goji Berry',
+        namespace: 'KameletBinding',
+      });
+    });
+
+    expect(result.current.settings.description).toEqual('The best description ever');
+    expect(result.current.settings.dsl).toEqual(initialSettings.dsl);
+    expect(result.current.settings.editorIsLightMode).toBeFalsy();
+    expect(result.current.settings.name).toEqual('Goji Berry');
+    expect(result.current.settings.namespace).toEqual('KameletBinding');
+  });
+});

--- a/src/store/stepCatalogStore.test.tsx
+++ b/src/store/stepCatalogStore.test.tsx
@@ -1,0 +1,25 @@
+import useStepCatalogStore from './stepCatalogStore';
+import { IStepProps } from '@kaoto/types';
+import { act, renderHook } from '@testing-library/react';
+
+describe('stepCatalogStore', () => {
+  it('setDsl', () => {
+    const { result } = renderHook(() => useStepCatalogStore());
+
+    act(() => {
+      result.current.setDsl('KameletBinding');
+    });
+
+    expect(result.current.dsl).toEqual('KameletBinding');
+  });
+
+  it('setStepCatalog', () => {
+    const { result } = renderHook(() => useStepCatalogStore());
+
+    act(() => {
+      result.current.setStepCatalog([{}, {}, {}] as IStepProps[]);
+    });
+
+    expect(result.current.stepCatalog).toHaveLength(3);
+  });
+});

--- a/src/store/visualizationStore.test.tsx
+++ b/src/store/visualizationStore.test.tsx
@@ -1,0 +1,121 @@
+import { useVisualizationStore } from './visualizationStore';
+import { IStepProps } from '@kaoto/types';
+import { MarkerType } from '@reactflow/core';
+import { act, renderHook } from '@testing-library/react';
+
+describe('visualizationStore', () => {
+  it('store works', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.edges).toEqual([]);
+  });
+
+  it('deleteNode', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    act(() => {
+      result.current.setNodes([
+        { id: 'node-1', position: { x: 0, y: 0 }, data: { label: '', step: {} as IStepProps } },
+        { id: 'node-2', position: { x: 0, y: 0 }, data: { label: '', step: {} as IStepProps } },
+      ]);
+
+      result.current.deleteNode(1);
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+  });
+
+  it('onEdgesChange', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    act(() => {
+      const edge = {
+        arrowHeadType: 'arrowclosed',
+        id: 'e-undefined>undefined',
+        markerEnd: {
+          color: '#d2d2d2',
+          strokeWidth: 2,
+          type: MarkerType.Arrow,
+        },
+        source: '',
+        style: {
+          stroke: '#d2d2d2',
+          strokeWidth: 2,
+        },
+        target: '',
+        type: 'CUSTOM-NODE',
+      };
+
+      result.current.onEdgesChange([
+        {
+          item: edge,
+          type: 'add',
+        },
+      ]);
+    });
+
+    expect(result.current.edges).toHaveLength(1);
+  });
+
+  it('onConnect', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    act(() => {
+      result.current.onConnect({ source: 'a', target: 'b', sourceHandle: '', targetHandle: '' });
+    });
+
+    expect(result.current.edges).toHaveLength(1);
+  });
+
+  it('setHoverStepUuid', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    expect(result.current.hoverStepUuid).toBe('');
+
+    act(() => {
+      result.current.setHoverStepUuid('elderberry');
+    });
+
+    expect(result.current.hoverStepUuid).toBe('elderberry');
+  });
+
+  it('setNodes', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    act(() => {
+      result.current.setNodes([
+        { id: 'node-1', position: { x: 0, y: 0 }, data: { label: '', step: {} as IStepProps } },
+        { id: 'node-2', position: { x: 0, y: 0 }, data: { label: '', step: {} as IStepProps } },
+      ]);
+    });
+
+    expect(result.current.nodes).toHaveLength(2);
+  });
+
+  it('setSelectedStepUuid', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    expect(result.current.selectedStepUuid).toBe('');
+
+    act(() => {
+      result.current.setSelectedStepUuid('jackfruit');
+    });
+
+    expect(result.current.selectedStepUuid).toBe('jackfruit');
+  });
+
+  it('updateNode', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    act(() => {
+      result.current.setNodes([
+        { id: 'kumquat', position: { x: 0, y: 0 }, data: { label: '', step: {} as IStepProps } },
+      ]);
+
+      result.current.updateNode(
+        {
+          id: 'starfruit',
+          position: { x: 0, y: 0 },
+          data: { label: '', step: {} as IStepProps },
+        },
+        0
+      );
+    });
+
+    expect(result.current.nodes).toHaveLength(1);
+    expect(result.current.nodes[0].id).toEqual('starfruit');
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for all Zustand stores, since this was one of the areas with the lowest test coverage.

## Changes
- Add mock for Zustand (relates to #1258)
- Make parameters in stores easier to understand (for example, `replaceParentStep` instead of `replaceStep`, or `updateViews` instead of `setViews`)
- Add type to `updateIntegration` method in `visualizationStore`

**Tasks remaining:** Next PR will be focusing on other areas that are also lacking test coverage, such as `services` and `api`.

## Screenshots

Current code coverage for `store` (43.13%):

![Screen Shot 2023-03-31 at 3 27 29 pm](https://user-images.githubusercontent.com/3844502/229151148-6d9eee8f-87bc-4dc0-abf9-c937b3aba138.png)

It should be 100% after this PR is merged.