### PR TITLE
chore(e2e): Update appearance tests

### DIFF
--- a/cypress/e2e/01-settings/appearance.cy.js
+++ b/cypress/e2e/01-settings/appearance.cy.js
@@ -16,28 +16,54 @@ describe('Settings: Appearance', () => {
     cy.get('[data-testid="appearance-modal"').should('be.visible');
   });
 
-  it('enables dark mode in Kaoto', () => {
-    cy.switchAppearanceTheme()
+  it('Enables dark mode in Kaoto', () => {
+    cy.switchAppearanceTheme().should(() => {
+      expect(localStorage.getItem('KAOTO_UI_THEME_IS_LIGHT')).to.eq('false');
+    });
 
     // Check that theme is dark
     cy.get('.pf-theme-dark').should('exist');
     cy.get('html').should('have.class', 'pf-theme-dark').and('have.css', 'color-scheme', 'dark');
 
-    cy.switchAppearanceTheme()
+    // Reload Page and check that theme is still dark
+    cy.openHomePage().should(() => {
+      expect(localStorage.getItem('KAOTO_UI_THEME_IS_LIGHT')).to.eq('false');
+    });
+    cy.get('.pf-theme-dark').should('exist');
+    cy.get('html').should('have.class', 'pf-theme-dark').and('have.css', 'color-scheme', 'dark');
+
+    cy.openAppearanceModal();
+    cy.switchAppearanceTheme().should(() => {
+      expect(localStorage.getItem('KAOTO_UI_THEME_IS_LIGHT')).to.eq('true');
+    });
 
     // Check that theme is not dark
     cy.get('.pf-theme-dark').should('not.exist');
-    cy.get('html')
-      .should('not.have.class', 'pf-theme-dark')
-      .and('not.have.css', 'color-scheme', 'dark');
+    cy.get('html').should('not.have.class', 'pf-theme-dark').and('not.have.css', 'color-scheme', 'dark');
+
+    // Reload Page and check that theme is still not dark
+    cy.openHomePage().should(() => {
+      expect(localStorage.getItem('KAOTO_UI_THEME_IS_LIGHT')).to.eq('true');
+    });;
+    cy.get('.pf-theme-dark').should('not.exist');
+    cy.get('html').should('not.have.class', 'pf-theme-dark').and('not.have.css', 'color-scheme', 'dark');
   });
 
-  it('enables light mode in code editor', () => {
-    cy.switchAppearanceTheme('editor')
+  it('Enables light mode in code editor', () => {
+    cy.switchAppearanceTheme('editor').should(() => {
+      expect(localStorage.getItem('KAOTO_EDITOR_THEME_IS_LIGHT')).to.eq('true');
+    });
     cy.closeAppearanceModal();
-    cy.openCodeEditor();
 
     // Check that theme is not dark
+    cy.openCodeEditor();
+    cy.get('.monaco-scrollable-element').should('not.have.class', 'vs-dark');
+
+    // Reload Page and check that theme is still not dark
+    cy.openHomePage().should(() => {
+      expect(localStorage.getItem('KAOTO_EDITOR_THEME_IS_LIGHT')).to.eq('true');
+    });
+    cy.openCodeEditor();
     cy.get('.monaco-scrollable-element').should('not.have.class', 'vs-dark');
 
     cy.openAppearanceModal();
@@ -45,6 +71,13 @@ describe('Settings: Appearance', () => {
     cy.closeAppearanceModal();
 
     // Check that theme is dark
+    cy.get('.monaco-scrollable-element').should('have.class', 'vs-dark');
+
+    // Reload Page and check that theme is still dark
+    cy.openHomePage().should(() => {
+      expect(localStorage.getItem('KAOTO_EDITOR_THEME_IS_LIGHT')).to.eq('false');
+    });
+    cy.openCodeEditor();
     cy.get('.monaco-scrollable-element').should('have.class', 'vs-dark');
   });
 });

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -77,6 +77,6 @@ Cypress.Commands.add('switchAppearanceTheme', (object) => {
     if (object === 'editor') {
         cy.get('[data-testid="appearance--theme-editor-switch"]').click({ force: true });
     } else {
-        cy.get('[data-testid="appearance--theme-switch"]').click({ force: true });
+        cy.get('[data-testid="appearance--theme-ui-switch"]').click({ force: true });
     }
 });


### PR DESCRIPTION
Hi, small update on appearance tests:

- Switch UI theme
- Switch Editor theme

in: [cypress/support/kaoto-ui-commands/default.js](https://github.com/KaotoIO/kaoto-ui/compare/main...unsortedhashsets:kaoto-ui:e2e_update_fix_1551?expand=1#diff-82affe5caf6cd31dfaefc888e1cd959d5ac0038ebdd468d959e6e0fc3ee19ee4) 
1) Fixed new `testid` from PR - https://github.com/KaotoIO/kaoto-ui/pull/1551

in: [cypress/e2e/01-settings/appearance.cy.js](https://github.com/KaotoIO/kaoto-ui/compare/main...unsortedhashsets:kaoto-ui:e2e_update_fix_1551?expand=1#diff-45cb1b48bad842fc2910ff18214254bcecdcc50d4185ff997480f6900c88493b)
1) Aded local storage check
2) Added reload check (problem was mentioned in issue - https://github.com/KaotoIO/kaoto-ui/issues/1175)


https://user-images.githubusercontent.com/46084942/234813197-f05a9bec-7c6a-4bd1-80d0-a1b54ffe1cac.mp4

