### PR TITLE
fix(stepsService): increment by 1 instead of 0.01

### DIFF
--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -649,6 +649,7 @@ export class StepsService {
       [label: string]: {
         type: string;
         defaultValue?: any;
+        step?: number;
         value?: any;
         description?: string;
         uniforms?: { placeholder: any };
@@ -663,6 +664,7 @@ export class StepsService {
         type,
         defaultValue,
         description,
+        ...(type === "number" || type === "integer") && {step : 1},
         uniforms: { placeholder: defaultValue },
         label: title,
       };


### PR DESCRIPTION
With the new version of uniforms-patternfly - it's possible now to specify schema with step value - set by default to 1.

Closes https://github.com/KaotoIO/kaoto-ui/issues/1201