### PR TITLE
chore(e2e): Add new wait for intercepted requests

### DIFF
--- a/cypress/e2e/09-step_actions_from_canvas/step_extension_actions_from_canvas.cy.js
+++ b/cypress/e2e/09-step_actions_from_canvas/step_extension_actions_from_canvas.cy.js
@@ -12,7 +12,7 @@ describe('Test for Step extensions', () => {
 
     it('User sees a step extension(transform)', () => {
         cy.insertStepMiniCatalog('transform');
-        cy.openStepConfigurationTab('transform');
+        cy.openStepConfigurationTab('transform', true);
 
         // CHECK that choice extension elements are visible
         cy.get('[data-testid="expression-syntax-select"]').should('be.visible');
@@ -22,7 +22,7 @@ describe('Test for Step extensions', () => {
 
     it('User configures a step from a step extension (set-header)', () => {
         cy.insertStepMiniCatalog('set-header');
-        cy.openStepConfigurationTab('set-header');
+        cy.openStepConfigurationTab('set-header', true);
 
         // Fill the step name
         cy.get('[data-testid="set-header-name-input"]').clear().type('test-name');
@@ -42,7 +42,7 @@ describe('Test for Step extensions', () => {
 
     it('User adds and removes a branch from a step using a step extension', () => {
         cy.insertStepMiniCatalog('choice');
-        cy.openStepConfigurationTab('choice');
+        cy.openStepConfigurationTab('choice', true);
 
 
         cy.addBranchChoiceExtension();

--- a/cypress/e2e/10-branching_actions_from_canvas/branches_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/branches_from_canvas.cy.js
@@ -20,7 +20,7 @@ describe('Test for Branching actions from the canvas', () => {
         cy.get('[data-testid="viz-step-choice"]').eq(0).children('[data-testid="stepNode__appendStep-btn"]').should('be.disabled');
 
         // Temporary solution with Choice extension
-        cy.openStepConfigurationTab('choice', 0);
+        cy.openStepConfigurationTab('choice', true, 0);
         cy.addBranchChoiceExtension();
         cy.closeStepConfigurationTab();
 

--- a/cypress/e2e/10-branching_actions_from_canvas/nested_branches_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/nested_branches_from_canvas.cy.js
@@ -39,7 +39,7 @@ describe('Test for Nested Branching actions from the canvas', () => {
         cy.get('[data-testid="stepNode__insertStep-btn"]').eq(3).click();
         cy.get('[data-testid="miniCatalog__branches"]').should('have.attr', 'aria-disabled', 'true')
         cy.get('.pf-c-button.pf-m-plain').click();
-        cy.openStepConfigurationTab('choice', 1);
+        cy.openStepConfigurationTab('choice', true, 1);
         cy.addBranchChoiceExtension();
         cy.closeStepConfigurationTab();
         cy.get('[data-testid="viz-step-choice"]').eq(1).children('[data-testid="stepNode__appendStep-btn"]').should('be.disabled');
@@ -53,7 +53,7 @@ describe('Test for Nested Branching actions from the canvas', () => {
         // cy.appendBranch(1);
 
         // Temporary workaround:
-        cy.openStepConfigurationTab('choice', 1);
+        cy.openStepConfigurationTab('choice', true, 1);
         cy.addBranchChoiceExtension();
         cy.addBranchChoiceExtension('other');
         cy.closeStepConfigurationTab();
@@ -84,7 +84,7 @@ describe('Test for Nested Branching actions from the canvas', () => {
         // cy.appendBranch(1);
 
         // Temporary workaround:
-        cy.openStepConfigurationTab('choice', 1);
+        cy.openStepConfigurationTab('choice', true, 1);
         cy.addBranchChoiceExtension();
         cy.addBranchChoiceExtension('other');
         cy.closeStepConfigurationTab();
@@ -118,7 +118,7 @@ describe('Test for Nested Branching actions from the canvas', () => {
         // cy.appendBranch(1);
 
         // Temporary workaround:
-        cy.openStepConfigurationTab('choice', 1);
+        cy.openStepConfigurationTab('choice', true, 1);
         cy.addBranchChoiceExtension();
         cy.addBranchChoiceExtension('other');
         cy.closeStepConfigurationTab();
@@ -151,7 +151,7 @@ describe('Test for Nested Branching actions from the canvas', () => {
         // cy.appendBranch(1);
 
         // Temporary workaround:
-        cy.openStepConfigurationTab('choice', 1);
+        cy.openStepConfigurationTab('choice', true, 1);
         cy.addBranchChoiceExtension();
         cy.addBranchChoiceExtension('other');
         cy.closeStepConfigurationTab();

--- a/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
@@ -15,7 +15,7 @@ describe('User completes normal actions on steps in a branch', () => {
         // cy.replaceEmptyStepMiniCatalog('amqp');
 
         // Workaround for: https://github.com/KaotoIO/kaoto-ui/issues/1381
-        cy.openStepConfigurationTab('choice', 1);
+        cy.openStepConfigurationTab('choice', true, 1);
         cy.addBranchChoiceExtension();
         cy.addBranchChoiceExtension('other');
         cy.closeStepConfigurationTab();

--- a/cypress/support/kaoto-ui-commands/steps.js
+++ b/cypress/support/kaoto-ui-commands/steps.js
@@ -57,11 +57,14 @@ Cypress.Commands.add('deleteStep', (step, stepIndex) => {
     cy.waitVisualizationUpdate();
 });
 
-Cypress.Commands.add('openStepConfigurationTab', (step, stepIndex) => {
+Cypress.Commands.add('openStepConfigurationTab', (step, EIP, stepIndex) => {
     stepIndex = stepIndex ?? 0;
+    EIP = EIP ?? false;
     cy.get(`[data-testid="viz-step-${step}"]`).eq(stepIndex).click();
     cy.get('[data-testid="configurationTab"]').click();
-    cy.waitVisualizationUpdate();
+    if (!EIP) {
+        cy.waitVisualizationUpdate();
+    }
 });
 
 Cypress.Commands.add('closeStepConfigurationTab', () => {

--- a/cypress/support/kaoto-ui-commands/steps.js
+++ b/cypress/support/kaoto-ui-commands/steps.js
@@ -61,6 +61,7 @@ Cypress.Commands.add('openStepConfigurationTab', (step, stepIndex) => {
     stepIndex = stepIndex ?? 0;
     cy.get(`[data-testid="viz-step-${step}"]`).eq(stepIndex).click();
     cy.get('[data-testid="configurationTab"]').click();
+    cy.waitVisualizationUpdate();
 });
 
 Cypress.Commands.add('closeStepConfigurationTab', () => {


### PR DESCRIPTION
I have added an additional wait for intercepting requests after opening the configuration for steps (not EIP)

In the absence of waiting, the flakiness of the test increases significantly (tested a lot with and without)

Related issue -> [1680](https://github.com/KaotoIO/kaoto-ui/issues/1680)