### PR TITLE
feature: Passing fetchStepDetails to step extensions

### DIFF
--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -129,6 +129,7 @@ export class StepsService {
     const currentIdx = this.findStepIdxWithUUID(step.UUID);
 
     return {
+      fetchStepDetails,
       getDeployment: async (
         deploymentName: string,
         namespace?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,7 @@ export interface IKaotoApi {
   stopDeployment: (deploymentName: string, namespace?: string) => void;
   updateStep: (step: IStepProps) => void;
   updateStepParams: (newValues: { [s: string]: unknown } | ArrayLike<unknown>) => void;
+  fetchStepDetails: (stepId: string) => Promise<IStepProps>;
 }
 
 export interface INestedStep {


### PR DESCRIPTION
Needed for https://github.com/KaotoIO/step-extension-repository/pull/866

I want to be able to generate steps "on the fly" to generate the skeleton of the REST API and for that I need all the step information.