### PR TITLE
fix: yarn build:lib on CI related to OTEL deps

### DIFF
--- a/src/webTracer.ts
+++ b/src/webTracer.ts
@@ -1,5 +1,4 @@
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { WebTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-web';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';


### PR DESCRIPTION
* The SimpleSpanProcessor was imported via other internal dependency, this probably was related to my vscode auto-import in the first PR or something, when adding otel capabilities.