### PR TITLE
chore(e2e): Add about modal e2e tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,14 +1,15 @@
 import { defineConfig } from 'cypress';
+import dotenv from 'dotenv';
 
 export default defineConfig({
   projectId: 'zfop6s',
   videoUploadOnPasses: false,
 
   e2e: {
-    // We've imported your old cypress plugins here.
-    // You may want to clean this up later by importing these.
-    setupNodeEvents(on, config) {
-      return require('./cypress/plugins/index.js')(on, config);
+    setupNodeEvents(_on, config) {
+      dotenv.config();
+      config.env.KAOTO_API = process.env.KAOTO_API;
+      return config
     },
     baseUrl: 'http://localhost:1337',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',

--- a/cypress/e2e/01-settings/about.cy.js
+++ b/cypress/e2e/01-settings/about.cy.js
@@ -1,0 +1,54 @@
+describe('Settings: About', () => {
+    beforeEach(() => {
+        cy.intercept('/v1/integrations/dsls').as('getDSLs');
+        cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+        cy.intercept('/v1/integrations*').as('getIntegration');
+
+        cy.openHomePage();
+        cy.openAboutModal();
+    });
+
+    it('Close and reopen about modal', () => {
+        // Check that the modal is open
+        cy.get('[data-testid="about-modal"').should('be.visible');
+
+        cy.closeAboutModal();
+
+        // Check that the modal is closed
+        cy.get('[data-testid="about-modal"').should('not.exist');
+
+        cy.openAboutModal();
+
+        // Check that the modal is open
+        cy.get('[data-testid="about-modal"').should('be.visible');
+    });
+
+    it('Check that the about modal contains the correct information', () => {
+        // Check that the modal is open
+        cy.get('[data-testid="about-modal"').should('be.visible');
+
+        // Check that the Kaoto logo is visible and loaded
+        cy.get('[alt="Kaoto Logo"]')
+            .should('be.visible')
+            .and(($img) => {
+                expect($img[0].naturalWidth).to.be.greaterThan(0)
+            });
+
+        // Check the backend version
+
+        cy.request(`${Cypress.env('KAOTO_API')}/v1/capabilities/version`).then((response) => {
+            cy.get('[data-testid="about-backend-version"').should('have.text', response.body);
+        });
+
+        // Check the frontend version
+        cy.readFile('package.json').then(Package => {
+            cy.get('[data-testid="about-frontend-version"').should('have.text', Package.version);
+        })
+
+        // Check information Grid
+        cy.get('dl > dt:first').should('have.text', 'Frontend Version')
+            .next().should('have.attr', 'data-testid', 'about-frontend-version')
+            .next().should('have.text', 'Backend Version')
+            .next().should('have.attr', 'data-testid', 'about-backend-version');
+    });
+});

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -39,6 +39,11 @@ Cypress.Commands.add('openMenuDropDown', () => {
     cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
 });
 
+Cypress.Commands.add('openAboutModal', () => {
+    cy.openMenuDropDown();
+    cy.get('[data-testid="kaotoToolbar-kebab__about"]').click();
+});
+
 Cypress.Commands.add('openAppearanceModal', () => {
     cy.openMenuDropDown();
     cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
@@ -51,6 +56,10 @@ Cypress.Commands.add('openSettingsModal', () => {
 
 Cypress.Commands.add('closeAppearanceModal', () => {
     cy.get('#pf-modal-part-3 > .pf-c-button').click();
+});
+
+Cypress.Commands.add('closeAboutModal', () => {
+    cy.get('.pf-c-button.pf-m-plain').click();
 });
 
 Cypress.Commands.add('closeMenuModal', () => {

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -21,9 +21,9 @@ export const AboutModal = ({ handleCloseModal, isModalOpen }: IAboutModal) => {
       <TextContent>
         <TextList component="dl">
           <TextListItem component="dt">Frontend Version</TextListItem>
-          <TextListItem component="dd">{KAOTO_VERSION}</TextListItem>
+          <TextListItem component="dd" data-testid="about-frontend-version" >{KAOTO_VERSION}</TextListItem>
           <TextListItem component="dt">Backend Version</TextListItem>
-          <TextListItem component="dd">{backendVersion}</TextListItem>
+          <TextListItem component="dd" data-testid="about-backend-version" >{backendVersion}</TextListItem>
         </TextList>
       </TextContent>
     </PatternFlyAboutModal>


### PR DESCRIPTION
Hi,

A small addition to e2e: tests for about modal

- Close and reopen about modal
- Check that the about modal contains the correct information (logo is visible and with size more than zero, backend and frontend versions are Ok, versions grid is correct) 


https://user-images.githubusercontent.com/46084942/235599877-7566a74a-22fa-4365-9cb1-eaa9dc8aabeb.mp4

PR resolves #1700 

