### PR TITLE
chore(viz): Adjust Node label clickable area

### DIFF
--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -107,12 +107,14 @@ button[data-disable-branchestab="true"][data-disable-stepstab="true"]:hover {
     left: -75%;
     position: relative;
     width: 250%;
+    pointer-events: none;
 }
 
 .stepNode__Label span {
     background: var(--pf-global--BackgroundColor--150);
     border-radius: 15%;
     padding: 0.4em;
+    pointer-events: auto;
 }
 
 .stepNode__Prepend {

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -175,8 +175,8 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
             <img src={data.step.icon} alt={data.label} />
           </div>
           {/* STEP LABEL */}
-          <div className={'stepNode__Label stepNode__clickable'}>
-            <span>{data.label}</span>
+          <div className={'stepNode__Label'}>
+            <span className={'stepNode__clickable'}>{data.label}</span>
           </div>
           {/* RIGHT-SIDE HANDLE FOR EDGE TO CONNECT WITH */}
           {!StepsService.isEndStep(data.step) && (
@@ -264,7 +264,9 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
               id="b"
               isConnectable={false}
             />
-            <div className={'stepNode__Label stepNode__clickable'}>{data.label}</div>
+            <div className={'stepNode__Label'}>
+              <span className={'stepNode__clickable'}>{data.label}</span>
+            </div>
           </div>
         </Popover>
       )}


### PR DESCRIPTION
Hi,

Here is a very small visualization update - described here -> [issue-1623](https://github.com/KaotoIO/kaoto-ui/issues/1623)

Before:

1) We have a clickable `<div>` container that is bigger than text content:
![chrome-capture-2023-3-4](https://user-images.githubusercontent.com/46084942/229735809-eb9b1489-031a-4090-9e55-60e86d9b723e.gif)

2) That container covered by non-clickable span if some step exists
![chrome-capture-2023-3-4 (1)](https://user-images.githubusercontent.com/46084942/229736383-487e69dd-c8c7-4920-b4c5-f4f762484c3d.gif)

After:

![chrome-capture-2023-3-4 (2)](https://user-images.githubusercontent.com/46084942/229752062-8f33049a-b6a1-473b-be05-11f9ce6eccb1.gif)

If you have any suggestions feel free to write :smile: 
