### PR TITLE
Feat/add new flow

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,3 +8,7 @@ coverage:
         base: auto
 ignore:
   - "**/*.stories.tsx"
+  - "**/*.(test|stories).{ts,tsx}"
+  - "**/index.ts"
+  - "**/store/data/**"
+  - "**/stubs/**"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,6 +6,7 @@ coverage:
         target: auto
         threshold: 0.5%
         base: auto
+        removed_code_behavior: adjust_base
 ignore:
   - "**/*.stories.tsx"
   - "**/*.(test|stories).{ts,tsx}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 package.json
 src/bootstrap.tsx
-src/services/stepsService.test.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,5 @@
   "printWidth": 100,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "all"
 }

--- a/cypress/e2e/01-settings/settings.cy.js
+++ b/cypress/e2e/01-settings/settings.cy.js
@@ -48,7 +48,6 @@ describe('Settings', () => {
 
     // CHECK that steps are still there and toolbar contains new name
     cy.get('[data-testid="viz-step-timer"]').should('be.visible');
-    cy.get('[data-testid="kaoto-toolbar--name"]').should('have.text', 'cherry');
 
     // verify that source code editor contains new values
     cy.openCodeEditor();
@@ -79,46 +78,5 @@ describe('Settings', () => {
 
     // CHECK that value is changed accordingly
     cy.get('[data-testid="settings--description"]').should('have.text', description);
-  });
-
-  it('Only shows relevant DSLs', () => {
-    cy.get('[data-testid="settings--integration-type"]')
-      .select('Integration')
-      .should('have.value', 'Integration');
-    cy.saveMenuModal();
-    cy.replaceEmptyStepMiniCatalog('timer');
-    cy.openSettingsModal();
-
-    // CHECK that KameletBinding DSL should not be available to select
-    cy.get('[data-testid="settings--integration-type__KameletBinding"]').should('not.exist');
-  });
-
-  it('updates the DSL', () => {
-    // close modal
-    cy.get('[data-testid="settings--integration-type"]')
-      .select('Integration')
-      .should('have.value', 'Integration');
-    cy.saveMenuModal(true);
-
-    cy.replaceEmptyStepMiniCatalog('kamelet');
-
-    // reopen modal, make changes, save and close again
-    cy.openSettingsModal();
-
-    // select Kamelet
-    cy.get('[data-testid="settings--integration-type"]')
-      .select('Kamelet')
-      .should('have.value', 'Kamelet');
-
-    cy.saveMenuModal(true);
-
-    // CHECK that steps are still there
-    cy.get('[data-testid="viz-step-kamelet"]').should('be.visible');
-
-    // reopen modal,
-    cy.openSettingsModal();
-
-    // CHECK that value is still Kamelet
-    cy.get('[data-testid="settings--integration-type"]').should('have.value', 'Kamelet');
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,19 @@ module.exports = {
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
 
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{ts,tsx}',
+    '!<rootDir>/src/**/*.(test|stories).{ts,tsx}',
+    '!<rootDir>/src/**/index.ts',
+    '!<rootDir>/src/store/data/**',
+    '!<rootDir>/src/stubs/**',
+  ],
+
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
+
   transform: {
-    '\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.jsx?$': 'babel-jest',
   },
 
   moduleNameMapper: {
@@ -20,7 +31,7 @@ module.exports = {
       path.resolve(__dirname, './src/__mocks__/fileMock.js'),
     '@patternfly/react-code-editor': path.resolve(
       __dirname,
-      './src/__mocks__/reactCodeEditorMock.js'
+      './src/__mocks__/reactCodeEditorMock.js',
     ),
     '@kaoto/api': path.resolve(__dirname, './src/api'),
     '@kaoto/assets': path.resolve(__dirname, './src/assets'),
@@ -33,7 +44,14 @@ module.exports = {
     '@kaoto/services': path.resolve(__dirname, './src/services'),
     '@kaoto/store': path.resolve(__dirname, './src/store'),
     '@kaoto/utils': path.resolve(__dirname, './src/utils'),
-    '@kie-tools/uniforms-patternfly/dist/esm': path.resolve(__dirname, 'node_modules/@kie-tools/uniforms-patternfly/dist/cjs'),
+    '@kie-tools/uniforms-patternfly/dist/esm': path.resolve(
+      __dirname,
+      'node_modules/@kie-tools/uniforms-patternfly/dist/cjs',
+    ),
+    '@patternfly/react-core/next': path.resolve(
+      __dirname,
+      'node_modules/@patternfly/react-core/dist/js/next',
+    ),
   },
 
   roots: ['<rootDir>'],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "yarn lint --fix",
     "lint-staged": "yarn lint:fix && yarn format:fix",
     "storybook": "storybook dev -p 6006",
-    "test": "jest --coverage src/**/*.test.ts*",
+    "test": "jest --coverage",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -1,5 +1,5 @@
 import { RequestService } from './requestService';
-import { IFlowsWrapper, IStepProps } from '@kaoto/types';
+import { ICapabilities, IFlowsWrapper, IStepProps } from '@kaoto/types';
 
 const apiVersion = '/v1';
 
@@ -23,7 +23,7 @@ export async function fetchBackendVersion(): Promise<string> {
  * domain-specific languages (DSLs)
  * Returns { dsls: { [val: string]: string }[] }
  */
-export async function fetchCapabilities(namespace?: string) {
+export async function fetchCapabilities(namespace?: string): Promise<ICapabilities> {
   try {
     const resp = await RequestService.get({
       endpoint: `${apiVersion}/capabilities`,
@@ -68,7 +68,7 @@ export async function fetchCatalogSteps(
     previousStep?: string;
     followingStep?: string;
   },
-  cache?: RequestCache | undefined
+  cache?: RequestCache | undefined,
 ) {
   try {
     if (!queryParams?.previousStep) {
@@ -166,7 +166,7 @@ export async function fetchDeployments(cache?: RequestCache | undefined, namespa
 export async function fetchDeploymentLogs(
   name: string,
   namespace?: string,
-  lines?: number
+  lines?: number,
 ): Promise<ReadableStream | unknown> {
   try {
     const resp = await RequestService.get({
@@ -197,7 +197,7 @@ export async function fetchDeploymentLogs(
 export async function fetchIntegrationJson(
   data: string,
   dsl: string,
-  namespace?: string
+  namespace?: string,
 ): Promise<IFlowsWrapper> {
   const resp = await RequestService.post({
     endpoint: `/v2/integrations`,

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,6 +1,11 @@
-import { AboutModal as PatternFlyAboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import logo from '../assets/images/logo-kaoto-dark.png';
-import { useSettingsStore } from '../store';
+import { useSettingsStore } from '@kaoto/store';
+import {
+  AboutModal as PatternFlyAboutModal,
+  TextContent,
+  TextList,
+  TextListItem,
+} from '@patternfly/react-core';
 
 export interface IAboutModal {
   handleCloseModal: () => void;
@@ -8,7 +13,7 @@ export interface IAboutModal {
 }
 
 export const AboutModal = ({ handleCloseModal, isModalOpen }: IAboutModal) => {
-  const backendVersion = useSettingsStore((state) => state.backendVersion);
+  const backendVersion = useSettingsStore((state) => state.settings.backendVersion);
 
   return (
     <PatternFlyAboutModal
@@ -21,9 +26,13 @@ export const AboutModal = ({ handleCloseModal, isModalOpen }: IAboutModal) => {
       <TextContent>
         <TextList component="dl">
           <TextListItem component="dt">Frontend Version</TextListItem>
-          <TextListItem component="dd" data-testid="about-frontend-version" >{KAOTO_VERSION}</TextListItem>
+          <TextListItem component="dd" data-testid="about-frontend-version">
+            {KAOTO_VERSION}
+          </TextListItem>
           <TextListItem component="dt">Backend Version</TextListItem>
-          <TextListItem component="dd" data-testid="about-backend-version" >{backendVersion}</TextListItem>
+          <TextListItem component="dd" data-testid="about-backend-version">
+            {backendVersion}
+          </TextListItem>
         </TextList>
       </TextContent>
     </PatternFlyAboutModal>

--- a/src/components/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal.test.tsx
@@ -1,0 +1,68 @@
+import { ConfirmationModal } from './ConfirmationModal';
+import { fireEvent, render } from '@testing-library/react';
+
+describe('ConfirmationModal.tsx', () => {
+  let onConfirm: jest.Mock;
+  let onCancel: jest.Mock;
+
+  beforeEach(() => {
+    onConfirm = jest.fn();
+    onCancel = jest.fn();
+  });
+
+  test('component renders', () => {
+    const wrapper = render(
+      <ConfirmationModal handleConfirm={onConfirm} handleCancel={onCancel} isModalOpen={true} />,
+    );
+
+    const element = wrapper.queryByTestId('confirmation-modal');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('click on confirm', async () => {
+    const wrapper = render(
+      <ConfirmationModal handleConfirm={onConfirm} handleCancel={onCancel} isModalOpen={true} />,
+    );
+
+    const confirmButton = await wrapper.findByText('Confirm');
+    fireEvent.click(confirmButton);
+
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  test('click on cancel', async () => {
+    const wrapper = render(
+      <ConfirmationModal handleConfirm={onConfirm} handleCancel={onCancel} isModalOpen={true} />,
+    );
+
+    const cancelButton = await wrapper.findByText('Cancel');
+    fireEvent.click(cancelButton);
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('should have "Confirmation" as title if not specified', async () => {
+    const wrapper = render(
+      <ConfirmationModal handleConfirm={onConfirm} handleCancel={onCancel} isModalOpen={true} />,
+    );
+
+    const title = await wrapper.findByRole('heading');
+
+    expect(title).toHaveTextContent('Confirmation');
+  });
+
+  test('should have a title if specified', async () => {
+    const wrapper = render(
+      <ConfirmationModal
+        handleConfirm={onConfirm}
+        handleCancel={onCancel}
+        isModalOpen={true}
+        modalTitle="This is a different title"
+      />,
+    );
+
+    const title = await wrapper.findByRole('heading');
+
+    expect(title).toHaveTextContent('This is a different title');
+  });
+});

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,12 +1,12 @@
 import { OrangeExclamationTriangleIcon } from './Icons';
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { FunctionComponent, PropsWithChildren } from 'react';
 
-export interface IConfirmationModal {
+export interface IConfirmationModal extends PropsWithChildren {
   handleCancel: () => void;
   handleConfirm: () => void;
   isModalOpen: boolean;
   modalTitle?: string;
-  modalBody?: string;
 }
 
 /**
@@ -18,13 +18,13 @@ export interface IConfirmationModal {
  * @param modalTitle
  * @constructor
  */
-export const ConfirmationModal = ({
+export const ConfirmationModal: FunctionComponent<IConfirmationModal> = ({
+  children,
   handleCancel,
   handleConfirm,
   isModalOpen,
-  modalBody,
   modalTitle,
-}: IConfirmationModal) => {
+}) => {
   const onCancel = () => {
     handleCancel();
   };
@@ -34,7 +34,7 @@ export const ConfirmationModal = ({
   };
 
   return (
-    <div className={'confirmation-modal'} data-testid={'confirmation-modal'}>
+    <div className="confirmation-modal" data-testid="confirmation-modal">
       <Modal
         actions={[
           <Button key="confirm" variant="primary" onClick={onConfirm}>
@@ -47,15 +47,12 @@ export const ConfirmationModal = ({
         aria-describedby="modal-description"
         isOpen={isModalOpen}
         onClose={handleCancel}
-        className={'customClass'}
+        className="customClass"
         titleIconVariant={OrangeExclamationTriangleIcon}
         title={modalTitle ?? 'Confirmation'}
         variant={ModalVariant.small}
       >
-        <span id="modal-description">
-          {modalBody ??
-            'WARNING! This action is not reversible. Are you sure you would like to proceed?'}
-        </span>
+        {children}
       </Modal>
     </div>
   );

--- a/src/components/DSL/DSLSelector.test.tsx
+++ b/src/components/DSL/DSLSelector.test.tsx
@@ -1,0 +1,255 @@
+import { capabilitiesStub } from '../../stubs';
+import { DSLSelector } from './DSLSelector';
+import { useSettingsStore } from '@kaoto/store';
+import { IDsl } from '@kaoto/types';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+
+describe('DSLSelector.tsx', () => {
+  let onSelect: jest.Mock;
+  const dsl: IDsl = {
+    name: 'Capability 1',
+    deployable: '',
+    description: '',
+    input: '',
+    output: '',
+    stepKinds: '',
+    validationSchema: '',
+  };
+
+  beforeEach(() => {
+    onSelect = jest.fn();
+
+    useSettingsStore.setState({
+      settings: {
+        ...useSettingsStore.getState().settings,
+        capabilities: capabilitiesStub.dsls,
+      },
+    });
+  });
+
+  test('component renders', () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} />);
+
+    const toggle = wrapper.queryByTestId('dsl-select');
+    expect(toggle).toBeInTheDocument();
+  });
+
+  test('should toggle list of DSLs', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = wrapper.getByText('Integration');
+    expect(element).toBeInTheDocument();
+
+    /** Close Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(element).not.toBeInTheDocument();
+  });
+
+  test('should show list of DSLs', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = await wrapper.findByText('Integration');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('should show selected value', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} selectedDsl={dsl} />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Integration');
+      fireEvent.click(element);
+    });
+
+    /** Open Select again */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const element = await wrapper.findByRole('option', { selected: true });
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveTextContent('Integration');
+  });
+
+  test('should not have anything selected if "isStatic=true"', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} isStatic />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Integration');
+      fireEvent.click(element);
+    });
+
+    /** Open Select again */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).not.toBeInTheDocument();
+    });
+  });
+
+  test('should have selected DSL if provided', async () => {
+    const wrapper = render(
+      <DSLSelector onSelect={onSelect} selectedDsl={capabilitiesStub.dsls[2]} />,
+    );
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent('Kamelet');
+    });
+  });
+
+  test('should have selected the first DSL if selectedDsl is not provided', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent('Integration');
+    });
+  });
+
+  test('should close Select when pressing ESC', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    const menu = await wrapper.findByRole('listbox');
+    /** Press Escape key to close the menu */
+    act(() => {
+      fireEvent.focus(menu);
+      fireEvent.keyDown(menu, { key: 'Escape', code: 'Escape', charCode: 27 });
+    });
+
+    expect(menu).not.toBeInTheDocument();
+
+    waitFor(() => {
+      const element = wrapper.queryByRole('option', { selected: true });
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveTextContent('Integration');
+    });
+  });
+
+  test('should call onSelect callback when provided', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} isStatic />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Integration');
+      fireEvent.click(element);
+    });
+
+    waitFor(() => {
+      expect(onSelect).toHaveBeenCalled();
+    });
+  });
+
+  test('should not call onSelect spy when not provided', async () => {
+    const wrapper = render(<DSLSelector onSelect={undefined} isStatic />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Integration');
+      fireEvent.click(element);
+    });
+
+    waitFor(() => {
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  test('should not call onSelect spy when the selected id does not exist', async () => {
+    const wrapper = render(<DSLSelector onSelect={onSelect} isStatic />);
+    const toggle = await wrapper.findByTestId('dsl-select');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    /** Forcing a non existing key. We're using splice since modifies the Array without triggering a store update */
+    useSettingsStore.getState().settings.capabilities.splice(0, Number.POSITIVE_INFINITY);
+
+    /** Click on first element */
+    act(() => {
+      const element = wrapper.getByText('Integration');
+      fireEvent.click(element);
+    });
+
+    waitFor(() => {
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  test('should render children components', async () => {
+    const wrapper = render(
+      <DSLSelector>
+        <p>This is a child component</p>
+      </DSLSelector>,
+    );
+
+    waitFor(() => {
+      const child = wrapper.getByText('This is a child component');
+      expect(child).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/DSL/DSLSelector.tsx
+++ b/src/components/DSL/DSLSelector.tsx
@@ -1,0 +1,90 @@
+import { useSettingsStore } from '@kaoto/store';
+import { IDsl } from '@kaoto/types';
+import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import { Select, SelectList, SelectOption } from '@patternfly/react-core/next';
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  MouseEvent as ReactMouseEvent,
+  Ref,
+  useCallback,
+  useState,
+} from 'react';
+import { shallow } from 'zustand/shallow';
+
+interface IDSLSelector extends PropsWithChildren {
+  isStatic?: boolean;
+  selectedDsl?: IDsl;
+  onSelect?: (value: IDsl) => void;
+}
+
+export const DSLSelector: FunctionComponent<IDSLSelector> = (props) => {
+  const capabilities = useSettingsStore((state) => state.settings.capabilities, shallow);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<IDsl | undefined>(
+    props.isStatic ? undefined : props.selectedDsl ?? capabilities[0],
+  );
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = useCallback(
+    (
+      _: ReactMouseEvent<Element, MouseEvent> | undefined,
+      selectedDslName: string | number | undefined,
+    ) => {
+      const dsl = capabilities.find((capability) => capability.name === selectedDslName);
+
+      if (!props.isStatic) {
+        setSelected(dsl);
+      }
+
+      setIsOpen(false);
+      if (typeof props.onSelect === 'function' && dsl !== undefined) {
+        props.onSelect(dsl);
+      }
+    },
+    [capabilities, props],
+  );
+
+  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+    <MenuToggle
+      data-testid="dsl-select"
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      {props.children}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id="dsl-select"
+      isOpen={isOpen}
+      selected={selected?.name}
+      onSelect={onSelect}
+      onOpenChange={(isOpen) => {
+        setIsOpen(isOpen);
+      }}
+      toggle={toggle}
+      minWidth="300px"
+    >
+      <SelectList>
+        {capabilities.map((capability) => {
+          return (
+            <SelectOption
+              key={`dsl-${capability.name}`}
+              itemId={capability.name}
+              description={<span className="pf-u-text-break-word">{capability.description}</span>}
+            >
+              {capability.name}
+            </SelectOption>
+          );
+        })}
+      </SelectList>
+    </Select>
+  );
+};

--- a/src/components/DSL/NewFlow.test.tsx
+++ b/src/components/DSL/NewFlow.test.tsx
@@ -1,0 +1,135 @@
+import { capabilitiesStub } from '../../stubs';
+import { NewFlow } from './NewFlow';
+import { useFlowsStore, useSettingsStore } from '@kaoto/store';
+import { act, fireEvent, render } from '@testing-library/react';
+
+describe('NewFlow.tsx', () => {
+  beforeEach(() => {
+    useFlowsStore.getState().deleteAllFlows();
+    useSettingsStore.setState({
+      settings: {
+        ...useSettingsStore.getState().settings,
+        dsl: capabilitiesStub.dsls[0],
+        capabilities: capabilitiesStub.dsls,
+      },
+    });
+  });
+
+  test('should add a new flow', async () => {
+    const wrapper = render(<NewFlow />);
+    const trigger = await wrapper.findByText('New route');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select an option */
+    act(() => {
+      const element = wrapper.getByText('Integration');
+      fireEvent.click(element);
+    });
+
+    expect(useFlowsStore.getState().flows).toHaveLength(1);
+    expect(useFlowsStore.getState().flows[0].dsl).toEqual('Integration');
+  });
+
+  test('should warn the user when adding a different type of flow', async () => {
+    useFlowsStore.getState().addNewFlow('Integration');
+
+    const wrapper = render(<NewFlow />);
+    const trigger = await wrapper.findByText('New route');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select an option */
+    act(() => {
+      const element = wrapper.getByText('Kamelet');
+      fireEvent.click(element);
+    });
+
+    const modal = await wrapper.findByTestId('confirmation-modal');
+    expect(modal).toBeInTheDocument();
+  });
+
+  test('should add a different type of flow', async () => {
+    useFlowsStore.getState().addNewFlow('Integration');
+
+    const wrapper = render(<NewFlow />);
+    const trigger = await wrapper.findByText('New route');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select an option */
+    act(() => {
+      const element = wrapper.getByText('Kamelet');
+      fireEvent.click(element);
+    });
+
+    const confirmButton = await wrapper.findByText('Confirm', { selector: 'button' });
+    act(() => {
+      fireEvent.click(confirmButton);
+    });
+
+    expect(useFlowsStore.getState().flows).toHaveLength(1);
+    expect(useFlowsStore.getState().flows[0].dsl).toEqual('Kamelet');
+  });
+
+  test('should not do anything if the user closes the modal', async () => {
+    useFlowsStore.getState().addNewFlow('Integration');
+
+    const wrapper = render(<NewFlow />);
+    const trigger = await wrapper.findByText('New route');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select an option */
+    act(() => {
+      const element = wrapper.getByText('Kamelet');
+      fireEvent.click(element);
+    });
+
+    const cancelButton = await wrapper.findByText('Cancel', { selector: 'button' });
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
+
+    expect(useFlowsStore.getState().flows).toHaveLength(1);
+    expect(useFlowsStore.getState().flows[0].dsl).toEqual('Integration');
+  });
+
+  test('should not do anything if the user cancel the modal', async () => {
+    useFlowsStore.getState().addNewFlow('Integration');
+
+    const wrapper = render(<NewFlow />);
+    const trigger = await wrapper.findByText('New route');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select an option */
+    act(() => {
+      const element = wrapper.getByText('Kamelet');
+      fireEvent.click(element);
+    });
+
+    const closeButton = await wrapper.findByLabelText('Close', { selector: 'button' });
+    act(() => {
+      fireEvent.click(closeButton);
+    });
+
+    expect(useFlowsStore.getState().flows).toHaveLength(1);
+    expect(useFlowsStore.getState().flows[0].dsl).toEqual('Integration');
+  });
+});

--- a/src/components/DSL/NewFlow.tsx
+++ b/src/components/DSL/NewFlow.tsx
@@ -1,0 +1,77 @@
+import { ConfirmationModal } from '../ConfirmationModal';
+import { DSLSelector } from './DSLSelector';
+import { FlowsStoreFacade, useFlowsStore, useSettingsStore } from '@kaoto/store';
+import { IDsl } from '@kaoto/types';
+import { Tooltip } from '@patternfly/react-core';
+import { PlusIcon } from '@patternfly/react-icons';
+import { FunctionComponent, PropsWithChildren, useCallback, useState } from 'react';
+import { shallow } from 'zustand/shallow';
+
+export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
+  const { namespace, setSettings } = useSettingsStore(
+    ({ settings, setSettings }) => ({
+      namespace: settings.namespace,
+      setSettings,
+    }),
+    shallow,
+  );
+  const { addNewFlow, deleteAllFlows } = useFlowsStore(
+    ({ addNewFlow, deleteAllFlows }) => ({ addNewFlow, deleteAllFlows }),
+    shallow,
+  );
+
+  const [proposedDsl, setProposedNewDsl] = useState<IDsl>();
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+
+  const checkBeforeAddNewFlow = useCallback((dsl: IDsl) => {
+    const isSameDsl = FlowsStoreFacade.isSameDsl(dsl.name);
+
+    if (isSameDsl) {
+      /**
+       * If it's the same DSL as we have in the existing Flows list,
+       * we don't need to do anything special, just add a new flow if
+       * supported
+       */
+      addNewFlow(dsl.name);
+    } else {
+      /**
+       * If it is not the same DSL, this operation might result in
+       * removing the existing flows, so then we warn the user first
+       */
+      setProposedNewDsl(dsl);
+      setIsConfirmationModalOpen(true);
+    }
+  }, [addNewFlow]);
+
+  return (
+    <>
+      <Tooltip content="Create a new route" position="right">
+        <DSLSelector isStatic onSelect={checkBeforeAddNewFlow}>
+          <PlusIcon />
+          <span className="pf-u-m-sm-on-lg">New route</span>
+        </DSLSelector>
+      </Tooltip>
+
+      <ConfirmationModal
+        handleCancel={() => {
+          setIsConfirmationModalOpen(false);
+        }}
+        handleConfirm={() => {
+          deleteAllFlows();
+
+          /** TODO: Check whether this configuration is required to be kept inside of settingsStore */
+          setSettings({ dsl: proposedDsl, name: 'integration', namespace });
+
+          addNewFlow(proposedDsl!.name);
+          setIsConfirmationModalOpen(false);
+        }}
+        isModalOpen={isConfirmationModalOpen}
+      >
+        <p>
+          This will remove the existing routes and you will lose your current work. Are you sure you
+          would like to proceed?
+        </p>
+      </ConfirmationModal>
+    </>
+  );
+};

--- a/src/components/KaotoToolbar.test.tsx
+++ b/src/components/KaotoToolbar.test.tsx
@@ -1,4 +1,4 @@
-import KaotoToolbar from './KaotoToolbar';
+import { KaotoToolbar } from './KaotoToolbar';
 import { AlertProvider } from '@kaoto/layout';
 import { screen, render, fireEvent, act } from '@testing-library/react';
 

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -9,7 +9,6 @@ import {
   SettingsModal,
 } from '@kaoto/components';
 import { LOCAL_STORAGE_UI_THEME_KEY, THEME_DARK_CLASS } from '@kaoto/constants';
-import { ValidationService } from '@kaoto/services';
 import {
   useDeploymentStore,
   useFlowsStore,
@@ -25,11 +24,9 @@ import {
   DropdownSeparator,
   DropdownToggle,
   Icon,
-  InputGroup,
   KebabToggle,
   OverflowMenu,
   OverflowMenuControl,
-  TextInput,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -39,16 +36,13 @@ import {
   BarsIcon,
   BellIcon,
   CatalogIcon,
-  CheckIcon,
   CodeIcon,
   CubesIcon,
   ExternalLinkAltIcon,
   GithubIcon,
-  PencilAltIcon,
-  TimesIcon,
 } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface IKaotoToolbar {
   toggleCatalog: () => void;
@@ -73,14 +67,7 @@ export const KaotoToolbar = ({
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
   const [appMenuIsOpen, setAppMenuIsOpen] = useState(false);
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
-  const [isEditingName, setIsEditingName] = useState(false);
-  const focusIntegrationInput = useCallback((element: HTMLInputElement) => {
-    element?.focus();
-  }, []);
-  const [localName, setLocalName] = useState(settings.name);
-  const [nameValidation, setNameValidation] = useState<
-    'default' | 'warning' | 'success' | 'error' | undefined
-  >('default');
+
   const [expanded, setExpanded] = useState({
     aboutModal: false,
     appearanceModal: false,
@@ -89,12 +76,6 @@ export const KaotoToolbar = ({
   });
 
   const { addAlert } = useAlert() || {};
-
-  // change in name from elsewhere should update local value
-  // otherwise, on edit it will show the old value
-  useEffect(() => {
-    setLocalName(settings.name);
-  }, [settings.name]);
 
   // fetch default namespace from the API,
   useEffect(() => {
@@ -285,7 +266,7 @@ export const KaotoToolbar = ({
 
           {/* STEP CATALOG BUTTON */}
           <ToolbarItem>
-            <Tooltip content={<div>Step Catalog</div>} position={'bottom'}>
+            <Tooltip content={<div>Step Catalog</div>} position="bottom">
               <Button
                 tabIndex={0}
                 variant="link"
@@ -304,7 +285,7 @@ export const KaotoToolbar = ({
 
           {/* CODE TOGGLE BUTTON */}
           <ToolbarItem>
-            <Tooltip content={<div>Source Code</div>} position={'bottom'}>
+            <Tooltip content={<div>Source Code</div>} position="bottom">
               <Button
                 variant="link"
                 isActive={isActiveButton == 'toolbar-show-code-btn' && leftDrawerExpanded}
@@ -322,93 +303,11 @@ export const KaotoToolbar = ({
 
           <ToolbarItem variant="separator" />
 
-          {/* NAME */}
-          <ToolbarItem variant="label">
-            {isEditingName ? (
-              <InputGroup>
-                <TextInput
-                  name="edit-integration-name"
-                  id="edit-integration-name"
-                  data-testid={'kaoto-toolbar--name__edit'}
-                  type="text"
-                  ref={focusIntegrationInput}
-                  onChange={(val) => {
-                    // save to local state while typing
-                    setLocalName(val);
-                    if (ValidationService.isNameValidCheck(val)) {
-                      setNameValidation('success');
-                    } else {
-                      setNameValidation('error');
-                    }
-                  }}
-                  value={localName}
-                  aria-label="edit integration name"
-                  validated={nameValidation}
-                  aria-invalid={nameValidation === 'error'}
-                  onKeyUp={(e) => {
-                    // allow users to save by pressing enter
-                    if (e.key !== 'Enter') return;
-                    if (ValidationService.isNameValidCheck(localName)) {
-                      setIsEditingName(false);
-                      // only issue change if different from current settings
-                      if (localName !== settings.name) {
-                        setSettings({ ...settings, name: localName });
-                      }
-                    }
-                  }}
-                />
-                <Button
-                  variant="plain"
-                  aria-label="save button for editing integration name"
-                  onClick={() => {
-                    if (ValidationService.isNameValidCheck(localName)) {
-                      setIsEditingName(false);
-                      // only issue change if different from current settings
-                      if (localName !== settings.name) {
-                        setSettings({ ...settings, name: localName });
-                      }
-                    }
-                  }}
-                  data-testid={'kaoto-toolbar--name__edit--save'}
-                  aria-disabled={nameValidation === 'error'}
-                  isDisabled={nameValidation === 'error'}
-                >
-                  <CheckIcon />
-                </Button>
-                <Button
-                  variant="plain"
-                  aria-label="close button for editing integration name"
-                  data-testid={'kaoto-toolbar--name__edit--close'}
-                  onClick={() => {
-                    setLocalName(settings.name);
-                    setNameValidation('default');
-                    setIsEditingName(false);
-                  }}
-                >
-                  <TimesIcon />
-                </Button>
-              </InputGroup>
-            ) : (
-              <>
-                <span data-testid={'kaoto-toolbar--name'}>{settings.name}</span>&nbsp;&nbsp;
-                <Button
-                  variant={'link'}
-                  data-testid={'kaoto-toolbar--name__edit--start'}
-                  onClick={() => {
-                    setIsEditingName(true);
-                  }}
-                >
-                  <PencilAltIcon />
-                </Button>
-              </>
-            )}
-          </ToolbarItem>
-
           {/* DEPLOYMENT STATUS */}
           {deployment.crd ? (
             <ToolbarItem alignment={{ default: 'alignRight' }}>
-              <div className="status-container" data-testid={'toolbar-deployment-status'}>
-                <div className={`dot`}></div>
+              <div className="status-container" data-testid="toolbar-deployment-status">
+                <div className="dot"></div>
                 <div className="text">Running</div>
               </div>
             </ToolbarItem>

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,3 +1,6 @@
+import logo from '../assets/images/logo-kaoto-dark.png';
+import { AboutModal } from './AboutModal';
+import { ExportCanvasToPng } from './ExportCanvasToPng';
 import { fetchDefaultNamespace, startDeployment } from '@kaoto/api';
 import {
   AppearanceModal,
@@ -46,9 +49,6 @@ import {
 } from '@patternfly/react-icons';
 import { useAlert } from '@rhoas/app-services-ui-shared';
 import { useCallback, useEffect, useState } from 'react';
-import logo from '../assets/images/logo-kaoto-dark.png';
-import { AboutModal } from './AboutModal';
-import { ExportCanvasToPng } from './ExportCanvasToPng';
 
 export interface IKaotoToolbar {
   toggleCatalog: () => void;
@@ -57,11 +57,16 @@ export interface IKaotoToolbar {
   hideLeftPanel: () => void;
 }
 
-export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, leftDrawerExpanded }: IKaotoToolbar) => {
+export const KaotoToolbar = ({
+  toggleCatalog,
+  toggleCodeEditor,
+  hideLeftPanel,
+  leftDrawerExpanded,
+}: IKaotoToolbar) => {
   const { settings, setSettings } = useSettingsStore((state) => state);
   const { sourceCode, setSourceCode } = useIntegrationSourceStore((state) => state);
   const deleteAllIntegrations = useFlowsStore((state) => state.deleteAllIntegrations);
-  const [isActiveButton,setIsActiveButton] = useState('');
+  const [isActiveButton, setIsActiveButton] = useState('');
   const htmlTagElement = document.documentElement;
 
   const { deployment, setDeploymentCrd } = useDeploymentStore();
@@ -102,8 +107,8 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
 
   // configure UI theme
   useEffect(() => {
-    const uiTheme = localStorage.getItem(LOCAL_STORAGE_UI_THEME_KEY) ?? "true";
-    if (uiTheme === "true") {
+    const uiTheme = localStorage.getItem(LOCAL_STORAGE_UI_THEME_KEY) ?? 'true';
+    if (uiTheme === 'true') {
       htmlTagElement?.classList.remove(THEME_DARK_CLASS);
     } else {
       htmlTagElement?.classList.add(THEME_DARK_CLASS);
@@ -203,21 +208,42 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
       Appearance
     </DropdownItem>,
     <DropdownSeparator key="separator-01" />,
-    <ExportCanvasToPng key="export" fileName={settings.name} onClick={() => { setKebabIsOpen(false); }}/>,
+    <ExportCanvasToPng
+      key="export"
+      fileName={settings.name}
+      onClick={() => {
+        setKebabIsOpen(false);
+      }}
+    />,
     <DropdownSeparator key="separator-02" />,
-    <DropdownItem key="tutorial" href="https://kaoto.io/workshop/" target="_blank" className="pf-u-display-flex pf-u-justify-content-space-between">
+    <DropdownItem
+      key="tutorial"
+      href="https://kaoto.io/workshop/"
+      target="_blank"
+      className="pf-u-display-flex pf-u-justify-content-space-between"
+    >
       <span className="pf-u-mr-lg">Tutorial</span>
       <Icon isInline>
         <ExternalLinkAltIcon />
       </Icon>
     </DropdownItem>,
-    <DropdownItem key="help" href="https://kaoto.io/docs/" target="_blank" className="pf-u-display-flex pf-u-justify-content-space-between">
+    <DropdownItem
+      key="help"
+      href="https://kaoto.io/docs/"
+      target="_blank"
+      className="pf-u-display-flex pf-u-justify-content-space-between"
+    >
       <span className="pf-u-mr-lg">Help</span>
       <Icon isInline>
         <ExternalLinkAltIcon />
       </Icon>
     </DropdownItem>,
-    <DropdownItem key="feedback" href="https://github.com/KaotoIO/kaoto-ui/issues/new/choose" target="_blank"  className="pf-u-display-flex pf-u-justify-content-space-between">
+    <DropdownItem
+      key="feedback"
+      href="https://github.com/KaotoIO/kaoto-ui/issues/new/choose"
+      target="_blank"
+      className="pf-u-display-flex pf-u-justify-content-space-between"
+    >
       <span className="pf-u-mr-lg">Feedback</span>
       <Icon isInline>
         <GithubIcon />
@@ -264,13 +290,15 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
                 tabIndex={0}
                 variant="link"
                 isActive={isActiveButton == 'toolbar-step-catalog-btn' && leftDrawerExpanded}
-                data-testid={'toolbar-step-catalog-btn'}
+                data-testid="toolbar-step-catalog-btn"
                 icon={<CatalogIcon />}
-                onClick={()=>{
-                toggleCatalog()
-                setIsActiveButton('toolbar-step-catalog-btn')
+                onClick={() => {
+                  toggleCatalog();
+                  setIsActiveButton('toolbar-step-catalog-btn');
                 }}
-              />
+              >
+                Catalog
+              </Button>
             </Tooltip>
           </ToolbarItem>
 
@@ -278,15 +306,17 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
           <ToolbarItem>
             <Tooltip content={<div>Source Code</div>} position={'bottom'}>
               <Button
-                variant={'link'}
+                variant="link"
                 isActive={isActiveButton == 'toolbar-show-code-btn' && leftDrawerExpanded}
-                data-testid={'toolbar-show-code-btn'}
-                onClick={()=>{
-                toggleCodeEditor()
-                setIsActiveButton('toolbar-show-code-btn')
+                data-testid="toolbar-show-code-btn"
+                onClick={() => {
+                  toggleCodeEditor();
+                  setIsActiveButton('toolbar-show-code-btn');
                 }}
                 icon={<CodeIcon />}
-              />
+              >
+                Source
+              </Button>
             </Tooltip>
           </ToolbarItem>
 
@@ -410,7 +440,14 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
               <OverflowMenuControl hasAdditionalOptions>
                 <Dropdown
                   position={DropdownPosition.right}
-                  toggle={<KebabToggle data-testid="toolbar-kebab-dropdown-toggle" onToggle={(val) => {setKebabIsOpen(val);}} />}
+                  toggle={
+                    <KebabToggle
+                      data-testid="toolbar-kebab-dropdown-toggle"
+                      onToggle={(val) => {
+                        setKebabIsOpen(val);
+                      }}
+                    />
+                  }
                   isOpen={kebabIsOpen}
                   isPlain
                   data-testid="toolbar-kebab-dropdown-btn"
@@ -447,12 +484,14 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
         isModalOpen={expanded.deploymentsModal ?? false}
       />
 
-      {expanded.settingsModal &&
+      {expanded.settingsModal && (
         <SettingsModal
           handleCloseModal={() => {
             setExpanded({ ...expanded, settingsModal: !expanded.settingsModal });
           }}
-          isModalOpen={expanded.settingsModal} />}
+          isModalOpen={expanded.settingsModal}
+        />
+      )}
 
       <AppearanceModal
         handleCloseModal={() => {
@@ -464,11 +503,11 @@ export const KaotoToolbar = ({ toggleCatalog, toggleCodeEditor, hideLeftPanel, l
       />
 
       <AboutModal
-        handleCloseModal={() => { setExpanded({ ...expanded, aboutModal: false }); }}
+        handleCloseModal={() => {
+          setExpanded({ ...expanded, aboutModal: false });
+        }}
         isModalOpen={expanded.aboutModal}
       />
     </>
   );
 };
-
-export default KaotoToolbar;

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -21,7 +21,7 @@ interface ISourceCodeEditor {
   syncAction?: () => {};
 }
 
-const SourceCodeEditor = (props: ISourceCodeEditor) => {
+export const SourceCodeEditor = (props: ISourceCodeEditor) => {
   const editorRef = useRef<Parameters<EditorDidMount>[0] | null>(null);
   const { sourceCode, setSourceCode } = useIntegrationSourceStore();
   const [syncedCode, setSyncedCode] = useState('');
@@ -42,7 +42,7 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
     : '';
 
   useEffect(() => {
-    if (previousFlows === flows || !Array.isArray(flows[0].steps)) return;
+    if (previousFlows === flows || !Array.isArray(flows[0]?.steps)) return;
 
     if (flows[0].dsl !== null && flows[0].dsl !== settings.dsl.name) {
       fetchCapabilities().then((capabilities: ICapabilities) => {
@@ -239,5 +239,3 @@ const SourceCodeEditor = (props: ISourceCodeEditor) => {
     </StepErrorBoundary>
   );
 };
-
-export { SourceCodeEditor };

--- a/src/layout/AppLayout.test.tsx
+++ b/src/layout/AppLayout.test.tsx
@@ -1,33 +1,37 @@
-import { fetchBackendVersion } from '@kaoto/api';
-import { act, render } from '@testing-library/react';
 import { AppLayout } from './AppLayout';
+import { fetchBackendVersion, fetchCapabilities } from '@kaoto/api';
+import { useSettingsStore } from '@kaoto/store';
+import { act, render } from '@testing-library/react';
 
 jest.mock('@kaoto/api', () => {
   const actual = jest.requireActual('@kaoto/api');
 
-  return ({
+  return {
     ...actual,
     fetchBackendVersion: jest.fn(),
-  });
+    fetchCapabilities: jest.fn(),
+  };
 });
 
 describe('AppLayout.tsx', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     (fetchBackendVersion as jest.Mock).mockRejectedValue(null);
+    (fetchCapabilities as jest.Mock).mockResolvedValue([]);
   });
 
   afterEach(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
     (fetchBackendVersion as jest.Mock).mockClear();
+    (fetchCapabilities as jest.Mock).mockClear();
   });
 
   test('component renders in loading mode', async () => {
     const wrapper = render(
       <AppLayout>
         <span data-testid="children">This is a placeholder</span>
-      </AppLayout>
+      </AppLayout>,
     );
 
     const element = wrapper.queryByTestId('children');
@@ -38,7 +42,7 @@ describe('AppLayout.tsx', () => {
     const wrapper = render(
       <AppLayout>
         <span data-testid="children">This is a placeholder</span>
-      </AppLayout>
+      </AppLayout>,
     );
 
     for (let i = 0; i <= 120; i++) {
@@ -57,7 +61,7 @@ describe('AppLayout.tsx', () => {
     const wrapper = render(
       <AppLayout>
         <span data-testid="children">This is a placeholder</span>
-      </AppLayout>
+      </AppLayout>,
     );
 
     await act(async () => {
@@ -66,5 +70,53 @@ describe('AppLayout.tsx', () => {
 
     const element = wrapper.queryByText('This is a placeholder');
     expect(element).toBeInTheDocument();
+  });
+
+  test('component fetch capabilities and saves it to the settings store', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockResolvedValueOnce({
+      dsls: [
+        {
+          output: 'true',
+          input: 'true',
+          validationSchema: '/v1/capabilities/Integration/schema',
+          deployable: 'true',
+          name: 'Integration',
+          description: 'An Integration defines a workflow of actions and steps.',
+          'step-kinds': '[CAMEL-CONNECTOR, EIP, EIP-BRANCH]',
+        },
+      ],
+    });
+
+    render(
+      <AppLayout>
+        <span data-testid="children">This is a placeholder</span>
+      </AppLayout>,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_100);
+    });
+
+    expect(useSettingsStore.getState().settings.capabilities[0].name).toEqual('Integration');
+  });
+
+  test('component fetch capabilities and errors out', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockRejectedValueOnce(new Error('Wild error!'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+
+    render(
+      <AppLayout>
+        <span data-testid="children">This is a placeholder</span>
+      </AppLayout>,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_100);
+    });
+
+    expect(useSettingsStore.getState().settings.capabilities).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith('Error when fetching capabilities', expect.any(Error));
   });
 });

--- a/src/services/FlowsService.test.ts
+++ b/src/services/FlowsService.test.ts
@@ -1,0 +1,44 @@
+import { FlowsService } from './FlowsService';
+
+describe('FlowsService', () => {
+  it('should generate a new flow', () => {
+    const newFlow = FlowsService.getNewFlow('Integration');
+
+    expect(newFlow).toMatchObject({
+      id: /Integration-[0-9]*/,
+      dsl: 'Integration',
+      description: '',
+      metadata: {},
+      params: [],
+      steps: [],
+    });
+  });
+
+  it('should generate a new flow with the provided ID', () => {
+    const newFlow = FlowsService.getNewFlow('Integration', 'Arbitrary-Id');
+
+    expect(newFlow).toMatchObject({
+      id: 'Arbitrary-Id',
+      dsl: 'Integration',
+      description: '',
+      metadata: {},
+      params: [],
+      steps: [],
+    });
+  });
+
+  it('should generate a new flow with the provided metadata', () => {
+    const newFlow = FlowsService.getNewFlow('Integration', 'Arbitrary-Id', {
+      metadata: { prop1: 100 },
+    });
+
+    expect(newFlow).toMatchObject({
+      id: 'Arbitrary-Id',
+      dsl: 'Integration',
+      description: '',
+      metadata: { prop1: 100 },
+      params: [],
+      steps: [],
+    });
+  });
+});

--- a/src/services/FlowsService.ts
+++ b/src/services/FlowsService.ts
@@ -1,0 +1,28 @@
+import { IIntegration } from '@kaoto/types';
+import { getRandomArbitraryNumber } from '@kaoto/utils';
+
+/**
+ * Flows Store Service
+ *
+ * This class cannot import the FlowsStore as this class its meant
+ * for generating static data or to calculate outputs based on the
+ * input methods.
+ */
+export class FlowsService {
+  static getNewFlow(
+    dsl: string,
+    flowId?: string,
+    options?: { metadata: IIntegration['metadata'] },
+  ): IIntegration {
+    const id = flowId ?? `${dsl}-${getRandomArbitraryNumber()}`;
+
+    return {
+      id,
+      dsl,
+      description: '',
+      metadata: options?.metadata ?? {},
+      params: [],
+      steps: [],
+    };
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
-export { StepsService } from "./stepsService";
+export { FlowsService } from './FlowsService';
+export { StepsService } from './stepsService';
 export { ValidationService } from './validationService';
 export { VisualizationService } from './visualizationService';

--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -36,9 +36,14 @@ import {
   IVizStepNode,
   IVizStepNodeData,
 } from '@kaoto/types';
+import { FlowsService } from './FlowsService';
 
 describe('stepsService', () => {
   const stepsService = new StepsService();
+
+  beforeEach(() => {
+    useFlowsStore.setState({ flows: [FlowsService.getNewFlow('Camel Route', 'Camel Route-1')] });
+  });
 
   it('addBranch(): should add a branch to the specified step from the store', () => {
     useFlowsStore.setState({

--- a/src/store/FlowsStore.test.ts
+++ b/src/store/FlowsStore.test.ts
@@ -1,0 +1,152 @@
+import { initialFlows, kameletSourceStepStub } from '../stubs';
+import { useFlowsStore } from './FlowsStore';
+import { StepsService } from '@kaoto/services';
+import { IFlowsWrapper, IViewProps } from '@kaoto/types';
+
+describe('FlowsStoreFacade', () => {
+  it('should start with a default value', () => {
+    const initialState = useFlowsStore.getState();
+
+    expect(initialState).toMatchObject({
+      flows: [
+        {
+          id: /Camel Route-[0-9]*/,
+          dsl: 'Camel Route',
+          description: '',
+          metadata: {},
+          params: [],
+          steps: [],
+        },
+      ],
+      properties: {},
+      views: [],
+      metadata: {},
+    });
+  });
+
+  it('should allow consumers to add a new flow', () => {
+    useFlowsStore.getState().addNewFlow('Integration');
+
+    expect(useFlowsStore.getState().flows).toMatchObject([
+      {
+        description: '',
+        dsl: 'Camel Route',
+        id: /Camel Route-[0-9]*/,
+        metadata: {
+          name: 'integration',
+          namespace: '',
+        },
+        params: [],
+        steps: [],
+      },
+      {
+        description: '',
+        dsl: 'Integration',
+        id: /Integration-[0-9]*/,
+        metadata: {},
+        params: [],
+        steps: [],
+      },
+    ]);
+  });
+
+  it('should allow consumers to add a new flow with a given ID', () => {
+    useFlowsStore.getState().addNewFlow('Integration', 'Arbitrary ID');
+
+    expect(useFlowsStore.getState().flows).toMatchObject([
+      {
+        description: '',
+        dsl: 'Camel Route',
+        id: /Camel Route-[0-9]*/,
+        metadata: {
+          name: 'integration',
+          namespace: '',
+        },
+        params: [],
+        steps: [],
+      },
+      {
+        description: '',
+        dsl: 'Integration',
+        id: 'Arbitrary ID',
+        metadata: {},
+        params: [],
+        steps: [],
+      },
+    ]);
+  });
+
+  it('should allow consumers to update views', () => {
+    useFlowsStore
+      .getState()
+      .updateViews([{ id: 'ID1', name: 'View Name', type: 'STEP' }] as IViewProps[]);
+
+    expect(useFlowsStore.getState().views).toMatchObject([
+      { id: 'ID1', name: 'View Name', type: 'STEP' },
+    ]);
+  });
+
+  it('should extract nested steps upon setting the Flows wrapper object', () => {
+    const extractNestedStepsSpy = jest.spyOn(StepsService, 'extractNestedSteps');
+
+    useFlowsStore.getState().setFlowsWrapper({
+      flows: [{ ...initialFlows[0], steps: [kameletSourceStepStub] }],
+      metadata: {},
+      properties: {},
+    } as IFlowsWrapper);
+
+    expect(extractNestedStepsSpy).toHaveBeenCalledTimes(1);
+    expect(extractNestedStepsSpy).toHaveBeenCalledWith([
+      {
+        ...kameletSourceStepStub,
+        UUID: 'Camel Route-0_timer-source-0',
+        integrationId: 'Camel Route-0',
+      },
+    ]);
+  });
+
+  it('should allow consumers to set the Flows wrapper object', () => {
+    useFlowsStore.getState().setFlowsWrapper({
+      flows: [{ ...initialFlows[0], steps: [kameletSourceStepStub] }],
+      metadata: {},
+      properties: {},
+    } as IFlowsWrapper);
+
+    expect(useFlowsStore.getState().flows).toMatchObject([
+      {
+        dsl: 'Camel Route',
+        id: 'Camel Route-0',
+        metadata: {
+          name: 'integration',
+          namespace: '',
+        },
+        params: [],
+        steps: [
+          {
+            UUID: 'Camel Route-0_timer-source-0',
+            branches: [],
+            description: 'Produces periodic messages with a custom payload.',
+            group: 'Timer',
+            icon: 'data:image/svg+xml;base64,',
+            id: 'timer-source',
+            integrationId: 'Camel Route-0',
+            kind: 'Kamelet',
+            maxBranches: 1,
+            minBranches: 0,
+            name: 'timer-source',
+            parameters: [],
+            required: [],
+            title: 'Timer Source',
+            type: 'START',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should allow consumers to delete all flows', () => {
+    useFlowsStore.getState().deleteAllFlows();
+
+    expect(useFlowsStore.getState().flows).toHaveLength(0);
+  });
+});

--- a/src/store/FlowsStoreFacade.test.ts
+++ b/src/store/FlowsStoreFacade.test.ts
@@ -1,0 +1,35 @@
+import { IFlowsStore, useFlowsStore } from './FlowsStore';
+import { FlowsStoreFacade } from './FlowsStoreFacade';
+import { IIntegration } from '@kaoto/types';
+
+describe('FlowsStoreFacade', () => {
+  it('should return "true" if all existing flows are the same as the provided type', () => {
+    useFlowsStore.setState({
+      flows: [{ dsl: 'Integration' }, { dsl: 'Integration' }],
+    } as IFlowsStore);
+
+    const isSameDsl = FlowsStoreFacade.isSameDsl('Integration');
+
+    expect(isSameDsl).toBeTruthy();
+  });
+
+  it('should return "true" if there is no flows', () => {
+    useFlowsStore.setState({
+      flows: [] as IIntegration[],
+    } as IFlowsStore);
+
+    const isSameDsl = FlowsStoreFacade.isSameDsl('Integration');
+
+    expect(isSameDsl).toBeTruthy();
+  });
+
+  it('should return "false" if not all existing flows are the same as the provided type', () => {
+    useFlowsStore.setState({
+      flows: [{ dsl: 'Integration' }, { dsl: 'Integration' }],
+    } as IFlowsStore);
+
+    const isSameDsl = FlowsStoreFacade.isSameDsl('Kamelet');
+
+    expect(isSameDsl).toBeFalsy();
+  });
+});

--- a/src/store/FlowsStoreFacade.ts
+++ b/src/store/FlowsStoreFacade.ts
@@ -1,0 +1,16 @@
+import { useFlowsStore } from '@kaoto/store';
+
+/**
+ * Flows Store Facade
+ *
+ * In this class should only be accessors for mapped properties
+ * from the flowsStore.
+ *
+ * The purpose of this facade is to avoid the circular dependency
+ * between the store and the service.
+ */
+export class FlowsStoreFacade {
+  static isSameDsl(dsl: string): boolean {
+    return useFlowsStore.getState().flows.every((flow) => flow.dsl === dsl);
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import { useDeploymentStore } from './deploymentStore';
-import { useFlowsStore } from './flowsStore';
+import { useFlowsStore } from './FlowsStore';
 import { useIntegrationSourceStore } from './integrationSourceStore';
 import { useNestedStepsStore } from './nestedStepsStore';
 import { useSettingsStore } from './settingsStore';
@@ -16,7 +16,8 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 export * from './deploymentStore';
-export * from './flowsStore';
+export * from './FlowsStore';
+export * from './FlowsStoreFacade';
 export * from './integrationSourceStore';
 export * from './nestedStepsStore';
 export * from './settingsStore';

--- a/src/store/settingsStore.test.tsx
+++ b/src/store/settingsStore.test.tsx
@@ -25,12 +25,12 @@ describe('settingsStore', () => {
 
   it('setBackendVersion', () => {
     const { result } = renderHook(() => useSettingsStore());
-    expect(result.current.backendVersion).toEqual('');
+    expect(result.current.settings.backendVersion).toEqual('');
 
     act(() => {
-      result.current.setBackendVersion('1.0-test');
+      result.current.setSettings({ backendVersion: '1.0-test' });
     });
 
-    expect(result.current.backendVersion).toEqual('1.0-test');
+    expect(result.current.settings.backendVersion).toEqual('1.0-test');
   });
 });

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -8,8 +8,6 @@ const isUILightMode = localStorage.getItem(LOCAL_STORAGE_UI_THEME_KEY) ?? 'true'
 interface ISettingsStore {
   settings: ISettings;
   setSettings: (vals?: Partial<ISettings>) => void;
-  backendVersion: string;
-  setBackendVersion: (backendVersion: string) => void;
 }
 
 export const initDsl: IDsl = {
@@ -31,6 +29,8 @@ export const initialSettings: ISettings = {
   editorIsLightMode: localStorage.getItem(LOCAL_STORAGE_EDITOR_THEME_KEY) === 'true',
   uiLightMode: isUILightMode === 'true',
   editorMode: CodeEditorMode.FREE_EDIT,
+  backendVersion: '',
+  capabilities: [],
 };
 
 export const useSettingsStore = create<ISettingsStore>((set) => ({
@@ -39,10 +39,4 @@ export const useSettingsStore = create<ISettingsStore>((set) => ({
     set((state) => ({
       settings: { ...state.settings, ...vals },
     })),
-  backendVersion: '',
-  setBackendVersion: (backendVersion: string) => {
-    set(() => ({
-      backendVersion: backendVersion,
-    }));
-  },
 }));

--- a/src/stubs/dsl.ts
+++ b/src/stubs/dsl.ts
@@ -1,0 +1,44 @@
+import { ICapabilities } from '@kaoto/types';
+
+export const capabilitiesStub: ICapabilities = {
+  dsls: [
+    {
+      output: 'true',
+      input: 'true',
+      validationSchema: '/v1/capabilities/Integration/schema',
+      deployable: 'true',
+      name: 'Integration',
+      description: 'An Integration defines a workflow of actions and steps.',
+      stepKinds: '[CAMEL-CONNECTOR, EIP, EIP-BRANCH]',
+    },
+    {
+      output: 'true',
+      input: 'true',
+      validationSchema: '/v1/capabilities/Camel Route/schema',
+      deployable: 'false',
+      name: 'Camel Route',
+      description: 'A camel route is a non deployable in cluster workflow of actions and steps.',
+      stepKinds: '[CAMEL-CONNECTOR, EIP, EIP-BRANCH]',
+    },
+    {
+      output: 'true',
+      input: 'true',
+      validationSchema: '/v1/capabilities/Kamelet/schema',
+      deployable: 'true',
+      name: 'Kamelet',
+      description:
+        'A Kamelet is a snippet of a route. It defines meta building blocks or steps that can be reused on integrations.',
+      stepKinds: '[CAMEL-CONNECTOR, EIP, EIP-BRANCH]',
+    },
+    {
+      output: 'true',
+      input: 'true',
+      validationSchema: '/v1/capabilities/KameletBinding/schema',
+      deployable: 'true',
+      name: 'KameletBinding',
+      description:
+        'Kamelet Bindings are used to create simple integrations that link a start step to an end step with optional intermediate action steps.',
+      stepKinds: '[KAMELET, KNATIVE]',
+    },
+  ],
+};

--- a/src/stubs/index.ts
+++ b/src/stubs/index.ts
@@ -1,4 +1,5 @@
 export * from './debezium-mongodb.step';
+export * from './dsl';
 export * from './initial-flows';
 export * from './integration-steps';
 export * from './steps';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,14 @@ export interface ISettings {
   name: string;
   // Cluster namespace
   namespace: string;
+
+  /** Current backend version */
+  backendVersion: string;
+  /**
+   * All capabilities supported by the backend regardless
+   * of the current steps.
+   */
+  capabilities: IDsl[];
 }
 
 export interface ICapabilities {


### PR DESCRIPTION
### Context
Currently, there is no mechanism to create a new flow in the canvas despite now the backend supporting such a feature.

This pull request adds the capability to create a new flow directly from the Toolbar.

### Changes:
* Remove the `Integration name` component from the `Toolbar`
* Add a new dropdown to select the new flow dsl
    * In case of the dsl of the existing flows is  the same as the new one, a new flow is created
    * On the contrary,  a modal is displayed to warn the user that the current flows will be lost
* In order to make the toolbar buttons more user-friendly, we're adding text to each of them, to convey their purpose easily.

### Demo

#### Create a new flow
https://github.com/KaotoIO/kaoto-ui/assets/16512618/23c065ac-e599-4513-99c1-f96e4db38d87

#### Changing flow type
https://github.com/KaotoIO/kaoto-ui/assets/16512618/83cd5505-cb6e-4744-94f2-6405ef50d144

relates to: https://github.com/KaotoIO/kaoto-ui/issues/801