### PR TITLE
fix: Add Beans support

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,10 +1,6 @@
 import { fetchCapabilities, fetchCompatibleDSLs, fetchIntegrationSourceCode } from '@kaoto/api';
 import { ValidationService } from '@kaoto/services';
-import {
-  useFlowsStore,
-  useIntegrationSourceStore,
-  useSettingsStore,
-} from '@kaoto/store';
+import { useFlowsStore, useIntegrationSourceStore, useSettingsStore } from '@kaoto/store';
 import { ICapabilities, ISettings } from '@kaoto/types';
 import { getDescriptionIfExists, usePrevious } from '@kaoto/utils';
 import {
@@ -23,9 +19,9 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
+import isEqual from 'lodash.isequal';
 import { useCallback, useEffect, useState } from 'react';
 import { shallow } from 'zustand/shallow';
-import isEqual from 'lodash.isequal';
 
 export interface ISettingsModal {
   handleCloseModal: () => void;
@@ -43,7 +39,15 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
   const [availableDSLs, setAvailableDSLs] = useState<string[]>([]);
   const { settings, setSettings } = useSettingsStore((state) => state);
   const [localSettings, setLocalSettings] = useState<ISettings>(settings);
-  const { flows, properties, setFlows } = useFlowsStore(({ flows, properties, setFlowsWrapper: setFlows }) => ({ flows, properties, setFlows }), shallow);
+  const { flows, properties, metadata, setFlowsWrapper } = useFlowsStore(
+    ({ flows, properties, metadata, setFlowsWrapper }) => ({
+      flows,
+      properties,
+      metadata,
+      setFlowsWrapper,
+    }),
+    shallow
+  );
   const { setSourceCode } = useIntegrationSourceStore();
   const previousFlows = usePrevious(flows);
   const previousNamespace = usePrevious(localSettings.namespace);
@@ -69,9 +73,10 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
             dsl: settings.dsl.name,
           })),
           properties,
+          metadata,
         };
 
-        setFlows(updatedFlowWrapper);
+        setFlowsWrapper(updatedFlowWrapper);
       });
     });
   }, []);
@@ -158,6 +163,7 @@ export const SettingsModal = ({ handleCloseModal, isModalOpen }: ISettingsModal)
         dsl: settings.dsl.name,
       })),
       properties,
+      metadata,
     };
 
     fetchIntegrationSourceCode(updatedFlowWrapper)

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -26,7 +26,15 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
   const { sourceCode, setSourceCode } = useIntegrationSourceStore();
   const [syncedCode, setSyncedCode] = useState('');
   const { settings, setSettings } = useSettingsStore();
-  const { flows, properties, setFlowsWrapper } = useFlowsStore(({ flows, properties, setFlowsWrapper }) => ({ flows, properties, setFlowsWrapper }), shallow);
+  const { flows, properties, metadata, setFlowsWrapper } = useFlowsStore(
+    ({ flows, properties, metadata, setFlowsWrapper }) => ({
+      flows,
+      properties,
+      metadata,
+      setFlowsWrapper,
+    }),
+    shallow
+  );
   const previousFlows = usePrevious(flows);
 
   const schemaUri = settings.dsl.validationSchema
@@ -42,12 +50,12 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
           if (dsl.name === flows[0].dsl) {
             const tmpSettings = { ...settings, dsl: dsl };
             setSettings(tmpSettings);
-            fetchTheSourceCode({flows, properties}, tmpSettings);
+            fetchTheSourceCode({ flows, properties, metadata }, tmpSettings);
           }
         });
       });
     } else {
-      fetchTheSourceCode({flows, properties}, settings);
+      fetchTheSourceCode({ flows, properties, metadata }, settings);
     }
   }, [flows, properties]);
 

--- a/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
+++ b/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
@@ -1,10 +1,6 @@
 import { useCancelableEffect } from './hooks/useCancelableEffect';
 import { fetchIntegrationJson, fetchIntegrationSourceCode } from '@kaoto/api';
-import {
-  useFlowsStore,
-  useIntegrationJsonStore,
-  useSettingsStore,
-} from '@kaoto/store';
+import { useFlowsStore, useIntegrationJsonStore, useSettingsStore } from '@kaoto/store';
 import { IFlowsWrapper, IIntegration } from '@kaoto/types';
 import isEqual from 'lodash.isequal';
 import { basename } from 'path';
@@ -47,13 +43,26 @@ function KogitoEditorIntegrationProviderInternal(
   { content, onContentChanged, onReady, children, contentPath }: IKogitoEditorIntegrationProvider,
   ref: Ref<KaotoIntegrationProviderRef>
 ) {
-  const { settings, setSettings } = useSettingsStore(({ settings, setSettings }) => ({ settings, setSettings }), shallow);
-  const { flows, properties, setFlowsWrapper } = useFlowsStore(({ flows, properties, setFlowsWrapper }) => ({ flows, properties, setFlowsWrapper }), shallow);
+  const { settings, setSettings } = useSettingsStore(
+    ({ settings, setSettings }) => ({ settings, setSettings }),
+    shallow
+  );
+  const { flows, properties, metadata, setFlowsWrapper } = useFlowsStore(
+    ({ flows, properties, metadata, setFlowsWrapper }) => ({
+      flows,
+      properties,
+      metadata,
+      setFlowsWrapper,
+    }),
+    shallow
+  );
 
   // The history is used to keep a log of every change to the content. Then, this log is used to undo and redo content.
   const { undo, redo, pastStates } = useIntegrationJsonStore.temporal.getState();
 
-  const previousFlowWrapper = useRef<IFlowsWrapper>(JSON.parse(JSON.stringify({ flows, properties })));
+  const previousFlowWrapper = useRef<IFlowsWrapper>(
+    JSON.parse(JSON.stringify({ flows, properties, metadata }))
+  );
   const previousContent = useRef<string>();
   const initialIntegrationJson = useRef<IIntegration>();
   const [lastAction, setLastAction] = useState<
@@ -108,7 +117,8 @@ function KogitoEditorIntegrationProviderInternal(
             metadata: { ...flow.metadata, ...settings },
             dsl: settings.dsl.name,
           })),
-          properties
+          properties,
+          metadata,
         };
 
         fetchIntegrationSourceCode(updatedFlowWrapper, settings.namespace).then((newSrc) => {
@@ -129,7 +139,7 @@ function KogitoEditorIntegrationProviderInternal(
           }
         });
       },
-      [flows, settings, properties, setSettings, lastAction, onContentChanged]
+      [flows, settings, properties, metadata, setSettings, lastAction, onContentChanged]
     )
   );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -254,6 +254,7 @@ export type IVizStepPropsEdge = Edge & {
 export interface IFlowsWrapper {
   flows: IIntegration[];
   properties: Record<string, unknown>;
+  metadata: Record<string, unknown>;
 }
 
 export type HandleDeleteStepFn = (integrationId: string, UUID: string) => void;


### PR DESCRIPTION
With KaotoIO/kaoto-backend#659, now the `beans` definition pasted in YAML code editor will be preserved.

Fixes: #1721