### PR TITLE
Fix detail panel closing behavior when deleting steps

### DIFF
--- a/cypress/e2e/09-step_actions_from_canvas/step_actions_from_canvas.cy.js
+++ b/cypress/e2e/09-step_actions_from_canvas/step_actions_from_canvas.cy.js
@@ -163,4 +163,19 @@ describe('Test for Step actions from the canvas', () => {
         // CHECK that the YAML is updated groupDelay: 15000
         cy.checkCodeSpanLine('groupDelay: 15000');
     });
+
+    it('Step detail - User selects a step, which opens the detail drawer', () => {
+        cy.insertStepMiniCatalog('choice');
+
+        cy.openStepConfigurationTab('log');
+
+        cy.get('[data-testid="kaoto-right-drawer"]').should('be.visible');
+        cy.deleteStep('log');
+        cy.get('[data-testid="kaoto-right-drawer"]').should('not.be.visible');
+
+        cy.openStepConfigurationTab('timer');
+        cy.get('[data-testid="kaoto-right-drawer"]').should('be.visible');
+        cy.deleteStep('choice');
+        cy.get('[data-testid="kaoto-right-drawer"]').should('be.visible');
+    })
 });

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -84,9 +84,11 @@ const Visualization = () => {
   const handleDeleteStep = (UUID?: string) => {
     if (!UUID) return;
 
-    setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '', integrationId: '' });
-    visualizationStore.setSelectedStepUuid('');
-    if (isPanelExpanded) setIsPanelExpanded(false);
+    if (selectedStep.UUID === UUID) {
+      setIsPanelExpanded(false);
+      setSelectedStep({ maxBranches: 0, minBranches: 0, name: '', type: '', UUID: '', integrationId: '' });
+      visualizationStore.setSelectedStepUuid('');
+    }
 
     stepsService.deleteStep(UUID);
   };


### PR DESCRIPTION
Before deleting any step would deselect the currently  selected step and try to close the panel. Now the panel is only closed if the currently selected step is deleted.
Closes: #1360 