### PR TITLE
chore(test): add tests for stepsService & Kaoto UI API

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 package.json
 src/bootstrap.tsx
+src/services/stepsService.test.ts

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,7 +7,6 @@ import '@patternfly/patternfly/utilities/Sizing/sizing.css';
 import '@patternfly/patternfly/utilities/Spacing/spacing.css';
 import 'reactflow/dist/style.css';
 import { AlertProvider } from '../src/layout';
-import { worker } from '../src/__mocks__/browser';
 
 if (process.env.NODE_ENV === 'development') {
   const { worker } = require('../src/__mocks__/browser');

--- a/src/__mocks__/zustand.js
+++ b/src/__mocks__/zustand.js
@@ -5,14 +5,23 @@ const { act } = require('react-dom/test-utils');
 const storeResetFns = new Set();
 
 const create = (createState) => {
-  const store = actualCreate(createState);
-
   /**
-   * if createState is empty, store won't have a getState function
-   * then we need to skip associating this value
+   * If createState is empty, store won't have a getState function
+   * and it will be the real createImpl function.
+   *
+   * In this situation, we need to make sure to return the function
+   * itself to be able to intercept the original createState function
+   * and be able to reset the store after each test.
+   *
    * This happens whenever we use the following syntax
    * create()(...) to help TS auto completion
    */
+  if (createState === undefined) {
+    return create;
+  }
+
+  const store = actualCreate(createState);
+
   if (typeof store.getState === 'function') {
     /** when creating a store, we get its initial state, create a reset function and add it in the set */
     const initialState = store.getState();

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -284,13 +284,13 @@ export async function startDeployment(integrationSource: string, name: string, n
 
 /**
  * Stops an integration deployment
- * @param name
+ * @param deploymentName
  * @param namespace
  */
-export async function stopDeployment(name: string, namespace?: string) {
+export async function stopDeployment(deploymentName: string, namespace?: string) {
   try {
     const resp = await request.delete({
-      endpoint: `${apiVersion}/deployments/${name.toLowerCase()}`,
+      endpoint: `${apiVersion}/deployments/${deploymentName.toLowerCase()}`,
       contentType: 'application/json',
       queryParams: { namespace: namespace ?? 'default' },
     });

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -1,10 +1,42 @@
+jest.mock('@kaoto/api', () => {
+  const actual = jest.requireActual('@kaoto/api');
+
+  return {
+    ...actual,
+    fetchDeployment: jest.fn(),
+    fetchIntegrationSourceCode: jest.fn(),
+    fetchStepDetails: jest.fn(),
+    fetchViews: jest.fn(),
+    startDeployment: jest.fn(),
+    stopDeployment: jest.fn()
+  };
+});
+
 import branchSteps from '../store/data/branchSteps';
+import deployment from '../store/data/deployment';
 import nestedBranch from '../store/data/kamelet.nested-branch.steps';
 import steps from '../store/data/steps';
+import YAML from '../store/data/yaml';
 import { integrationSteps } from '../stubs';
 import { StepsService } from './stepsService';
+import {
+  fetchDeployment,
+  fetchIntegrationSourceCode,
+  fetchStepDetails,
+  fetchViews,
+  startDeployment,
+  stopDeployment,
+} from '@kaoto/api';
 import { useIntegrationJsonStore, useNestedStepsStore, useVisualizationStore } from '@kaoto/store';
-import { IStepProps, IStepPropsBranch, IStepPropsParameters, IViewProps } from '@kaoto/types';
+import {
+  INestedStep,
+  IStepProps,
+  IStepPropsBranch,
+  IStepPropsParameters,
+  IViewProps,
+  IVizStepNode,
+  IVizStepNodeData,
+} from '@kaoto/types';
 
 describe('stepsService', () => {
   const stepsService = new StepsService(
@@ -13,25 +45,197 @@ describe('stepsService', () => {
     useVisualizationStore.getState()
   );
 
-  /**
-   * containsBranches
-   */
+  beforeEach(() => {
+    useIntegrationJsonStore.getState().deleteIntegration();
+  });
+
+  it('addBranch(): should add a branch to the specified step from the store', () => {
+    useIntegrationJsonStore.setState({
+      integrationJson: {
+        ...useIntegrationJsonStore.getState().integrationJson,
+        steps: [
+          { UUID: 'blueberry', name: 'blueberry', minBranches: 0, maxBranches: -1 },
+        ] as IStepProps[],
+      },
+    });
+
+    stepsService.addBranch(
+      { UUID: 'blueberry', name: 'blueberry' } as IStepProps,
+      { branchUuid: 'blueberry-branch-01', steps: [] as IStepProps[] } as IStepPropsBranch
+    );
+
+    expect(useIntegrationJsonStore.getState().integrationJson.steps[0].branches).toHaveLength(1);
+  });
+
+  it('buildStepSchemaAndModel(): should ignore empty array parameter', () => {
+    const parameter: IStepPropsParameters = {
+      id: 'key',
+      type: 'string',
+      description: 'test description',
+      value: 'value',
+    };
+    const parameter2: IStepPropsParameters = {
+      id: 'array',
+      type: 'array',
+      description: '',
+      value: [],
+    };
+    const parameter3: IStepPropsParameters = {
+      id: 'array2',
+      type: 'array',
+      description: 'array',
+      value: null,
+    };
+    const modelObjectRef = {} as IStepPropsParameters;
+    const schemaObjectRef: {
+      [label: string]: { type: string; value?: any; description?: string };
+    } = {};
+
+    StepsService.buildStepSchemaAndModel(parameter, modelObjectRef, schemaObjectRef);
+    StepsService.buildStepSchemaAndModel(parameter2, modelObjectRef, schemaObjectRef);
+    StepsService.buildStepSchemaAndModel(parameter3, modelObjectRef, schemaObjectRef);
+
+    const modelEntries = Object.entries(modelObjectRef);
+    const schemaEntries = Object.entries(schemaObjectRef);
+
+    expect(schemaEntries.length).toBe(1);
+    expect(modelEntries.length).toBe(1);
+
+    expect(modelEntries[0][0]).toContain('key');
+    expect(modelEntries[0][1]).toContain('value');
+
+    expect(JSON.stringify(schemaEntries)).toContain('test description');
+  });
+
   it('containsBranches(): should determine if a given step contains branches', () => {
     expect(StepsService.containsBranches(branchSteps[0])).toBe(false);
     expect(StepsService.containsBranches(branchSteps[1])).toBe(true);
   });
 
-  /**
-   * extractNestedSteps
-   */
+  describe('createKaotoApi(): should create an instance of IKaotoApi for step extensions to consume', () => {
+    const step = {
+      name: 'pineapple',
+      parameters: [
+        { title: 'Description', type: 'string', id: 'description', value: 'A fruit' },
+      ] as IStepPropsParameters[],
+    } as IStepProps;
+
+    it('getDeployment(): should call apiService to return the current running deployment', async () => {
+      jest.mocked(fetchDeployment).mockResolvedValueOnce(deployment);
+      await stepsService
+        .createKaotoApi(step, jest.fn(), jest.fn())
+        .getDeployment('lexi')
+        .then((res) => {
+          expect(res).toEqual(deployment);
+          expect(fetchDeployment).toHaveBeenCalled();
+        });
+    });
+
+    it('getIntegrationSource(): should call apiService to return the source code (YAML) for the current running deployment', async () => {
+      const integration = {
+        metadata: { name: 'Updated integration' },
+        dsl: 'KameletBinding',
+        params: [],
+        namespace: 'default',
+        steps: [],
+      };
+      jest.mocked(fetchIntegrationSourceCode).mockResolvedValueOnce(YAML);
+      await stepsService
+        .createKaotoApi(step, jest.fn(), jest.fn())
+        .getIntegrationSource(integration, 'KameletBinding', 'default')
+        .then(() => {
+          expect(fetchIntegrationSourceCode).toHaveBeenCalled();
+        });
+    });
+
+    it('notifyKaoto(): should call the provided callback to alert Kaoto', () => {
+      const alertKaoto = jest.fn();
+      stepsService.createKaotoApi(step, jest.fn(), alertKaoto).notifyKaoto('Dummy notification');
+      expect(alertKaoto).toHaveBeenCalled();
+    });
+
+    it('startDeployment(): should call apiService to deploy the current source code (YAML) if valid', async () => {
+      jest.mocked(startDeployment).mockResolvedValueOnce(YAML);
+      await stepsService
+        .createKaotoApi(step, jest.fn(), jest.fn())
+        .startDeployment(YAML, 'Updated integration', 'default')
+        .then(() => {
+          expect(startDeployment).toHaveBeenCalled();
+        });
+    });
+
+    it('step: should return the current step', () => {
+      expect(stepsService.createKaotoApi(step, jest.fn(), jest.fn()).step).toMatchObject(step);
+    });
+
+    it('stepParams: should return the current step parameters', () => {
+      expect(
+        stepsService.createKaotoApi(step, jest.fn(), jest.fn()).stepParams.Description
+      ).toEqual('A fruit');
+    });
+
+    it('stopDeployment(): should call apiService to stop the current running deployment', async () => {
+      jest.mocked(stopDeployment).mockResolvedValueOnce('Deployment stopped...');
+      stepsService
+        .createKaotoApi(step, jest.fn(), jest.fn())
+        .stopDeployment('Updated integration', 'default');
+      expect(stopDeployment).toHaveBeenCalled();
+    });
+
+    it('updateStep(): should replace the current step with the one provided', () => {
+      const customStep = { name: 'pineapple', UUID: 'pineapple-0' } as IStepProps;
+      useIntegrationJsonStore.getState().insertStep(customStep, 0);
+      expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain(
+        'pineapple'
+      );
+      stepsService
+        .createKaotoApi(customStep, jest.fn(), jest.fn())
+        .updateStep({ name: 'blackberry' } as IStepProps);
+      expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain(
+        'blackberry'
+      );
+    });
+
+    it('updateStepParams(): should call the provided callback for updating step params', () => {
+      const saveConfig = jest.fn();
+      stepsService.createKaotoApi(step, saveConfig, jest.fn()).updateStepParams({ name: 'pizza' });
+      expect(saveConfig).toHaveBeenCalled();
+    });
+  });
+
+  it('deleteBranch(): should delete branch from specified step from the store', () => {
+    const step = {
+      UUID: 'peach',
+      name: 'peach',
+      branches: [
+        { branchUuid: 'peach-0|branch-0', steps: [] as IStepProps[] } as IStepPropsBranch,
+      ] as IStepPropsBranch[],
+    } as IStepProps;
+
+    useIntegrationJsonStore.setState({
+      integrationJson: {
+        ...useIntegrationJsonStore.getState().integrationJson,
+        steps: [step],
+      },
+    });
+
+    expect(useIntegrationJsonStore.getState().integrationJson.steps[0].branches).toHaveLength(1);
+
+    stepsService.deleteBranch(step, 'peach-0|branch-0');
+
+    expect(useIntegrationJsonStore.getState().integrationJson.steps[0].branches).toHaveLength(0);
+  });
+
+  it('deleteStep(): should delete specified step from the store', () => {
+    useIntegrationJsonStore.getState().insertStep({ name: 'pineapple' } as IStepProps, 0);
+    expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(1);
+  });
+
   it('extractNestedSteps(): should create an array of properties for all nested steps', () => {
     const nested = nestedBranch.slice();
     expect(StepsService.extractNestedSteps(nested)).toHaveLength(6);
   });
 
-  /**
-   * findStepIdxWithUUID
-   */
   it("findStepIdxWithUUID(): should find a step's index, given a particular UUID", () => {
     const steps = [
       { UUID: 'twitter-search-source-0' },
@@ -39,6 +243,7 @@ describe('stepsService', () => {
       { UUID: 'caffeine-action-2' },
     ] as IStepProps[];
     expect(stepsService.findStepIdxWithUUID('caffeine-action-2', steps)).toEqual(2);
+
     // passing it a nested branch's steps array
     const nestedSteps = steps.slice();
     nestedSteps.push({
@@ -48,11 +253,17 @@ describe('stepsService', () => {
     expect(
       stepsService.findStepIdxWithUUID('nested-step-1', nestedSteps[3].branches![0].steps)
     ).toEqual(1);
+
+    // testing without explicitly passing a steps array
+    useIntegrationJsonStore.setState({
+      integrationJson: {
+        ...useIntegrationJsonStore.getState().integrationJson,
+        steps: steps,
+      },
+    });
+    expect(stepsService.findStepIdxWithUUID('caffeine-action-2')).toEqual(2);
   });
 
-  /**
-   * flattenSteps
-   */
   it('flattenSteps(): should flatten an array of deeply nested steps', () => {
     expect(nestedBranch).toHaveLength(4);
     const deeplyNestedBranchStepUuid = 'set-body-877932';
@@ -63,9 +274,166 @@ describe('stepsService', () => {
     expect(flattenedSteps.some((s) => s.UUID === deeplyNestedBranchStepUuid)).toBeTruthy();
   });
 
-  /**
-   * insertStep
-   */
+  it('getStepNested(): gets a nested step with its UUID', () => {
+    useNestedStepsStore.getState().addStep({ stepUuid: 'strawberry' } as INestedStep);
+    expect(stepsService.getStepNested('strawberry')).toMatchObject({ stepUuid: 'strawberry' });
+  });
+
+  it('handleAppendStep(): should append a step to another and update the store', async () => {
+    useIntegrationJsonStore
+      .getState()
+      .insertStep({ name: 'lychee', UUID: 'lychee' } as IStepProps, 0);
+    expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(1);
+
+    // mock fetching additional parameters for new step
+    jest
+      .mocked(fetchStepDetails)
+      .mockResolvedValueOnce({ name: 'raspberry', type: 'START', parameters: [] });
+
+    await stepsService
+      .handleAppendStep(
+        { name: 'lychee', UUID: 'lychee' } as IStepProps,
+        { name: 'raspberry', UUID: 'raspberry' } as IStepProps
+      )
+      .then(() => {
+        expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(2);
+      });
+
+    expect(fetchStepDetails).toHaveBeenCalled();
+  });
+
+  it('handleDropOnExistingStep(): should replace an existing step and update the store', async () => {
+    useIntegrationJsonStore
+      .getState()
+      .insertStep({ name: 'lychee', UUID: 'lychee', type: 'START' } as IStepProps, 0);
+    expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain('lychee');
+
+    // mock fetching additional parameters for new step
+    jest
+      .mocked(fetchStepDetails)
+      .mockResolvedValueOnce({ name: 'raspberry', type: 'START', parameters: [] });
+
+    await stepsService
+      .handleDropOnExistingStep(
+        { step: { type: 'START' } } as IVizStepNodeData,
+        { name: 'lychee', UUID: 'lychee-0' } as IStepProps,
+        { name: 'raspberry', UUID: 'raspberry-0' } as IStepProps
+      )
+      .then(() => {
+        expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain(
+          'raspberry'
+        );
+      });
+
+    expect(fetchStepDetails).toHaveBeenCalled();
+  });
+
+  it('handleInsertStep(): should insert a step between two specified steps and update the store', async () => {
+    useIntegrationJsonStore.setState({
+      integrationJson: {
+        ...useIntegrationJsonStore.getState().integrationJson,
+        steps: [
+          { name: 'apple', UUID: 'apple-0', type: 'START' },
+          { name: 'watermelon', UUID: 'watermelon-1', type: 'MIDDLE' },
+        ] as IStepProps[],
+      },
+    });
+
+    expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain('apple');
+
+    // mock fetching additional parameters for new step
+    jest
+      .mocked(fetchStepDetails)
+      .mockResolvedValueOnce({ name: 'grape', type: 'START', parameters: [] });
+
+    await stepsService
+      .handleInsertStep(
+        { data: { step: { name: 'watermelon', UUID: 'watermelon-1' } } } as IVizStepNode,
+        { name: 'grape', UUID: 'grape-1' } as IStepProps
+      )
+      .then(() => {
+        // new step UUID should contain the target node's old index
+        expect(useIntegrationJsonStore.getState().integrationJson.steps[1].UUID).toContain(
+          'grape-1'
+        );
+        // UUID for watermelon should contain the new index
+        expect(useIntegrationJsonStore.getState().integrationJson.steps[2].UUID).toContain(
+          'watermelon-2'
+        );
+      });
+
+    expect(fetchStepDetails).toHaveBeenCalled();
+  });
+
+  it('handlePrependStep(): should insert a step before another and update the store', async () => {
+    useIntegrationJsonStore.setState({
+      integrationJson: {
+        ...useIntegrationJsonStore.getState().integrationJson,
+        steps: [
+          { name: 'cherry', UUID: 'cherry-0', type: 'START' },
+          { name: 'peach', UUID: 'peach-1', type: 'MIDDLE' },
+        ] as IStepProps[],
+      },
+    });
+
+    expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain('cherry');
+
+    // mock fetching additional parameters for new step
+    jest
+      .mocked(fetchStepDetails)
+      .mockResolvedValueOnce({ name: 'lime', type: 'START', parameters: [] });
+
+    await stepsService
+      .handlePrependStep(
+        { name: 'peach', UUID: 'peach-1' } as IStepProps,
+        { name: 'lime', UUID: 'lime-1' } as IStepProps
+      )
+      .then(() => {
+        expect(useIntegrationJsonStore.getState().integrationJson.steps[1].UUID).toContain('lime');
+        expect(useIntegrationJsonStore.getState().integrationJson.steps[2].UUID).toContain('peach');
+      });
+
+    expect(fetchStepDetails).toHaveBeenCalled();
+  });
+
+  describe('hasCustomStepExtension(): should determine if the specified step has a step extension', () => {
+    it('should return "false" for empty views', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [] as IViewProps[]
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return "false" for a matching view with no URL available', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [{ step: 'random-id', url: '' }] as IViewProps[]
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return "false" for non-matching views', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [{ step: 'not-a-random-id', url: '/dev/null' }] as IViewProps[]
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should return "true" for matching views and an URL available', () => {
+      const result = StepsService.hasCustomStepExtension(
+        { UUID: 'random-id' } as IStepProps,
+        [{ step: 'random-id', url: '/dev/null' }] as IViewProps[]
+      );
+
+      expect(result).toBeTruthy();
+    });
+  });
+
   it('insertStep(): should insert the provided step at the index specified, in a given array of steps', () => {
     const steps = [
       {
@@ -83,18 +451,12 @@ describe('stepsService', () => {
     });
   });
 
-  /**
-   * isFirstStepEip
-   */
   it('isFirstStepEip(): should determine if the provided step is an EIP', () => {
     const firstBranch = branchSteps[1].branches![0];
     expect(StepsService.isFirstStepEip(branchSteps)).toBe(false);
     expect(StepsService.isFirstStepEip(firstBranch.steps)).toBe(true);
   });
 
-  /**
-   * isFirstStepStart
-   */
   it('isFirstStepStart(): should determine if the first step is a START', () => {
     // first step is a START
     expect(StepsService.isFirstStepStart(steps)).toBe(true);
@@ -114,34 +476,22 @@ describe('stepsService', () => {
     ).toBe(false);
   });
 
-  /**
-   * isEndStep
-   */
   it('isEndStep(): should determine if the provided step is an END step', () => {
     expect(StepsService.isEndStep(branchSteps[3])).toBe(true);
     expect(StepsService.isEndStep(branchSteps[0])).toBe(false);
   });
 
-  /**
-   * isMiddleStep
-   */
   it('isMiddleStep(): should determine if the provided step is a MIDDLE step', () => {
     expect(StepsService.isMiddleStep(branchSteps[1])).toBe(true);
     expect(StepsService.isMiddleStep(branchSteps[0])).toBe(false);
   });
 
-  /**
-   * isStartStep
-   */
   it('isStartStep(): should determine if the provided step is a START step', () => {
     expect(StepsService.isStartStep(branchSteps[0])).toBe(true);
     expect(StepsService.isStartStep(branchSteps[1])).toBe(false);
   });
 
-  /**
-   * regenerateUuids
-   */
-  describe('regenerateUuids', () => {
+  describe('regenerateUuids(): should (re)generate UUIDs for all steps', () => {
     it('should generate UUIDs for the main steps array', () => {
       const result = StepsService.regenerateUuids(integrationSteps);
 
@@ -206,8 +556,7 @@ describe('stepsService', () => {
     });
 
     it('should generate UUIDs for nested steps at two levels deep', () => {
-      const copiedIntegrationSteps = JSON.parse(JSON.stringify(integrationSteps));
-      const nestedIntegrationSteps: IStepProps[] = copiedIntegrationSteps;
+      const nestedIntegrationSteps: IStepProps[] = JSON.parse(JSON.stringify(integrationSteps));
       nestedIntegrationSteps[1].branches![0].steps = integrationSteps;
 
       const result = StepsService.regenerateUuids(nestedIntegrationSteps);
@@ -324,6 +673,29 @@ describe('stepsService', () => {
     });
   });
 
+  it('replacePlaceholderStep(): should replace a placeholder with a step and update the store', async () => {
+    expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(0);
+
+    // mock fetching additional parameters for new step
+    jest
+      .mocked(fetchStepDetails)
+      .mockResolvedValueOnce({ name: 'strawberry', type: 'START', parameters: [] });
+
+    await stepsService
+      .replacePlaceholderStep(
+        { step: { type: 'START' } } as IVizStepNodeData,
+        { name: 'strawberry', UUID: 'strawberry-0' } as IStepProps
+      )
+      .then(() => {
+        expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(1);
+        expect(useIntegrationJsonStore.getState().integrationJson.steps[0].UUID).toContain(
+          'strawberry'
+        );
+      });
+
+    expect(fetchStepDetails).toHaveBeenCalled();
+  });
+
   it('supportsBranching(): should determine if the provided step supports branching', () => {
     expect(
       StepsService.supportsBranching({
@@ -345,81 +717,47 @@ describe('stepsService', () => {
     expect(StepsService.supportsBranching({ UUID: 'no-branches' } as IStepProps)).toBeFalsy();
   });
 
-  describe('hasCustomStepExtension()', () => {
-    it('should return "false" for empty views', () => {
-      const result = StepsService.hasCustomStepExtension(
-        { UUID: 'random-id' } as IStepProps,
-        [] as IViewProps[]
-      );
+  it('updateStepParameters(): should update existing parameters for specified step, with provided values', () => {
+    const step = {
+      name: 'plum',
+      parameters: [{ type: 'string', id: 'description', value: 'wat' }] as IStepPropsParameters[],
+    } as IStepProps;
+    useIntegrationJsonStore.getState().insertStep(step, 0);
 
-      expect(result).toBeFalsy();
-    });
+    stepsService.updateStepParameters(step, { description: 'guava' });
 
-    it('should return "false" for a matching view with no URL available', () => {
-      const result = StepsService.hasCustomStepExtension(
-        { UUID: 'random-id' } as IStepProps,
-        [{ step: 'random-id', url: '' }] as IViewProps[]
-      );
-
-      expect(result).toBeFalsy();
-    });
-
-    it('should return "false" for non-matching views', () => {
-      const result = StepsService.hasCustomStepExtension(
-        { UUID: 'random-id' } as IStepProps,
-        [{ step: 'not-a-random-id', url: '/dev/null' }] as IViewProps[]
-      );
-
-      expect(result).toBeFalsy();
-    });
-
-    it('should return "true" for matching views and an URL available', () => {
-      const result = StepsService.hasCustomStepExtension(
-        { UUID: 'random-id' } as IStepProps,
-        [{ step: 'random-id', url: '/dev/null' }] as IViewProps[]
-      );
-
-      expect(result).toBeTruthy();
-    });
+    expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(1);
+    expect(
+      useIntegrationJsonStore.getState().integrationJson.steps[0].parameters![0]
+    ).toMatchObject({ type: 'string', id: 'description', value: 'guava' });
   });
 
-  it('buildStepSchemaAndModel():should ignore empty array parameter', () => {
-    const parameter: IStepPropsParameters = {
-      id: 'key',
-      type: 'string',
-      description: 'test description',
-      value: 'value',
-    };
-    const parameter2: IStepPropsParameters = {
-      id: 'array',
-      type: 'array',
-      description: '',
-      value: [],
-    };
-    const parameter3: IStepPropsParameters = {
-      id: 'array2',
-      type: 'array',
-      description: 'array',
-      value: null,
-    };
-    const modelObjectRef = {} as IStepPropsParameters;
-    const schemaObjectRef: {
-      [label: string]: { type: string; value?: any; description?: string };
-    } = {};
+  it('updateViews(): should call on apiService to fetch views for provided steps', async () => {
+    const step = {
+      name: 'plum',
+      parameters: [{ type: 'string', id: 'description', value: 'wat' }] as IStepPropsParameters[],
+    } as IStepProps;
+    useIntegrationJsonStore.getState().insertStep(step, 0);
+    expect(useIntegrationJsonStore.getState().integrationJson.steps).toHaveLength(1);
+    expect(useIntegrationJsonStore.getState().views).toHaveLength(0);
 
-    StepsService.buildStepSchemaAndModel(parameter, modelObjectRef, schemaObjectRef);
-    StepsService.buildStepSchemaAndModel(parameter2, modelObjectRef, schemaObjectRef);
-    StepsService.buildStepSchemaAndModel(parameter3, modelObjectRef, schemaObjectRef);
+    // mock fetching additional parameters for new step
+    jest.mocked(fetchViews).mockResolvedValueOnce([
+      {
+        name: 'Integration View',
+        type: 'generic',
+        id: 'integration',
+        properties: {},
+        step: null,
+        url: null,
+        constraints: null,
+        scope: null,
+        module: null,
+      },
+    ]);
 
-    const modelEntries = Object.entries(modelObjectRef);
-    const schemaEntries = Object.entries(schemaObjectRef);
-
-    expect(schemaEntries.length).toBe(1);
-    expect(modelEntries.length).toBe(1);
-
-    expect(modelEntries[0][0]).toContain('key');
-    expect(modelEntries[0][1]).toContain('value');
-
-    expect(JSON.stringify(schemaEntries)).toContain('test description');
+    await stepsService.updateViews().then(() => {
+      expect(useIntegrationJsonStore.getState().views).toHaveLength(1);
+    });
   });
 });

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -376,8 +376,11 @@ describe('visualizationService', () => {
       type: 'step',
     };
 
-    it('should return minlen=2 when in horizontal mode and have more than one nested step', () => {
-      const sourceNode = { ...node, data: { step: { ...steps[1], branches: [1, 2] } } } as IVizStepNode;
+    it('should return minlen=2 when in horizontal mode and has more than one nested step', () => {
+      const sourceNode = {
+        ...node,
+        data: { step: { ...steps[1], branches: [1, 2] } },
+      } as IVizStepNode;
       const result = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
 
       expect(result).toMatchObject({
@@ -385,8 +388,11 @@ describe('visualizationService', () => {
       });
     });
 
-    it('should return minlen=1 when in horizontal mode and have one nested step', () => {
-      const sourceNode = { ...node, data: { step: { ...steps[1], branches: [1] } } } as IVizStepNode;
+    it('should return minlen=1 when in horizontal mode and has one nested step', () => {
+      const sourceNode = {
+        ...node,
+        data: { step: { ...steps[1], branches: [1] } },
+      } as IVizStepNode;
       const result = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
 
       expect(result).toMatchObject({
@@ -394,7 +400,7 @@ describe('visualizationService', () => {
       });
     });
 
-    it('should return minlen=1 when in horizontal mode and have no nested step', () => {
+    it('should return minlen=1 when in horizontal mode and has no nested step', () => {
       const sourceNode = { ...node, data: { step: { ...steps[1], branches: [] } } } as IVizStepNode;
       const result = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
 
@@ -403,8 +409,11 @@ describe('visualizationService', () => {
       });
     });
 
-    it('should return minlen=1 when in horizontal mode and have no nranch info', () => {
-      const sourceNode = { ...node, data: { step: { ...steps[1], branches: null } } } as IVizStepNode;
+    it('should return minlen=1 when in horizontal mode and has no branch info', () => {
+      const sourceNode = {
+        ...node,
+        data: { step: { ...steps[1], branches: null } },
+      } as IVizStepNode;
       const result = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
 
       expect(result).toMatchObject({
@@ -422,7 +431,10 @@ describe('visualizationService', () => {
     });
 
     it('should return weight=2 for steps with nested steps', () => {
-      const sourceNode = { ...node, data: { step: { ...steps[1], branches: [1, 2, 3] } } } as IVizStepNode;
+      const sourceNode = {
+        ...node,
+        data: { step: { ...steps[1], branches: [1, 2, 3] } },
+      } as IVizStepNode;
       const result = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
 
       expect(result).toMatchObject({
@@ -440,7 +452,10 @@ describe('visualizationService', () => {
     });
 
     it('should return weight=1 for steps without branches', () => {
-      const sourceNode = { ...node, data: { step: { ...steps[1], branches: null } } } as IVizStepNode;
+      const sourceNode = {
+        ...node,
+        data: { step: { ...steps[1], branches: null } },
+      } as IVizStepNode;
       const result = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
 
       expect(result).toMatchObject({

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -433,7 +433,10 @@ export class VisualizationService {
 
     edges.forEach((edge) => {
       const sourceNode = nodes.find((node) => node.id === edge.source);
-      const dagreWeightedValues = VisualizationService.getDagreWeightedValues(isHorizontal, sourceNode);
+      const dagreWeightedValues = VisualizationService.getDagreWeightedValues(
+        isHorizontal,
+        sourceNode
+      );
 
       dagreGraph.setEdge(edge.source, edge.target, dagreWeightedValues);
     });
@@ -459,11 +462,14 @@ export class VisualizationService {
     return { layoutedNodes: nodes, layoutedEdges: edges };
   }
 
-  static getDagreWeightedValues(isHorizontal: boolean, sourceNode?: IVizStepNode): { minlen: number; weight: number } {
+  static getDagreWeightedValues(
+    isHorizontal: boolean,
+    sourceNode?: IVizStepNode
+  ): { minlen: number; weight: number } {
     return {
       minlen: isHorizontal ? (sourceNode?.data.step.branches?.length > 1 ? 2 : 1) : 1.5,
       weight: sourceNode?.data.step.branches?.length > 0 ? 2 : 1,
-    }
+    };
   }
 
   /**
@@ -624,13 +630,10 @@ export class VisualizationService {
 
   /**
    * Determines whether to show the Branches tab in the mini catalog
-   * @param nodeData
+   * @param step
    */
   static showBranchesTab(step: IStepProps): boolean {
-    return (
-      StepsService.supportsBranching(step) &&
-      step.branches?.length !== step.maxBranches
-    );
+    return StepsService.supportsBranching(step) && step.branches?.length !== step.maxBranches;
   }
 
   /**

--- a/src/store/data/deployment.ts
+++ b/src/store/data/deployment.ts
@@ -1,0 +1,93 @@
+export default 'apiVersion: camel.apache.org/v1alpha1\n' +
+  'group: camel.apache.org\n' +
+  'kind: KameletBinding\n' +
+  'metadata:\n' +
+  '  additionalProperties: {}\n' +
+  '  annotations:\n' +
+  '    camel.apache.org/kamelet.icon: data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iOTJwdCIgd2lkdGg9IjkycHQiIHZlcnNpb249IjEuMCIgeG1sbnM6Y2M9Imh0dHA6Ly9jcmVhdGl2ZWNvbW1vbnMub3JnL25zIyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyI+Cgk8ZGVmcz4KCQk8bGluZWFyR3JhZGllbnQgaWQ9ImEiPgoJCQk8c3RvcCBzdG9wLWNvbG9yPSIjZmZmZmZmIiBzdG9wLW9wYWNpdHk9Ii41IiBvZmZzZXQ9IjAiLz4KCQkJPHN0b3Agc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIuMSIgb2Zmc2V0PSIxIi8+CgkJPC9saW5lYXJHcmFkaWVudD4KCQk8bGluZWFyR3JhZGllbnQgaWQ9ImQiIHkyPSI2Mi4yOTkiIHhsaW5rOmhyZWY9IiNhIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeTE9IjMzLjYxIiBncmFkaWVudFRyYW5zZm9ybT0ibWF0cml4KC43ODQ3OSAwIDAgMS4yNzQyIC0yNS42OTEgLTguNTYzNSkiIHgyPSI5NS42ODkiIHgxPSI1OS4wOTkiLz4KCQk8bGluZWFyR3JhZGllbnQgaWQ9ImMiIHkyPSIyNDEuMDkiIHhsaW5rOmhyZWY9IiNhIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeTE9IjIwOC4wNCIgZ3JhZGllbnRUcmFuc2Zvcm09Im1hdHJpeCgxLjk3NzcgMCAwIC41MDU2MyAtMjUuNjkxIC04LjU2MzUpIiB4Mj0iMjguMTc5IiB4MT0iMTcuNDAyIi8+CgkJPGxpbmVhckdyYWRpZW50IGlkPSJiIiB5Mj0iODAuOTA5IiB4bGluazpocmVmPSIjYSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHkxPSI1NS45ODgiIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoMS41NDY5IDAgMCAuNjQ2NDcgLTI1LjY5MSAtOC41NjM1KSIgeDI9Ijg3LjA3NCIgeDE9IjcwLjA2MyIvPgoJPC9kZWZzPgoJPHBhdGggc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0ibTEyLjQ2MyAyNC44ODZjMi4zNTIgMS4yMjYgMjIuMzY4IDUuNDg4IDMzLjk3MiA1LjIyNiAxNi41MjcgMC4yNjIgMzAuMzEzLTYuMDQ5IDMyLjkyNy03LjA1NSAwIDEuNDMzLTIuMzA3IDEwLjI3My0yLjYxNCAxNS42NzkgMCA1LjQ0OCAxLjgzIDI4LjQxNSAyLjA5MSAzMy43MTEgMC44NjggNi4xNzggMi43MDQgMTMuODYxIDQuNDQzIDE5LjA3NyAxLjgyOSAzLjU1My0yMy41NjMgOS44NTYtMzQuNzU3IDEwLjQ1Ni0xMi42MDIgMC43OC0zOC45MzctNC4zNzUtMzcuMzY5LTguMzY2IDAtMy45NjggMy42NTktMTMuMzgzIDMuNjU5LTE5LjU5OSAwLjUyMi02LjAyNS0wLjI2Mi0yMy4yNzMtMC4yNjItMzAuODM2LTAuMjYxLTYuNzgtMS4wNTMtMTIuNTYxLTIuMDktMTguMjkzeiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMXB0IiBmaWxsPSIjZmJkOTAwIi8+Cgk8cGF0aCBkPSJtMTAuNjMzIDk0LjY1OWMtNS41ODUxLTEuMzMxLTcuODc4NiAxMC4xMTEtMS44Mjg4IDEyLjAyMSA2LjM2NzggMy43NSAyOS43MDMgNy4wNiAzOS4xOTkgNi4yNyAxMS4xMDEtMC4yNiAzMS4xOTItNC40NCAzNS44MDEtOC4zNiA2LjEzNC0zLjkyIDUuNDY2LTEzLjA2NiAwLTEyLjAyMS0zLjI3OCAzLjY1OC0yNi42OTkgOC44ODEtMzYuNTg1IDkuNDExLTkuMjIzIDAuNzgtMzAuNzQ5LTIuNTMtMzYuNTg2LTcuMzIxeiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMXB0IiBmaWxsPSIjZmJmM2JmIi8+Cgk8cGF0aCBzdHJva2UtbGluZWpvaW49ImJldmVsIiBkPSJtNzcuMzgyIDM0LjA0NmMxLjI0NS0zLjIxMiA5LjYzOS02Ljk3MiAxMi4zNjQtNy41MTYgNC42ODYtMS4wNSAxMi4zODQtMS4zODggMTYuNzY0IDQuMjggNy45NCAxMC4zMjMgNi43NiAyOC42MjYgMi44NiAzNC42MzgtMi43OCA1LjEwNC05LjM3MSAxMC4yODItMTQuNjM1IDExLjg3OC01LjE1MSAxLjUzMy0xMi43MDcgMi42NjEtMTQuMzMzIDMuNzExLTAuMzUtMS4yOTYtMS4zMjctNy4zODgtMS4zOC05LjA3MSAxLjk1IDAuMTI4IDcuNDg5LTAuODkzIDExLjY5NS0xLjg2OCAzLjkwMi0wLjg5OSA2LjQ1LTMuMjc0IDkuMzMzLTYuMjIyIDUtNC43IDQuMzUtMjEuMTYgMC41NC0yNS4wNTctMi4yMzMtMi4yNjItNi44NDktMy45MDQtOS45MTUtMy4zMjMtNC45OTIgMS4wMzItMTMuNjc3IDcuMzY2LTEzLjY3NyA2Ljk4LTAuNTA4LTIuMDgtMC4yNS02LjE1OSAwLjM4NC04LjQzeiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMS4yNSIgZmlsbD0iI2ZiZjNiZiIvPgoJPHBhdGggc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0ibTMyLjAyMiAzOC4zNjhjMS42NTUgMS4yMDYtMS4zNTUgMTYuOTU1LTAuOTQyIDI4LjEzMSAwLjQxNCAxNC4yOTUgMS40NDQgMjMuNTI4LTAuNTIxIDI0LjYzNS0zLjEwOCAxLjY3NS05LjkwMS0wLjEzNS0xMi4wNDYtMi40Mi0xLjI3My0xLjUwNyAxLjgwNi0xMC4yNCAyLjAxMy0xNi40MjktMC40MTQtOC43MTEtMS43MDMtMzMuMzAzLTAuNDYxLTM0Ljc3OCAyLjI1Mi0yLjA1MyA5LjY4MS0xLjE1MiAxMS45NTcgMC44NjF6IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSIxLjI1IiBmaWxsPSIjZmJlNjAwIi8+Cgk8cGF0aCBkPSJtNDAuNjEyIDM5LjAzN2MtMS40NzggMS40MjQtMC4wNjMgMTkuNjI1LTAuMDYzIDIyLjU1OSAwLjMwNSAzLjgwOC0xLjEwMSAyNy40NTItMC4xNzggMjguOTU0IDEuODQ4IDIuMTIyIDEwLjIxNiAyLjQ0MiAxMy4wMDEtMC4zNTYgMS41MDUtMS44NzUtMC40NzgtMjIuNTQ0LTAuNDc4LTI3LjY4IDAtNS41MSAxLjQwNy0yMi4wNTItMC40NC0yMy41OC0yLjAzMy0yLjE0OS04LjQ0LTMuMTgtMTEuODQyIDAuMTAzeiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMXB0IiBmaWxsPSIjZmJlNjAwIi8+Cgk8cGF0aCBzdHJva2UtbGluZWpvaW49InJvdW5kIiBkPSJtNjAuMzAxIDM3LjU5M2MtMS42NTggMS4yNTYgMS4xNzkgMTUuOCAxLjE5NCAyNi45ODIgMC4xMzcgMTQuMjk5LTEuMjQ1IDI0LjY2MiAwLjgyNCAyNS43MDkgMy4yNjggMS41NzggMTAuODgxLTEuNTQyIDEzLTMuODkxIDEuMjUzLTEuNTQ1LTEuNDExLTEwLjE3OS0yLjA4Mi0xNi4zNTgtMC45ODQtOC4xNjQgMC4xNDgtMzMuMTI4LTEuMTg5LTM0LjU2NC0yLjQwMi0xLjk4NC05LjQ4MiAwLjA0LTExLjc0NyAyLjEyMnoiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjEuMjUiIGZpbGw9IiNmYmU2MDAiLz4KCTxwYXRoIGQ9Im01My41ODIgMzEuMTJjLTQuOTg5IDEuMTA5LTM2LjU4OC0zLjE0MS0zOS43MjktNC44MDQgMC45MjQgNC42MiAzLjE0MSA0NS4yNzIgMS42NjMgNDkuODkyIDAuMTg1IDIuMDMyLTMuODggMTUuMTUyLTMuNjk1IDE3LjkyNCAxNy4xODQtNjguMzcgMzkuNzI4LTQ4Ljk2OCA0MS43NjEtNjMuMDEyeiIgZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSJ1cmwoI2QpIi8+Cgk8cGF0aCBkPSJtMTAuMDI3IDk1LjMwOWMtMy4wNTE1LTAuODk3LTUuMjA1MyA2LjgyMS0yLjg3MiA5LjE1MSA1Ljc0MyAyLjY5IDEzLjI4Mi0yLjMzIDM4LjIzLTEuNjEtMTIuNzQzLTAuMzYtMzEuNTg5LTIuODc0LTM1LjM1OC03LjU0MXoiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZmlsbD0idXJsKCNjKSIvPgoJPHBhdGggZD0ibTc4LjU5IDMzLjU2N2M0LjQ4Ny00LjQ4OCA4Ljc5NC01LjU2NCAxMy45OTktNi40NjIgOC43OTEtMi4zMzMgMTQuOTAxIDMuNzY5IDE2Ljg3MSAxMS44NDYtNC40OS03LjE3OS0xMC4yMy04LjI1Ni0xNC4xNzgtOC40MzYtNC4xMjggMC43MTgtMTUuNzk1IDcuODk4LTE2Ljg3MiA5LjE1NHMtMC43MTgtNC4xMjggMC4xOC02LjEwMnoiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZmlsbD0idXJsKCNiKSIvPgoJPHBhdGggc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZD0ibTExLjQwOCA3Ny4zNGMyLjM4MzIgMS4xNTkgNC4yODExLTEuNTY5MyAzLjQ2NDktMy4wMzAzIDAuOTE1MDMgMC4wODY1OCAxLjc5NDgtMC4zMjU0IDEuNzk0OC0xLjc5NDggMC43MjA0NC0wLjcyMDQ0LTAuMzY0NjEtMS44NTQ0LTAuMzY0NjEtMi43MzU3LTAuOTkzNTQtMC45OTM1NCAwLjAwNTYtMi4xNjUgMC4wMDU2LTMuNzI1NyAwLTEuNTUzNSAwLjg5NzQyLTIuNTAyNCAwLjg5NzQyLTQuMTI4MSAwLTIuMzYxMSAyLjA1OTQtMS4xODA3IDAuODk3NDItNC42NjY2IDEuMDg4Mi0wLjQyNDU1IDIuMjc0MS0xLjQ4NDUgMC44OTc0Mi0yLjY5MjMgMi4xNjAxLTAuMjM5NTIgMy4yMTg2LTIuMzU0MiAwLjUzODQ1LTQuNjY2NiA0LjA3MzQgMC00LjIzMDItOC43MzA1IDIuNjkyMy02Ljk5OTkgMi4yMjItMC41NTU1MSAxLjc5NDgtMi4yMTUxIDEuNzk0OC00LjMwNzYgMi44NzE3IDMuOTQ4NyA2Ljg5NTQgMi42MjEzIDcuNTM4MyAwIDEuMzQ4NiA0LjM5OTggMTAuNTkgMi41ODY5IDEwLjU5LTIuODcxNyAwLjE3OTQ4IDYuNzUwMiA3LjExNzcgMy40MDQ2IDguNDM1OCAzLjk0ODYtMS42MTU0IDEuODY2MiAxLjU4NDEgOS4wNzk2IDQuMzA3NiA5LjE1MzctNi4zMDk3IDQuNzMyMy01LjE3MjkgMTMuMDAxIDIuNTEyOCAxNC41MzggMy44OTM4IDAgNS4zODQ1LTMuMjc4NSA1LjM4NDUtNy44OTczIDEuMjU2NCAyLjY0NDcgNi45NzIgNC4yNzk3IDYuOTk5OS0wLjE3OTQ4IDIuODcxNyA1LjU0NDYgNi40OTU5LTEuNDcwNCA0LjMwNzYtMi4xNTM4IDUuMDI1NiAxLjkwNTcgMy4yMTI4LTYuOTgxMSAxLjM3ODUtOS4wNTYgMi44NzE4LTAuOTE0NDggMS44MzQ2LTcuNjE4NCAwLjA1NzQtOS43ODk4IDIuNjIxMiAyLjY2NTIgNi43Mzg1LTAuODMxMTIgNi4yODItNS45MjMgMS4yMjggMy40NjcxIDkuMTQ3NS0wLjM2ODI4IDMuNzY5Mi04LjQzNTggMC0xLjU0NTEtNC40ODcxLTEuNzQ4OC01LjU2NC0wLjUzODQ1LTAuMDE1NDEtNS40NDYxLTQuMDk5Ny05LjY5MjEtNi45OTk5LTguNjE1MiAxLjc5OS0yLjY5MzItOS4wNDgtNC44OTk5LTExLjMwOC0wLjUzOSAxLjM1MS01LjcwMTItMTMuODEtOS4zMzM2LTE0LjE3OS02LjEwMjktMS43NDgtMi41MTI4LTExLjc3MS0yLjU1ODYtMTQuNzE4IDYuMjgxOSAwLTQuODYwNi0xNi4zMDktNi45OTk5LTE1Ljk3NCAwLjM1ODk3LTMuNDg5OS0yLjQzMzEtOS4yMjc0IDAuMzU4OTctOC43OTQ3IDMuMjMwNy01LjM4NDUtMi43MDM0LTcuODQyIDkuNTYxMS0zLjQxMDIgMTAuMjMxLTIuNTEyOCAyLjI2MjQtMi42OTIzIDExLjMxMSAwLjUzODQ1IDExLjEyOC0xLjk3NDMgMi4xMjk3LTAuODk3NDIgOC40MzY2IDEuMjU2NCA4LjYxNTItMS42Nzk0IDIuMzIwNiAwLjI0NTcgMTMuNjc0IDcuMTc5NCAxMS44NDYgMCAyLjUyMzQgMC43MDg3NyA0LjY5NDEtMC4xNzk0OCA3LjM1ODggMCAxLjU0NTUtMC44OTc0MiAyLjg1MjgtMC44OTc0MiA0LjQ4NzEgMC4zNzIwNiAwLjc0NDEyLTEuMjU5NyAyLjcyNDQgMC41Mzg0NSAzLjk0ODYtNC4yMTY3IDEuNzU5My0zLjMwMjQgNC40NjQyLTEuNjcwMSA1LjcyMjZ6IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSIxcHQiIGZpbGw9IiNmZmZmZmYiLz4KCTxwYXRoIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im0xMS4zMTcgMzIuNTc0Yy0xLjUwOTgtMS42NSAxLjIyMS03LjA0IDQuMjQyLTYuNzYzIDAuNjg5LTIuNDc0IDIuNTg2LTIuODkyIDQuNjg4LTIuMTg3LTEuMDQ4LTIuMDQ1IDEuNTAzLTMuOTkyIDMuNzUtMS42ODIgMS41MTctMi42MjIgNC42NzctNC42NDUgNi4zNTYtMy4yMzEtMC4xMzItMy4zNzMgNi4wNjMtNi43OTQgOC4zMzEtMy44MzcgMCAwLjYwNi0wLjM2MiAxLjg3NSAwIDEuODc1IiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSIxcHQiIGZpbGw9Im5vbmUiLz4KCTxwYXRoIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGQ9Im00OC4zNzIgMjIuMzc0Yy0wLjEwNC00LjcyMSAxNC4wMDktOC41OTEgMTEuMjUtMC4zMTMgMS4yNjktMC42MzQgNi44NzUtMS4yOTkgNS44NDQgMi4zMTQgNC4xMjMtMC40NjYgMTAuMzkgMS4xMDQgNi42NjIgNi42ODggMi4zOTYgMS44MDYgMS4zMzEgNi42OTYtMC4zMTkgNS4wNjEiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjFwdCIgZmlsbD0ibm9uZSIvPgo8L3N2Zz4K\n' +
+  "  creationTimestamp: '2022-07-10T13:25:09Z'\n" +
+  '  finalizers: []\n' +
+  '  generation: 1\n' +
+  '  managedFields:\n' +
+  '    - additionalProperties: {}\n' +
+  '      apiVersion: camel.apache.org/v1alpha1\n' +
+  '      fieldsType: FieldsV1\n' +
+  '      fieldsV1:\n' +
+  '        additionalProperties:\n' +
+  '          f:metadata:\n' +
+  '            f:annotations:\n' +
+  '              .: {}\n' +
+  '              f:camel.apache.org/kamelet.icon: {}\n' +
+  '      manager: kamel\n' +
+  '      operation: Update\n' +
+  "      time: '2022-07-10T13:25:09Z'\n" +
+  '    - additionalProperties: {}\n' +
+  '      apiVersion: camel.apache.org/v1alpha1\n' +
+  '      fieldsType: FieldsV1\n' +
+  '      fieldsV1:\n' +
+  '        additionalProperties:\n' +
+  '          f:status:\n' +
+  '            .: {}\n' +
+  '            f:conditions: {}\n' +
+  '            f:phase: {}\n' +
+  '      manager: kamel\n' +
+  '      operation: Update\n' +
+  '      subresource: status\n' +
+  "      time: '2022-07-10T13:25:09Z'\n" +
+  '    - additionalProperties: {}\n' +
+  '      apiVersion: camel.apache.org/v1alpha1\n' +
+  '      fieldsType: FieldsV1\n' +
+  '      fieldsV1:\n' +
+  '        additionalProperties:\n' +
+  '          f:spec:\n' +
+  '            .: {}\n' +
+  '            f:sink:\n' +
+  '              .: {}\n' +
+  '              f:ref:\n' +
+  '                .: {}\n' +
+  '                f:apiVersion: {}\n' +
+  '                f:kind: {}\n' +
+  '                f:name: {}\n' +
+  '            f:source:\n' +
+  '              .: {}\n' +
+  '              f:ref:\n' +
+  '                .: {}\n' +
+  '                f:apiVersion: {}\n' +
+  '                f:kind: {}\n' +
+  '                f:name: {}\n' +
+  '            f:steps: {}\n' +
+  '      manager: okhttp\n' +
+  '      operation: Update\n' +
+  "      time: '2022-07-10T13:25:09Z'\n" +
+  '  name: lexi\n' +
+  '  namespace: default\n' +
+  '  ownerReferences: []\n' +
+  "  resourceVersion: '6390'\n" +
+  '  uid: c2106f2f-11bc-4d7d-912d-9d876365cc03\n' +
+  'plural: kameletbindings\n' +
+  'scope: Namespaced\n' +
+  'served: true\n' +
+  'singular: kameletbinding\n' +
+  'spec:\n' +
+  '  source:\n' +
+  '    ref:\n' +
+  '      apiVersion: camel.apache.org/v1alpha1\n' +
+  '      name: beer-source\n' +
+  '      kind: Kamelet\n' +
+  '  steps:\n' +
+  '    - uri: log:null?\n' +
+  '  sink:\n' +
+  '    ref:\n' +
+  '      apiVersion: camel.apache.org/v1alpha1\n' +
+  '      name: mail-sink\n' +
+  '      kind: Kamelet\n' +
+  'status:\n' +
+  '  conditions:\n' +
+  "    - lastTransitionTime: '2022-07-10T13:25:09Z'\n" +
+  "      lastUpdateTime: '2022-07-10T13:25:09Z'\n" +
+  '      reason: Creating\n' +
+  "      status: 'False'\n" +
+  '      type: Ready\n' +
+  '  phase: Creating\n' +
+  'storage: true\n' +
+  'version: v1alpha1\n';

--- a/src/store/nestedStepsStore.tsx
+++ b/src/store/nestedStepsStore.tsx
@@ -11,7 +11,7 @@ export interface INestedStepStore {
 
 const initialState: INestedStep[] = [];
 
-export const useNestedStepsStore = create<INestedStepStore>()((set, get) => ({
+export const useNestedStepsStore = create<INestedStepStore>((set, get) => ({
   ...initialState,
   addStep: (newStep) => {
     set((state) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,7 +87,7 @@ export interface IDsl {
  * a Generic or Step Extension
  */
 export interface IKaotoApi {
-  getDeployment: (name: string, namespace?: string) => Promise<string | unknown>;
+  getDeployment: (deploymentName: string, namespace?: string) => Promise<string | unknown>;
   getIntegrationSource: (
     integration: IIntegration,
     dsl: string,
@@ -96,12 +96,12 @@ export interface IKaotoApi {
   notifyKaoto: (title: string, body?: string, variant?: string) => void;
   startDeployment: (
     integration: any,
-    name: string,
+    deploymentName: string,
     namespace?: string
   ) => Promise<string | unknown>;
   step: IStepProps;
   stepParams: { [p: string]: any };
-  stopDeployment: (name: string, namespace?: string) => void;
+  stopDeployment: (deploymentName: string, namespace?: string) => void;
   updateStep: (step: IStepProps) => void;
   updateStepParams: (newValues: { [s: string]: unknown } | ArrayLike<unknown>) => void;
 }


### PR DESCRIPTION
This PR adds unit tests for all the remaining methods in `stepsService`, with some caveats.

## Changes
- Adds unit tests for the following:
  - `deleteBranch`
  - `deleteStep`
  - `getStepNested`
  - `handleAppendStep`
  - `handleDropOnExistingStep`
  - `handleInsertStep`
  - `handlePrependStep`
  - `replacePlaceholderStep`
  - `updateStepParameters`
  - `updateViews`
- Adds test suite for `createKaotoApi` and tests for its methods:
  - `deleteStep`
  - `getDeployment`
  - `getIntegrationSource`
  - `notifyKaoto`
  - `startDeployment`
  - `step`
  - `stepParams`
  - `stopDeployment`
  - `updateStep`
  - `updateStepParams`
- Updates the `findStepIdxWithUUID` test to cover cases where we don't pass an array of `steps`
- Updates descriptions of tests and alphabetizes a few of the tests 🤪
- Updates a few function params to be clearer what it's asking for (e.g. `handleDropOnExistingStep`)
- Clears the `integrationJson` store before each test as a workaround to an issue with mocking Zundo (see below)

### Caveat
Execution paths for nested steps are still not covered as there were some issues with nested calls to other Zustand stores, seemingly related to Zundo--paths that call `nestedStepsStore` from a secondary function were very difficult to mock. I'll update these once we get a workaround. cc @lordrip 

## Test Coverage
Current coverage of `services` and `stepsService`:

<img width="1597" alt="Screen Shot 2023-04-06 at 6 39 35 pm" src="https://user-images.githubusercontent.com/3844502/230454952-d9edbfc4-d2ee-46d8-aca8-0ead2d41c85b.png">

```
 services                        |   57.55 |    63.61 |   60.86 |   57.85 |
  index.ts                       |     100 |      100 |     100 |     100 |
  stepsService.ts                |   30.97 |    35.77 |   40.62 |   31.07 | ...8,91-186,244-246,290-412,486-506,534-562,571
  validationService.ts           |   78.18 |    94.73 |   58.33 |   82.69 | 129-149
  visualizationService.ts        |   82.73 |    71.48 |   94.44 |    83.2 | 120-187,328,516
```

Expected coverage of `services` and `stepsService`:
```
 services                        |   77.34 |    72.89 |   88.23 |   78.23 |
  index.ts                       |     100 |      100 |     100 |     100 |
  stepsService.ts                |   72.28 |    68.22 |    89.7 |   72.88 | ...189,307-312,339-341,363-376,400-410,498-505,551-555,567
  validationService.ts           |   78.18 |    94.73 |   58.33 |   82.69 | 129-149
  visualizationService.ts        |   82.73 |    71.48 |   94.44 |    83.2 | 120-187,328,522
```

Coverage is not 100% due to the issue with `nestedStepsStore` and Zundo, described above.