### PR TITLE
chore: remove duplicated useEffect

### DIFF
--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -90,14 +90,6 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
   useEffect(() => {
     setLocalName(settings.name);
   }, [settings.name]);
-  // fetch default namespace from the API,
-  useEffect(() => {
-    fetchDefaultNamespace().then((data) => {
-      const newSettings = settings;
-      newSettings.namespace = data.namespace;
-      setSettings(newSettings);
-    });
-  }, []);
 
   // fetch default namespace from the API,
   useEffect(() => {


### PR DESCRIPTION
### Context
Probably during a rebase, this block of code got duplicated, as we can see in the network tab upon loading the project.

![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/120d1d5e-7313-4d75-ae1f-899d900cc211)

![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/9c057d8e-bb9b-409b-bddd-eb7624fb2daa)

### Changes
* Remove the duplicated block of code