### PR TITLE
fix(stepsService): Use id instead of title for steps parameters

### DIFF
--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -171,8 +171,8 @@ describe('stepsService', () => {
 
     it('stepParams: should return the current step parameters', () => {
       expect(
-        stepsService.createKaotoApi(step, jest.fn(), jest.fn()).stepParams.Description
-      ).toEqual('A fruit');
+        stepsService.createKaotoApi(step, jest.fn(), jest.fn()).stepParams,
+      ).toMatchObject({ description: 'A fruit' });
     });
 
     it('stopDeployment(): should call apiService to stop the current running deployment', async () => {

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -120,7 +120,7 @@ export class StepsService {
   ): IKaotoApi {
     let stepParams = {};
     step.parameters?.forEach((parameter) => {
-      const paramKey = parameter.title;
+      const paramKey = parameter.id;
       // @ts-ignore
       stepParams[paramKey] = parameter.value ?? parameter.defaultValue;
     });


### PR DESCRIPTION
### Context
In the past, the `id` and `title` properties from a step were the same. With the introduction of https://github.com/KaotoIO/kaoto-backend/pull/650, now those properties are not the same.

On the UI side, the 'title' property was used to build the parameters of the step, so in combination with the previous fix, this caused step extensions relying upon the previous information are no longer working.

The fix is to use the `id` property form now on

relates to: https://github.com/KaotoIO/kaoto-ui/issues/1534