### PR TITLE
feat(viz): Export current flow to PNG

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@rhoas/app-services-ui-shared": "^0.16.6",
     "ajv": "^8.12.0",
     "dagre": "^0.8.5",
+    "html-to-image": "^1.11.11",
     "immer": "^10.0.1",
     "lodash.isequal": "^4.5.0",
     "monaco-editor": "^0.38.0",

--- a/src/components/ExportCanvasToPng.tsx
+++ b/src/components/ExportCanvasToPng.tsx
@@ -1,0 +1,42 @@
+import { DropdownItem } from '@patternfly/react-core';
+import { toPng } from 'html-to-image';
+import { useCallback } from 'react';
+
+/** Taken from https://reactflow.dev/docs/examples/misc/download-image/ */
+const downloadImage = (dataUrl: string, fileName: string) => {
+  const a = document.createElement('a');
+
+  a.setAttribute('download', `${fileName}.png`);
+  a.setAttribute('href', dataUrl);
+  a.click();
+}
+
+interface IExportCanvasToPng {
+  fileName: string;
+  onClick: () => void;
+}
+
+export const ExportCanvasToPng = ({ fileName, onClick }: IExportCanvasToPng) => {
+  const scheduleExport = useCallback(() => {
+    onClick();
+
+    const reactFlowNode = document.querySelector<HTMLElement>('.react-flow');
+    if (reactFlowNode === null) return;
+
+    toPng(reactFlowNode, {
+      filter: (node) => {
+        /** Filter ReactFlow minimap and controls */
+        return !node?.classList?.contains('react-flow__minimap')
+          && !node?.classList?.contains('react-flow__controls');
+      },
+    }).then((dataUrl) => {
+      downloadImage(dataUrl, fileName);
+    });
+  }, [onClick, fileName]);
+
+  return (
+    <DropdownItem data-testid="kaotoToolbar-kebab__export" component="button" onClick={scheduleExport}>
+      Export canvas to PNG
+    </DropdownItem>
+  );
+  }

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,4 +1,3 @@
-import logo from '../assets/images/logo-kaoto-dark.png';
 import { fetchDefaultNamespace, startDeployment } from '@kaoto/api';
 import {
   AppearanceModal,
@@ -47,7 +46,9 @@ import {
 } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useCallback, useEffect, useState } from 'react';
+import logo from '../assets/images/logo-kaoto-dark.png';
 import { AboutModal } from './AboutModal';
+import { ExportCanvasToPng } from './ExportCanvasToPng';
 
 export interface IKaotoToolbar {
   toggleCatalog: () => void;
@@ -183,6 +184,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
 
   const kebabItems = [
     <DropdownItem
+      autoFocus
       key="about"
       data-testid="kaotoToolbar-kebab__about"
       onClick={() => {
@@ -209,13 +211,15 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
       Appearance
     </DropdownItem>,
     <DropdownSeparator key="separator-01" />,
+    <ExportCanvasToPng key="export" fileName={settings.name} onClick={() => { setKebabIsOpen(false); }}/>,
+    <DropdownSeparator key="separator-02" />,
     <DropdownItem key="tutorial" href="https://kaoto.io/workshop/" target="_blank" className="pf-u-display-flex pf-u-justify-content-space-between">
-      <span className="pf-u-mr-lg ">Tutorial</span>
+      <span className="pf-u-mr-lg">Tutorial</span>
       <Icon isInline>
         <ExternalLinkAltIcon />
       </Icon>
     </DropdownItem>,
-    <DropdownItem key="help" href="https://kaoto.io/docs/" target="_blank"  className="pf-u-display-flex pf-u-justify-content-space-between">
+    <DropdownItem key="help" href="https://kaoto.io/docs/" target="_blank" className="pf-u-display-flex pf-u-justify-content-space-between">
       <span className="pf-u-mr-lg">Help</span>
       <Icon isInline>
         <ExternalLinkAltIcon />
@@ -227,7 +231,7 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
         <GithubIcon />
       </Icon>
     </DropdownItem>,
-    <DropdownSeparator key="separator-02" />,
+    <DropdownSeparator key="separator-03" />,
     <DropdownItem key="delete" component="button" onClick={() => setIsConfirmationModalOpen(true)}>
       Delete
     </DropdownItem>,

--- a/src/components/Visualization.css
+++ b/src/components/Visualization.css
@@ -1,5 +1,8 @@
-.pf-c-drawer__content.panelCustom {
+.pf-c-drawer__content.panelCustom, .react-flow.panelCustom {
     background-color: var(--pf-global--BackgroundColor--200);
+}
+
+.pf-c-drawer__content.panelCustom {
     overflow: hidden;
 }
 

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -189,6 +189,7 @@ const Visualization = () => {
             snapGrid={[15, 15]}
             deleteKeyCode={null}
             zoomOnDoubleClick={false}
+            className="panelCustom"
           >
             {/*<MiniMap nodeBorderRadius={2} className={'visualization__minimap'} />*/}
             <VisualizationControls />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9337,6 +9337,11 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
   integrity sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==
 
+html-to-image@^1.11.11:
+  version "1.11.11"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.11.11.tgz#c0f8a34dc9e4b97b93ff7ea286eb8562642ebbea"
+  integrity sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==
+
 html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"


### PR DESCRIPTION
### Context
This commit adds the functionality to export the current canvas to a PNG file named after the integration name.

This iteration of exporting flows handles exporting the existing canvas to a PNG file. This functionality is placed under the kebab menu from the toolbar

### How to use
1. Open the kebab menu
![image](https://user-images.githubusercontent.com/16512618/236887421-4967a36e-6da2-4598-85a4-568d920aab07.png)

2. Click on the `Export canvas to PNG` option
![image](https://user-images.githubusercontent.com/16512618/236889679-e27b1bee-d31e-4070-b01c-0e7f1684bed9.png)
 
3. The PNG image is exported
![image](https://user-images.githubusercontent.com/16512618/236887623-65efc614-93a2-406a-9fd5-2a9baf3b92d5.png)

### Notes
* The export functionality supports `light` and `dark` modes
* The exported image will contain what's currently visible on the canvas
* In case not all elements are visible on the screen, they won't appear on the canvas, another possibility is to try to center the canvas before exporting.

### Open questions
1. Would it be better to have a dedicated button on the canvas itself? for instance like
![image](https://user-images.githubusercontent.com/16512618/236888579-3a474b14-037b-42c5-b702-99dce8c67dce.png)
2. In case we want to keep the existing mechanism, would the following order be better?
![image](https://user-images.githubusercontent.com/16512618/236889263-95628adf-b0ee-4f36-8ccb-52dee6c25b3b.png)

Implements the first iteration of #1708 