### PR TITLE
fix(stepsService): Avoid passing a whole step into the getStepNested method

### DIFF
--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -360,7 +360,7 @@ export class StepsService {
   async handleInsertStep(targetNode: IVizStepNode | undefined, step: IStepProps) {
     return fetchStepDetails(step.id).then((newStep) => {
       if (targetNode?.data.branchInfo) {
-        const currentStepNested = this.getStepNested(targetNode.data.step);
+        const currentStepNested = this.getStepNested(targetNode.data.step.UUID);
 
         if (currentStepNested) {
           const stepsCopy = useIntegrationJsonStore.getState().integrationJson.steps.slice();


### PR DESCRIPTION
### Context
Currently, we're passing a whole step into the getStepNested method instead of a string.

This is caused because of how the IVizStepNode interface it's defined, turning
the whole Step typing into any.

Relates to: https://github.com/KaotoIO/kaoto-ui/issues/1725
Relates to: https://github.com/KaotoIO/kaoto-ui/issues/1232