### PR TITLE
feat(multiple-flows): Enable experimental support for multiple flows

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -18,12 +18,13 @@ import {
   Modal,
   ModalVariant,
   Popover,
+  Switch,
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface ISettingsModal {
   handleCloseModal: () => void;
@@ -176,6 +177,10 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
     handleCloseModal();
   };
 
+  const onToggleUseMultipleFlowsSupport = useCallback((useMultipleFlows: boolean) => {
+    setLocalSettings({ ...localSettings, useMultipleFlows });
+  }, [localSettings]);
+
   return (
     <Modal
       actions={[
@@ -325,6 +330,18 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
               );
             })}
           </FormSelect>
+        </FormGroup>
+
+        {/* TODO: Temporary toggle to enable experimental support for Multiple Flows */}
+        <FormGroup
+          fieldId="useMultipleFlows"
+          label="Enable experimental support for multiple flows"
+        >
+          <Switch
+            aria-label="enable multiple flows support"
+            isChecked={localSettings.useMultipleFlows}
+            onChange={onToggleUseMultipleFlowsSupport}
+          />
         </FormGroup>
       </Form>
     </Modal>

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -9,7 +9,7 @@ import {
   VisualizationStepViews,
 } from '@kaoto/components';
 import { StepsService, VisualizationService } from '@kaoto/services';
-import { useIntegrationJsonStore, useVisualizationStore } from '@kaoto/store';
+import { useIntegrationJsonStore, useSettingsStore, useVisualizationStore } from '@kaoto/store';
 import { IStepProps, IVizStepNode } from '@kaoto/types';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, { Background, Viewport } from 'reactflow';
@@ -33,6 +33,8 @@ const Visualization = () => {
     UUID: '',
     integrationId: '',
   });
+
+  const useMultipleFlows = useSettingsStore((state) => state.settings.useMultipleFlows);
   const visualizationStore = useVisualizationStore.getState();
   const layout = useVisualizationStore((state) => state.layout);
   const nodes = useVisualizationStore((state) => state.nodes);
@@ -70,7 +72,7 @@ const Visualization = () => {
 
   useEffect(() => {
     visualizationService.redrawDiagram(handleDeleteStep, true).catch((e) => console.error(e));
-  }, [integrationJson, layout]);
+  }, [integrationJson, layout, useMultipleFlows]);
 
   const nodeTypes = useMemo(() => ({ step: VisualizationStep }), []);
   const edgeTypes = useMemo(

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -228,7 +228,7 @@ describe('visualizationService', () => {
     expect(VisualizationService.buildEdges(nodes)).toHaveLength(1);
 
     // let's test that it works for branching too
-    const stepNodes = VisualizationService.buildNodesFromSteps(branchSteps, 'RIGHT');
+    const stepNodes = VisualizationService.buildNodesFromSteps('Camel Route-1', branchSteps, 'RIGHT');
 
     expect(VisualizationService.buildEdges(stepNodes)).toHaveLength(branchSteps.length - 1);
   });
@@ -260,13 +260,13 @@ describe('visualizationService', () => {
   });
 
   it('buildNodesFromSteps(): should build visualization nodes from an array of steps', () => {
-    const stepNodes = VisualizationService.buildNodesFromSteps(steps, 'RIGHT');
+    const stepNodes = VisualizationService.buildNodesFromSteps('Camel Route-1', steps, 'RIGHT');
     expect(stepNodes[0].data.step.UUID).toBeDefined();
     expect(stepNodes[0].id).toContain(stepNodes[0].data.step.UUID);
   });
 
   it.skip('buildNodesFromSteps(): should build visualization nodes from an array of steps with branches', () => {
-    const stepNodes = VisualizationService.buildNodesFromSteps(branchSteps, 'RIGHT');
+    const stepNodes = VisualizationService.buildNodesFromSteps('Camel Route-1', branchSteps, 'RIGHT');
     expect(stepNodes[0].data.step.UUID).toBeDefined();
     expect(stepNodes).toHaveLength(branchSteps.length);
   });
@@ -480,7 +480,7 @@ describe('visualizationService', () => {
 
   it('insertAddStepPlaceholder(): should add an ADD STEP placeholder to the beginning of the array', () => {
     const nodes: IVizStepNode[] = [];
-    VisualizationService.insertAddStepPlaceholder(nodes, '', 'START', { nextStepUuid: '' });
+    VisualizationService.insertAddStepPlaceholder('Camel Route-1', nodes, '', 'START', { nextStepUuid: '' });
     expect(nodes).toHaveLength(1);
   });
 

--- a/src/store/flowsStore.tsx
+++ b/src/store/flowsStore.tsx
@@ -14,7 +14,7 @@ export interface IFlowsStore {
   views: IViewProps[];
 
   // Handler methods
-  appendStep: (integrationId: string, newStep: IStepProps) => void;
+  insertStep: (integrationId: string, newStep: IStepProps) => void;
   deleteStep: (integrationId: string, stepUUID: string) => void;
 }
 
@@ -51,7 +51,7 @@ export const useFlowsStore = create<IFlowsStore>()(
        */
       ...{ flows: initialFlows },
 
-      appendStep: (integrationId, newStep) => {
+      insertStep: (integrationId, newStep) => {
         set((state: IFlowsStore): IFlowsStore => {
           const integrationIndex = state.flows.findIndex((integration) => integration.id === integrationId);
           if (integrationIndex === -1) {

--- a/src/store/flowsStore.tsx
+++ b/src/store/flowsStore.tsx
@@ -40,7 +40,7 @@ export const flowsInitialState: Pick<IFlowsStore, 'flows' | 'properties' | 'view
  * to clean the duplication and hopefully get a smaller
  * API for the consumers
  */
-export const flowsStore = create<IFlowsStore>()(
+export const useFlowsStore = create<IFlowsStore>()(
   temporal(
     (set) => ({
       ...flowsInitialState,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,6 @@
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 import { useDeploymentStore } from './deploymentStore';
-import { flowsStore } from './flowsStore';
+import { useFlowsStore } from './flowsStore';
 import { useIntegrationJsonStore } from './integrationJsonStore';
 import { useIntegrationSourceStore } from './integrationSourceStore';
 import { useNestedStepsStore } from './nestedStepsStore';
@@ -10,7 +10,7 @@ import { useVisualizationStore } from './visualizationStore';
 
 if (process.env.NODE_ENV === 'development') {
   mountStoreDevtool('deploymentStore', useDeploymentStore);
-  mountStoreDevtool('flowsStore', flowsStore);
+  mountStoreDevtool('flowsStore', useFlowsStore);
   mountStoreDevtool('integrationJsonStore', useIntegrationJsonStore);
   mountStoreDevtool('integrationSourceStore', useIntegrationSourceStore);
   mountStoreDevtool('nestedStepsStore', useNestedStepsStore);

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -31,6 +31,7 @@ export const initialSettings: ISettings = {
   editorIsLightMode: localStorage.getItem(LOCAL_STORAGE_EDITOR_THEME_KEY) === 'true',
   uiLightMode: isUILightMode === 'true',
   editorMode: CodeEditorMode.FREE_EDIT,
+  useMultipleFlows: false,
 };
 
 export const useSettingsStore = create<ISettingsStore>((set) => ({
@@ -44,7 +45,7 @@ export const useSettingsStore = create<ISettingsStore>((set) => ({
     set(() => ({
       backendVersion: backendVersion,
     }));
-  }
+  },
 }));
 
 export default useSettingsStore;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,9 @@ export interface ISettings {
   name: string;
   // Cluster namespace
   namespace: string;
+
+  /** TODO: Temporary config to enable the support for multiple flows */
+  useMultipleFlows: boolean,
 }
 
 export interface ICapabilities {


### PR DESCRIPTION
### Context
In order to support multiple flows in the UI, we need to switch our data model from a single flow to an array of flows.

In practical terms, there are at least two alternatives:
1. Refactor existing `IIntegrationJSONStore` to support multiple flows
2. Move from `IIntegrationJSONStore` to another store that supports multiple flows and ports the existing functionality.

### Changes
In this pull request, the latter was chosen, and for that purpose, the `useFlowsStore` was created. It also includes an additional setting to switch between single and multiple flows during runtime, to avoid any potential big-bang effect while developing this feature.

### Notes
Not all the functionality existing in **Single Flow Mode** is ported to the **Multiple Flows Mode**. Subsequent pull requests will add more functionality gradually.

### Limitations
* The backend support for multiple flows is not wired-up yet (A separate pull request will follow)
* The Add / Remove flow functionality is still pending.
* Removing individual nodes from a flow that it's part of a multiple flows scheme is still pending.

### Screenshots
#### New setting: Enable experimental support for multiple flows
![image](https://user-images.githubusercontent.com/16512618/236671452-d950cfdc-bef4-4974-926e-19cdd2d8a93b.png)

#### Demo: Multiple flows
![image](https://user-images.githubusercontent.com/16512618/236671481-5e227fd1-bbab-42c2-8aad-5e1637520ef1.png)

Related discussion: https://github.com/KaotoIO/kaoto-ui/discussions/1750
Relates to: https://github.com/KaotoIO/kaoto-ui/issues/801
Related backend pull request: https://github.com/KaotoIO/kaoto-backend/pull/638