### PR TITLE
chore: Add id and integrationId properties

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -187,26 +187,28 @@ export async function fetchDeploymentLogs(
  * @param namespace
  */
 export async function fetchIntegrationJson(
-  data: string | IStepProps[],
+  data: string,
   dsl: string,
   namespace?: string
-) {
-  try {
-    const resp = await RequestService.post({
-      endpoint: `${apiVersion}/integrations`,
-      contentType: typeof data === 'string' ? 'text/yaml' : 'application/json',
-      body: typeof data === 'string' ? data : { steps: data },
-      queryParams: {
-        dsl,
-        namespace: namespace ?? 'default',
-      },
-    });
+): Promise<IIntegration[]> {
+  const resp = await RequestService.post({
+    endpoint: `${apiVersion}/integrations`,
+    contentType: 'text/yaml',
+    body: data,
+    queryParams: {
+      dsl,
+      namespace: namespace ?? 'default',
+    },
+  });
 
-    return await resp.json();
-  } catch (err) {
-    console.error(err);
-    return err;
+  // TODO: Temporary workaround until multiple routes are supported in the backend
+  const response = (await resp.json()) as IIntegration | IIntegration[];
+
+  if (!Array.isArray(response)) {
+    return [response];
   }
+
+  return response;
 }
 
 /**

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -71,13 +71,13 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
   const handleChanges = (incomingData: string) => {
     // update integration JSON state with changes
     fetchIntegrationJson(incomingData, settings.dsl.name)
-      .then((res: IIntegration) => {
-        let tmpInt = res;
-        if (typeof res.metadata?.name === 'string' && res.metadata.name !== '') {
-          settings.name = res.metadata.name;
-          setSettings({ name: res.metadata.name });
+      .then((res) => {
+        let tmpInt = res[0];
+        if (typeof tmpInt.metadata?.name === 'string' && tmpInt.metadata.name !== '') {
+          settings.name = tmpInt.metadata.name;
+          setSettings({ name: tmpInt.metadata.name });
         }
-        tmpInt.metadata = { ...res.metadata, ...settings };
+        tmpInt.metadata = { ...tmpInt.metadata, ...settings };
         updateIntegration(tmpInt);
       })
       .catch((e) => {

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -31,6 +31,7 @@ const Visualization = () => {
     name: '',
     type: '',
     UUID: '',
+    integrationId: '',
   });
   const visualizationStore = useVisualizationStore.getState();
   const layout = useVisualizationStore((state) => state.layout);
@@ -61,7 +62,7 @@ const Visualization = () => {
     if (step) {
       setSelectedStep(step);
     } else {
-      setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '' });
+      setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '', integrationId: '' });
       visualizationStore.setSelectedStepUuid('');
       setIsPanelExpanded(false);
     }
@@ -83,7 +84,7 @@ const Visualization = () => {
   const handleDeleteStep = (UUID?: string) => {
     if (!UUID) return;
 
-    setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '' });
+    setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '', integrationId: '' });
     visualizationStore.setSelectedStepUuid('');
     if (isPanelExpanded) setIsPanelExpanded(false);
 

--- a/src/components/VisualizationStep.stories.tsx
+++ b/src/components/VisualizationStep.stories.tsx
@@ -20,6 +20,7 @@ export default {
       isPlaceholder: false,
       step: {
         id: 'servlet',
+        integrationId: 'Camel Route-1',
         name: 'servlet',
         type: 'START',
         description:

--- a/src/components/VisualizationStepViews.stories.tsx
+++ b/src/components/VisualizationStepViews.stories.tsx
@@ -8,6 +8,7 @@ export default {
     isPanelExpanded: true,
     step: {
       id: 'servlet',
+      integrationId: 'Camel Route-1',
       name: 'servlet',
       type: 'START',
       description:

--- a/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
+++ b/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
@@ -138,17 +138,17 @@ function KogitoEditorIntegrationProviderInternal(
         if (previousContent.current === content) return;
 
         fetchIntegrationJson(content, settings.namespace)
-          .then((res: IIntegration) => {
+          .then((res) => {
             if (canceled.get()) return;
 
-            let tmpInt = res;
+            let tmpInt = res[0];
 
-            if (typeof res.metadata?.name === 'string' && res.metadata.name !== '') {
-              settings.name = res.metadata.name;
-              setSettings({ name: res.metadata.name });
+            if (typeof tmpInt.metadata?.name === 'string' && tmpInt.metadata.name !== '') {
+              settings.name = tmpInt.metadata.name;
+              setSettings({ name: tmpInt.metadata.name });
             }
 
-            tmpInt.metadata = { ...res.metadata, ...settings };
+            tmpInt.metadata = { ...tmpInt.metadata, ...settings };
             updateIntegration(tmpInt);
 
             if (!initialIntegrationJson.current) {

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -133,6 +133,7 @@ describe('stepsService', () => {
 
     it('getIntegrationSource(): should call apiService to return the source code (YAML) for the current running deployment', async () => {
       const integration = {
+        id: '',
         metadata: { name: 'Updated integration' },
         dsl: 'KameletBinding',
         params: [],
@@ -529,6 +530,7 @@ describe('stepsService', () => {
               steps: [
                 {
                   UUID: 'choice-1|branch-0|log-0',
+                  integrationId: 'Camel Route-1',
                   minBranches: 0,
                   maxBranches: 0,
                   name: 'log',
@@ -542,6 +544,7 @@ describe('stepsService', () => {
               steps: [
                 {
                   UUID: 'choice-1|branch-1|log-0',
+                  integrationId: 'Camel Route-1',
                   minBranches: 0,
                   maxBranches: 0,
                   name: 'log',
@@ -571,6 +574,7 @@ describe('stepsService', () => {
               steps: [
                 {
                   UUID: 'choice-1|branch-0|timer-0',
+                  integrationId: 'Camel Route-1',
                   minBranches: 0,
                   maxBranches: 0,
                   name: 'timer',
@@ -579,6 +583,7 @@ describe('stepsService', () => {
                 },
                 {
                   UUID: 'choice-1|branch-0|choice-1',
+                  integrationId: 'Camel Route-1',
                   minBranches: 1,
                   maxBranches: -1,
                   name: 'choice',
@@ -589,6 +594,7 @@ describe('stepsService', () => {
                       steps: [
                         {
                           UUID: 'choice-1|branch-0|choice-1|branch-0|log-0',
+                          integrationId: 'Camel Route-1',
                           minBranches: 0,
                           maxBranches: 0,
                           name: 'log',
@@ -602,6 +608,7 @@ describe('stepsService', () => {
                       steps: [
                         {
                           UUID: 'choice-1|branch-0|choice-1|branch-1|log-0',
+                          integrationId: 'Camel Route-1',
                           minBranches: 0,
                           maxBranches: 0,
                           name: 'log',
@@ -620,6 +627,7 @@ describe('stepsService', () => {
               steps: [
                 {
                   UUID: 'choice-1|branch-1|log-0',
+                  integrationId: 'Camel Route-1',
                   minBranches: 0,
                   maxBranches: 0,
                   name: 'log',
@@ -646,6 +654,7 @@ describe('stepsService', () => {
               steps: [
                 {
                   UUID: 'choice-0|branch-0|log-0',
+                  integrationId: 'Camel Route-1',
                   minBranches: 0,
                   maxBranches: 0,
                   name: 'log',
@@ -659,6 +668,7 @@ describe('stepsService', () => {
               steps: [
                 {
                   UUID: 'choice-0|branch-1|log-0',
+                  integrationId: 'Camel Route-1',
                   minBranches: 0,
                   maxBranches: 0,
                   name: 'log',

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -16,7 +16,7 @@ import { MarkerType, Position } from 'reactflow';
 
 describe('visualizationService', () => {
   const groupWidth = 80;
-  const baseStep = { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '' };
+  const baseStep = { UUID: '', name: '', maxBranches: 0, minBranches: 0, type: '', integrationId: 'Camel Route-1' };
 
   it('buildBranchNodeParams(): should build params for a branch node', () => {
     const currentStep = steps[3];
@@ -208,18 +208,18 @@ describe('visualizationService', () => {
   });
 
   it('buildEdges(): should build an edge for every node except the first, given an array of nodes', () => {
-    const nodes = [
+    const nodes: IVizStepNode[] = [
       {
         data: {
           label: 'aws-kinesis-source',
-          step: { ...baseStep, UUID: 'example-1234' },
+          step: { ...baseStep, UUID: 'example-1234', integrationId: 'Camel Route-1' },
           nextStepUuid: 'example-1235',
         },
         id: 'dndnode_1',
         position: { x: 720, y: 250 },
       },
       {
-        data: { label: 'avro-deserialize-sink', step: { ...baseStep, UUID: 'example-1235' } },
+        data: { label: 'avro-deserialize-sink', step: { ...baseStep, UUID: 'example-1235', integrationId: 'Camel Route-1' } },
         id: 'dndnode_2',
         position: { x: 880, y: 250 },
       },

--- a/src/store/data/branchSteps.ts
+++ b/src/store/data/branchSteps.ts
@@ -14,6 +14,7 @@ export default [
     parameters: [],
     title: 'Kamelet Source',
     UUID: 'kamelet:source-233189',
+    integrationId: 'Camel Route-1',
   },
   {
     id: 'choice',
@@ -65,6 +66,7 @@ export default [
             required: ['name'],
             title: 'Set Header',
             UUID: 'set-header-337596',
+            integrationId: 'Camel Route-1',
           },
         ],
       },
@@ -113,6 +115,7 @@ export default [
             required: ['name'],
             title: 'Set Property',
             UUID: 'set-property-00823',
+            integrationId: 'Camel Route-1',
           },
           {
             id: 'remove-property',
@@ -136,6 +139,7 @@ export default [
             required: ['name'],
             title: 'Remove Property',
             UUID: 'remove-property-2403409',
+            integrationId: 'Camel Route-1',
           },
         ],
       },
@@ -166,6 +170,7 @@ export default [
             ],
             title: 'Transform',
             UUID: 'transform-208704',
+            integrationId: 'Camel Route-1',
           },
         ],
       },
@@ -195,6 +200,7 @@ export default [
             ],
             title: 'Set Body',
             UUID: 'set-body-28904309',
+            integrationId: 'Camel Route-1',
           },
           {
             id: 'remove-header',
@@ -218,6 +224,7 @@ export default [
             required: ['name'],
             title: 'Remove Header',
             UUID: 'remove-header-281047',
+            integrationId: 'Camel Route-1',
           },
         ],
       },
@@ -242,6 +249,7 @@ export default [
     ],
     title: 'Content Based Router.',
     UUID: 'choice-344294',
+    integrationId: 'Camel Route-1',
   },
   {
     id: 'filter',
@@ -275,6 +283,7 @@ export default [
             ],
             title: 'Set Body',
             UUID: 'set-body-12334',
+            integrationId: 'Camel Route-1',
           },
         ],
       },
@@ -299,6 +308,7 @@ export default [
     ],
     title: 'Filter',
     UUID: 'filter-3923735',
+    integrationId: 'Camel Route-1',
   },
   {
     id: 'kamelet:sink',
@@ -313,5 +323,6 @@ export default [
     parameters: [],
     title: 'Kamelet Sink',
     UUID: 'kamelet:sink-559424',
+    integrationId: 'Camel Route-1',
   },
 ] as IStepProps[];

--- a/src/store/data/steps.ts
+++ b/src/store/data/steps.ts
@@ -6,6 +6,7 @@ export default [
     name: 'twitter-search-source',
     type: 'START',
     UUID: 'twitter-search-source-0',
+    integrationId: 'Camel Route-1',
     description:
       'Allows to get all tweets on particular keywords from Twitter.\n\nIt requires tokens that can be obtained by creating an application \nin the Twitter developer portal: https://developer.twitter.com/.',
     group: 'Twitter',
@@ -72,6 +73,7 @@ export default [
     name: 'pdf-action',
     type: 'MIDDLE',
     UUID: 'pdf-action-1',
+    integrationId: 'Camel Route-1',
     description: 'Create a PDF',
     group: 'PDF',
     icon: 'data:image/svg+xml',
@@ -116,6 +118,7 @@ export default [
     name: 'caffeine-action',
     type: 'MIDDLE',
     UUID: 'caffeine-action-2',
+    integrationId: 'Camel Route-1',
     description:
       "Perform operations on a caffeine cache\n\nThe Kamelet expects the following headers to be set:\n\n- `caffeine-key` / `ce-caffeinekey`: as the cache key used in the operation\n\n- `caffeine-operation` / `ce-caffeineoperation`: as the operation to perform. It can be PUT, GET, INVALIDATE and CLEANUP.\n\nIf the caffeine-key header won't be set the exchange ID will be used as key.\n\nIf the caffeine-operation header won't be set, the GET operation will be performed.",
     group: 'Caffeine',
@@ -141,6 +144,7 @@ export default [
     name: 'kafka-sink',
     type: 'END',
     UUID: 'kafka-sink-3',
+    integrationId: 'Camel Route-1',
     description:
       'Send data to Kafka topics.\n\nThe Kamelet is able to understand the following headers to be set:\n\n- `key` / `ce-key`: as message key\n\n- `partition-key` / `ce-partitionkey`: as message partition key\n\nBoth the headers are optional.',
     group: 'Kafka',

--- a/src/store/integrationJsonStore.tsx
+++ b/src/store/integrationJsonStore.tsx
@@ -30,8 +30,9 @@ export interface IIntegrationJsonStore {
   views: IViewProps[];
 }
 
-export const integrationJsonInitialState = {
+export const integrationJsonInitialState: Pick<IIntegrationJsonStore, 'integrationJson' | 'views'>   = {
   integrationJson: {
+    id: `${initDsl.name}-1`,
     dsl: initDsl.name,
     metadata: { name: initialSettings.name, namespace: initialSettings.namespace },
     steps: [],

--- a/src/stubs/debezium-mongodb.step.ts
+++ b/src/stubs/debezium-mongodb.step.ts
@@ -1028,4 +1028,5 @@ export const debeziumMongoDBStep: IStepProps = {
   minBranches: 0,
   maxBranches: 0,
   UUID: 'random-and-unique-id',
+  integrationId: 'Camel Route-1',
 };

--- a/src/stubs/integration-steps.ts
+++ b/src/stubs/integration-steps.ts
@@ -238,6 +238,7 @@ export const integrationSteps: IStepProps[] = [
     minBranches: 0,
     maxBranches: 0,
     UUID: 'timer-0',
+    integrationId: 'Camel Route-1',
   },
   {
     name: 'choice',
@@ -447,6 +448,7 @@ export const integrationSteps: IStepProps[] = [
             minBranches: 0,
             maxBranches: 0,
             UUID: 'log-0-3610810635',
+            integrationId: 'Camel Route-1',
           },
         ],
         parameters: [],
@@ -585,6 +587,7 @@ export const integrationSteps: IStepProps[] = [
             minBranches: 0,
             maxBranches: 0,
             UUID: 'log-0-793453600',
+            integrationId: 'Camel Route-1',
           },
         ],
         parameters: [],
@@ -595,5 +598,6 @@ export const integrationSteps: IStepProps[] = [
     minBranches: 1,
     maxBranches: -1,
     UUID: 'choice-1',
+    integrationId: 'Camel Route-1',
   },
 ];

--- a/src/stubs/steps.ts
+++ b/src/stubs/steps.ts
@@ -15,7 +15,8 @@ export const kameletSourceStepStub: IStepProps = {
   branches: [],
   minBranches: 0,
   maxBranches: 1,
-  UUID: 'timer-source-0'
+  UUID: 'timer-source-0',
+  integrationId: 'Camel Route-1',
 }
 
 export const stepsStub = {
@@ -69,7 +70,8 @@ export const integrationJSONStub = {
       branches: null,
       minBranches: 0,
       maxBranches: 0,
-      UUID: 'timer-source-0'
+      UUID: 'timer-source-0',
+      integrationId: 'Camel Route-1',
     }
   ],
   params: []
@@ -87,7 +89,8 @@ export const stepsCatalog: IStepProps[] = [
     group: 'Camel-Component',
     minBranches: 0,
     maxBranches: 0,
-    UUID: 'random-id-1'
+    UUID: 'random-id-1',
+    integrationId: 'Camel Route-1',
   },
   {
     name: 'activemq',
@@ -100,7 +103,8 @@ export const stepsCatalog: IStepProps[] = [
     group: 'Camel-Component',
     minBranches: 0,
     maxBranches: 0,
-    UUID: 'random-id-2'
+    UUID: 'random-id-2',
+    integrationId: 'Camel Route-1',
   },
   {
     name: 'activemq',
@@ -113,6 +117,7 @@ export const stepsCatalog: IStepProps[] = [
     group: 'Camel-Component',
     minBranches: 0,
     maxBranches: 0,
-    UUID: 'random-id-3'
+    UUID: 'random-id-3',
+    integrationId: 'Camel Route-1',
   },
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export interface IDeployment {
 }
 
 export interface IIntegration {
+  id: string;
   dsl: string;
   metadata: IIntegrationMetadata;
   params: IIntegrationParams[];
@@ -142,6 +143,9 @@ export interface IStepProps {
 
   // generated only for integration steps
   UUID: string;
+
+  // IntegrationID to which this step belongs to
+  integrationId: string;
 }
 
 export interface IStepPropsBranch {


### PR DESCRIPTION
### Context
Within the scope of supporting multiple routes, a way to identify them is required and for that matter, this commit adds:

* `id` property to the `IIntegration` interface
* `integrationId` property to the `IStepProps` interface
* Update `fetchIntegrationJson` function to return `IIntegration[]`

It also updates all related stubs, mocks, and test to support the newly added properties.

relates: [801](https://github.com/KaotoIO/kaoto-ui/issues/801)