### PR TITLE
Replace "null" string with "No default value"

### DIFF
--- a/src/components/FieldLabelIcon.tsx
+++ b/src/components/FieldLabelIcon.tsx
@@ -19,7 +19,7 @@ export const FieldLabelIcon = (props: FieldLabelIconProps) => {
   const bodyContent = props.description ? props.description : '';
 
   const footerContent = () => {
-    return <Text component={TextVariants.small}>Default: {props.defaultValue ?? 'null'}</Text>;
+    return <Text component={TextVariants.small}>Default: {props.defaultValue ?? 'No default value'}</Text>;
   };
 
   return (

--- a/src/components/FieldLabelIcon.tsx
+++ b/src/components/FieldLabelIcon.tsx
@@ -19,7 +19,7 @@ export const FieldLabelIcon = (props: FieldLabelIconProps) => {
   const bodyContent = props.description ? props.description : '';
 
   const footerContent = () => {
-    return <Text component={TextVariants.small}>Default: {props.defaultValue ?? 'No default value'}</Text>;
+    return <Text component={TextVariants.small}>Default: {props.defaultValue ?? <i>No default value</i>}</Text>;
   };
 
   return (


### PR DESCRIPTION
Hi,

here is a small change of `null` to a more friendly value `No default value`

Before:
![image](https://user-images.githubusercontent.com/46084942/229514408-0071c3a7-7d6d-4c96-8e8d-d5fd332342ad.png)

After:
![Screenshot from 2023-04-03 14-47-05](https://user-images.githubusercontent.com/46084942/229514439-f432627d-2212-4862-9011-53dcee037d64.png)

Relates:
-  [Issue-1577](https://github.com/KaotoIO/kaoto-ui/issues/1577)