### PR TITLE
Fix flaky code-editor-actions actions test

### DIFF
--- a/cypress/e2e/08-code-editor-actions/code_editor_actions.cy.js
+++ b/cypress/e2e/08-code-editor-actions/code_editor_actions.cy.js
@@ -88,14 +88,12 @@ describe('editing properties', () => {
     cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');
     cy.get('[data-testid="viz-step-set-header"]').should('not.exist');
 
-    // First click undo button => alert is displayed
+    // First click undo button => reverted automatic adjustments
     cy.editorClickUndoXTimes();
-
+    // Second click undo button => changes reverted & alert is displayed
+    cy.editorClickUndoXTimes();
     // CHECK alert is displayed
     cy.get('.pf-c-alert__title').contains('Any invalid code will be replaced after sync. If you don\'t want to lose your changes please make a backup.');
-
-    // Second click undo button => changes reverted
-    cy.editorClickUndoXTimes();
     cy.syncUpCodeChanges();
 
     // CHECK branch with digitalocean and set header step was deleted


### PR DESCRIPTION
Found the source of instabilities for code-editor-actions tests in Chrome and Edge. The backend updates the yaml in editor on save - changing the indentation. This change is sometimes detected, sometimes not by the monaco editor, but only on these two browsers - didn't see this error in FF. I also didn't find  too much about the "undo" function. The alert is therefor a bit unpredictable, however the test was adjusted to verify the alert after the second "undo" invocation, where the alert fires regularly.