### PR TITLE
Add stepNode__clickable class to Node

### DIFF
--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -124,7 +124,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     <>
       {!data.isPlaceholder ? (
         <div
-          className={`stepNode stepNode--${layoutCssClass}` + getSelectedClass() + getHoverClass()}
+          className={`stepNode stepNode--${layoutCssClass} stepNode__clickable` + getSelectedClass() + getHoverClass()}
           onDrop={onDropReplace}
           onMouseEnter={() => {
             if (data.branchInfo || supportsBranching) {


### PR DESCRIPTION
Hi,

here is a small  fix to the issue with not clickable node circle 

Before:
![clickOutsideOfIconIsNotWorking](https://user-images.githubusercontent.com/1105127/229046739-49bc581e-6af5-447b-bbfa-0cd6f85465d1.gif)

After:
![clickOutsideOfIconIsWorking](https://user-images.githubusercontent.com/46084942/229517333-46ad17af-9ca8-4d8c-a827-582449e3648d.gif)

Relates:
-  [Issue-1577](https://github.com/KaotoIO/kaoto-ui/issues/1597)