### PR TITLE
feat(about): Add About modal to display front and back version

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -4,6 +4,7 @@ import 'whatwg-fetch';
 import { stepsCatalog } from './src/stubs/steps';
 
 global.TextEncoder = TextEncoder;
+global.KAOTO_VERSION = '1.0-test';
 
 jest.mock('@kaoto/api', () => {
   const actual = jest.requireActual('@kaoto/api');

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -4,6 +4,21 @@ import { IIntegration, IStepProps } from '@kaoto/types';
 const apiVersion = '/v1';
 
 /**
+ * Returns the backend version
+ */
+export async function fetchBackendVersion(): Promise<string> {
+  try {
+    const resp = await request.get({
+      endpoint: `${apiVersion}/capabilities/version`,
+    });
+
+    return await resp.text();
+  } catch (err) {
+    throw new Error(`Unable to fetch Backend version ${err}`);
+  }
+}
+
+/**
  * Returns a list of all capabilities, including all
  * domain-specific languages (DSLs)
  * Returns { dsls: { [val: string]: string }[] }

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -10,4 +10,3 @@ import { createRoot } from 'react-dom/client';
 const container = document.getElementById('app');
 const root = createRoot(container!);
 root.render(<App />);
-

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,0 +1,31 @@
+import { AboutModal as PatternFlyAboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import logo from '../assets/images/logo-kaoto-dark.png';
+import { useSettingsStore } from '../store';
+
+export interface IAboutModal {
+  handleCloseModal: () => void;
+  isModalOpen: boolean;
+}
+
+export const AboutModal = ({ handleCloseModal, isModalOpen }: IAboutModal) => {
+  const backendVersion = useSettingsStore((state) => state.backendVersion);
+
+  return (
+    <PatternFlyAboutModal
+      isOpen={isModalOpen}
+      onClose={handleCloseModal}
+      brandImageSrc={logo}
+      brandImageAlt="Kaoto Logo"
+      data-testid="about-modal"
+    >
+      <TextContent>
+        <TextList component="dl">
+          <TextListItem component="dt">Frontend Version</TextListItem>
+          <TextListItem component="dd">{KAOTO_VERSION}</TextListItem>
+          <TextListItem component="dt">Backend Version</TextListItem>
+          <TextListItem component="dd">{backendVersion}</TextListItem>
+        </TextList>
+      </TextContent>
+    </PatternFlyAboutModal>
+  );
+};

--- a/src/components/KaotoToolbar.test.tsx
+++ b/src/components/KaotoToolbar.test.tsx
@@ -1,7 +1,6 @@
 import KaotoToolbar from './KaotoToolbar';
 import { AlertProvider } from '@kaoto/layout';
-import { screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
+import { screen, render, fireEvent, act } from '@testing-library/react';
 
 describe('KaotoToolbar.tsx', () => {
   test('component renders correctly', () => {
@@ -32,5 +31,31 @@ describe('KaotoToolbar.tsx', () => {
     );
     const element = screen.getByTestId('kaoto-logo');
     expect(element).toBeInTheDocument();
+  });
+
+  test('open about modal', async () => {
+    const wrapper = render(
+      <AlertProvider>
+        <KaotoToolbar
+          leftDrawerExpanded
+          toggleCatalog={jest.fn()}
+          toggleCodeEditor={jest.fn()}
+          hideLeftPanel={jest.fn()}
+        />
+      </AlertProvider>
+    );
+
+    const kebabDropdownMenu = wrapper.getByTestId('toolbar-kebab-dropdown-toggle');
+    await act(async () => {
+      fireEvent.click(kebabDropdownMenu);
+    });
+
+    const aboutMenuItem = wrapper.getByTestId('kaotoToolbar-kebab__about');
+    await act(async () => {
+      fireEvent.click(aboutMenuItem);
+    });
+
+    const aboutModal = wrapper.getByTestId('about-modal');
+    expect(aboutModal).toBeInTheDocument();
   });
 });

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 import logo from '../assets/images/logo-kaoto-dark.png';
 import { fetchDefaultNamespace, startDeployment } from '@kaoto/api';
 import {
@@ -44,15 +43,13 @@ import {
 } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useCallback, useEffect, useState } from 'react';
+import { AboutModal } from './AboutModal';
 
 export interface IKaotoToolbar {
   toggleCatalog: () => void;
   leftDrawerExpanded: boolean;
   toggleCodeEditor: () => void;
   hideLeftPanel: () => void;
-}
-function LogoImg() {
-  return <img data-testid={'kaoto-logo'} src={logo} alt="Kaoto Logo" style={{ height: '30px' }} />;
 }
 
 export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, leftDrawerExpanded }: IKaotoToolbar) => {
@@ -73,6 +70,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
     'default' | 'warning' | 'success' | 'error' | undefined
   >('default');
   const [expanded, setExpanded] = useState({
+    aboutModal: false,
     appearanceModal: false,
     deploymentsModal: false,
     settingsModal: false,
@@ -169,6 +167,15 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
 
   const kebabItems = [
     <DropdownItem
+      key="about"
+      data-testid="kaotoToolbar-kebab__about"
+      onClick={() => {
+        setExpanded({ ...expanded, aboutModal: !expanded.aboutModal });
+      }}
+    >
+      About
+    </DropdownItem>,
+    <DropdownItem
       key="settings"
       data-testid={'kaotoToolbar-kebab__settings'}
       onClick={() => {
@@ -205,8 +212,9 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
     <>
       <Toolbar className={'viz-toolbar'} data-testid={'viz-toolbar'}>
         <ToolbarContent>
+          <img data-testid="kaoto-logo" src={logo} alt="Kaoto Logo" style={{ height: '30px' }} />
+
           {/* APP MENU */}
-          <LogoImg />
           <ToolbarItem>
             <Dropdown
               onSelect={onSelectAppMenu}
@@ -381,10 +389,10 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
               <OverflowMenuControl hasAdditionalOptions>
                 <Dropdown
                   position={DropdownPosition.right}
-                  toggle={<KebabToggle onToggle={(val) => setKebabIsOpen(val)} />}
+                  toggle={<KebabToggle data-testid="toolbar-kebab-dropdown-toggle" onToggle={(val) => {setKebabIsOpen(val);}} />}
                   isOpen={kebabIsOpen}
                   isPlain
-                  data-testid={'toolbar-kebab-dropdown-btn'}
+                  data-testid="toolbar-kebab-dropdown-btn"
                   dropdownItems={kebabItems}
                 />
               </OverflowMenuControl>
@@ -431,6 +439,11 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
           }
         }}
         isModalOpen={expanded.appearanceModal ?? false}
+      />
+
+      <AboutModal
+        handleCloseModal={() => { setExpanded({ ...expanded, aboutModal: false }); }}
+        isModalOpen={expanded.aboutModal}
       />
     </>
   );

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png';
+declare module '*.svg';
+declare var KAOTO_API: string;
+declare var KAOTO_VERSION: string;

--- a/src/layout/AppLayout.test.tsx
+++ b/src/layout/AppLayout.test.tsx
@@ -1,0 +1,70 @@
+import { fetchBackendVersion } from '@kaoto/api';
+import { act, render } from '@testing-library/react';
+import { AppLayout } from './AppLayout';
+
+jest.mock('@kaoto/api', () => {
+  const actual = jest.requireActual('@kaoto/api');
+
+  return ({
+    ...actual,
+    fetchBackendVersion: jest.fn(),
+  });
+});
+
+describe('AppLayout.tsx', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (fetchBackendVersion as jest.Mock).mockRejectedValue(null);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    (fetchBackendVersion as jest.Mock).mockClear();
+  });
+
+  test('component renders in loading mode', async () => {
+    const wrapper = render(
+      <AppLayout>
+        <span data-testid="children">This is a placeholder</span>
+      </AppLayout>
+    );
+
+    const element = wrapper.queryByTestId('children');
+    expect(element).not.toBeInTheDocument();
+  });
+
+  test('component times out and display error message', async () => {
+    const wrapper = render(
+      <AppLayout>
+        <span data-testid="children">This is a placeholder</span>
+      </AppLayout>
+    );
+
+    for (let i = 0; i <= 120; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1_100);
+      });
+    }
+
+    const element = wrapper.queryByText('Kaoto API is unreachable');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('component display its children once the API has been reached', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+
+    const wrapper = render(
+      <AppLayout>
+        <span data-testid="children">This is a placeholder</span>
+      </AppLayout>
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_100);
+    });
+
+    const element = wrapper.queryByText('This is a placeholder');
+    expect(element).toBeInTheDocument();
+  });
+});

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,30 +1,34 @@
 import { WaitingPage } from '../components/WaitingPage';
-import { fetchCapabilities } from '@kaoto/api';
+import { fetchBackendVersion } from '@kaoto/api';
 import { sleep } from '@kaoto/utils';
 import { Panel } from '@patternfly/react-core';
 import { ReactNode, useEffect, useState } from 'react';
+import { useSettingsStore } from '../store';
 
 interface IAppLayout {
   children: ReactNode;
 }
-const AppLayout = ({ children }: IAppLayout) => {
+
+export const AppLayout = ({ children }: IAppLayout) => {
   const [backendAvailable, setBackendAvailable] = useState(false);
   const [message, setMessage] = useState('Trying to reach the Kaoto API');
   const [fetching, setFetching] = useState(true);
+  const setBackendVersion = useSettingsStore((state) => state.setBackendVersion);
 
   useEffect(() => {
-    // Method that tries to connect to capabilities endpoint and evaluate if the API is available
+    // Method that tries to connect to capabilities/version endpoint and evaluate if the API is available
     const tryApiAvailable = (retries: number) => {
-      fetchCapabilities()
+      fetchBackendVersion()
         .then((resp) => {
           if (resp) {
             setBackendAvailable(true);
             setMessage('Trying to reach the Kaoto API');
+            setBackendVersion(resp);
           }
         })
         .catch(() => {
           if (retries > 0) {
-            sleep(1000).then(() => {
+            sleep(1_000).then(() => {
               tryApiAvailable(retries - 1);
             });
           } else {
@@ -44,5 +48,3 @@ const AppLayout = ({ children }: IAppLayout) => {
     </Panel>
   );
 };
-
-export { AppLayout };

--- a/src/store/settingsStore.test.tsx
+++ b/src/store/settingsStore.test.tsx
@@ -22,4 +22,15 @@ describe('settingsStore', () => {
     expect(result.current.settings.name).toEqual('Goji Berry');
     expect(result.current.settings.namespace).toEqual('KameletBinding');
   });
+
+  it('setBackendVersion', () => {
+    const { result } = renderHook(() => useSettingsStore());
+    expect(result.current.backendVersion).toEqual('');
+
+    act(() => {
+      result.current.setBackendVersion('1.0-test');
+    });
+
+    expect(result.current.backendVersion).toEqual('1.0-test');
+  });
 });

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore
 import svg from '../assets/images/kaoto.svg';
 import LOCAL_STORAGE_EDITOR_THEME_KEY from '@kaoto/constants';
 import { CodeEditorMode, IDsl, ISettings } from '@kaoto/types';
@@ -7,6 +6,8 @@ import { create } from 'zustand';
 interface ISettingsStore {
   settings: ISettings;
   setSettings: (vals?: Partial<ISettings>) => void;
+  backendVersion: string;
+  setBackendVersion: (backendVersion: string) => void;
 }
 
 export const initDsl: IDsl = {
@@ -35,6 +36,12 @@ export const useSettingsStore = create<ISettingsStore>((set) => ({
     set((state) => ({
       settings: { ...state.settings, ...vals },
     })),
+  backendVersion: '',
+  setBackendVersion: (backendVersion: string) => {
+    set(() => ({
+      backendVersion: backendVersion,
+    }));
+  }
 }));
 
 export default useSettingsStore;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,7 +3,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
-const { dependencies, federatedModuleName } = require('./package.json');
+const { dependencies, federatedModuleName, version } = require('./package.json');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
@@ -14,8 +14,6 @@ const isPatternflyStyles = (stylesheet) =>
   stylesheet.includes('@patternfly/react-core/') ||
   stylesheet.includes('@patternfly/react-code-editor') ||
   stylesheet.includes('monaco-editor-webpack-plugin');
-
-const deps = require('./package.json').dependencies;
 
 module.exports = () => {
   return {
@@ -110,10 +108,13 @@ module.exports = () => {
         library: { type: 'var', name: federatedModuleName },
         // exposes: ['./src/@kaoto/index.ts'],
         shared: {
-          ...deps,
+          ...dependencies,
         },
       }),
       // new FederatedTypesPlugin(),
+      new webpack.DefinePlugin({
+        KAOTO_VERSION: JSON.stringify(version),
+      }),
     ],
     resolve: {
       extensions: ['.js', '.ts', '.tsx', '.jsx'],


### PR DESCRIPTION
### Context
At this moment, there's no mechanism in place to easily determine which version of Kaoto frontend or backend we're using.

This pull request provides a dedicated view to display those values.

### Changes
* Injects the KaotoUI version from the `package.json` file into a global variable `KAOTO_VERSION`.
* Wires up an endpoint from the backend to retrieve the backend version.
* Add an About modal to display the aforementioned versions.

### Example
* About menu item
![image](https://user-images.githubusercontent.com/16512618/234229137-0fa9099e-4b1e-4c7a-aabb-78abb6dac24c.png)

* About modal
![image](https://user-images.githubusercontent.com/16512618/234229256-97c11635-358d-442b-87ca-00ce1ea43a58.png)

fix: [696](https://github.com/KaotoIO/kaoto-ui/issues/696)