### PR TITLE
feat(flows): Add mechanism to navigate between flows

### DIFF
--- a/src/components/Catalog.stories.tsx
+++ b/src/components/Catalog.stories.tsx
@@ -1,5 +1,5 @@
 import { Catalog } from './Catalog';
-import KaotoDrawer from './KaotoDrawer';
+import { KaotoDrawer } from './KaotoDrawer';
 import { DrawerContentBody } from '@patternfly/react-core';
 import { StoryFn, Meta } from '@storybook/react';
 

--- a/src/components/DSL/DSLSelector.test.tsx
+++ b/src/components/DSL/DSLSelector.test.tsx
@@ -30,13 +30,13 @@ describe('DSLSelector.tsx', () => {
   test('component renders', () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} />);
 
-    const toggle = wrapper.queryByTestId('dsl-select');
+    const toggle = wrapper.queryByTestId('dsl-list-dropdown');
     expect(toggle).toBeInTheDocument();
   });
 
   test('should toggle list of DSLs', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -56,7 +56,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should show list of DSLs', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -69,7 +69,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should show selected value', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} selectedDsl={dsl} />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -94,7 +94,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should not have anything selected if "isStatic=true"', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} isStatic />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -122,7 +122,7 @@ describe('DSLSelector.tsx', () => {
     const wrapper = render(
       <DSLSelector onSelect={onSelect} selectedDsl={capabilitiesStub.dsls[2]} />,
     );
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -138,7 +138,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should have selected the first DSL if selectedDsl is not provided', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -154,7 +154,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should close Select when pressing ESC', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -179,7 +179,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should call onSelect callback when provided', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} isStatic />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -199,7 +199,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should not call onSelect spy when not provided', async () => {
     const wrapper = render(<DSLSelector onSelect={undefined} isStatic />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -219,7 +219,7 @@ describe('DSLSelector.tsx', () => {
 
   test('should not call onSelect spy when the selected id does not exist', async () => {
     const wrapper = render(<DSLSelector onSelect={onSelect} isStatic />);
-    const toggle = await wrapper.findByTestId('dsl-select');
+    const toggle = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {

--- a/src/components/DSL/DSLSelector.tsx
+++ b/src/components/DSL/DSLSelector.tsx
@@ -1,6 +1,6 @@
 import { useSettingsStore } from '@kaoto/store';
 import { IDsl } from '@kaoto/types';
-import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import { MenuToggle, MenuToggleAction, MenuToggleElement } from '@patternfly/react-core';
 import { Select, SelectList, SelectOption } from '@patternfly/react-core/next';
 import {
   FunctionComponent,
@@ -19,16 +19,21 @@ interface IDSLSelector extends PropsWithChildren {
 }
 
 export const DSLSelector: FunctionComponent<IDSLSelector> = (props) => {
-  const capabilities = useSettingsStore((state) => state.settings.capabilities, shallow);
+  const { capabilities, dsl } = useSettingsStore(
+    ({ settings }) => ({ capabilities: settings.capabilities, dsl: settings.dsl }),
+    shallow,
+  );
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<IDsl | undefined>(
     props.isStatic ? undefined : props.selectedDsl ?? capabilities[0],
   );
 
+  /** Toggle the DSL dropdown */
   const onToggleClick = () => {
     setIsOpen(!isOpen);
   };
 
+  /** Selecting a DSL checking the the existing flows */
   const onSelect = useCallback(
     (
       _: ReactMouseEvent<Element, MouseEvent> | undefined,
@@ -48,21 +53,38 @@ export const DSLSelector: FunctionComponent<IDSLSelector> = (props) => {
     [capabilities, props],
   );
 
+  /** Selecting the same DSL directly*/
+  const onNewSameTypeRoute = useCallback(() => {
+    onSelect(undefined, dsl.name);
+  }, [dsl.name, onSelect]);
+
   const toggle = (toggleRef: Ref<MenuToggleElement>) => (
     <MenuToggle
-      data-testid="dsl-select"
+      data-testid="dsl-list-dropdown"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
       isFullWidth
-    >
-      {props.children}
-    </MenuToggle>
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="dsl-list-btn"
+            key="dsl-list-btn"
+            data-testid="dsl-list-btn"
+            aria-label="DSL list"
+            onClick={onNewSameTypeRoute}
+          >
+            {props.children}
+          </MenuToggleAction>,
+        ],
+      }}
+    />
   );
 
   return (
     <Select
-      id="dsl-select"
+      id="dsl-list-select"
       isOpen={isOpen}
       selected={selected?.name}
       onSelect={onSelect}

--- a/src/components/DSL/NewFlow.test.tsx
+++ b/src/components/DSL/NewFlow.test.tsx
@@ -15,9 +15,22 @@ describe('NewFlow.tsx', () => {
     });
   });
 
+  test('should add a new flow with the same type upon clicking on the action button', async () => {
+    const wrapper = render(<NewFlow />)
+    const trigger = await wrapper.findByTestId('dsl-list-btn');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    expect(useFlowsStore.getState().flows).toHaveLength(1);
+    expect(useFlowsStore.getState().flows[0].dsl).toEqual('Integration');
+  });
+
   test('should add a new flow', async () => {
     const wrapper = render(<NewFlow />);
-    const trigger = await wrapper.findByText('New route');
+    const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -38,7 +51,7 @@ describe('NewFlow.tsx', () => {
     useFlowsStore.getState().addNewFlow('Integration');
 
     const wrapper = render(<NewFlow />);
-    const trigger = await wrapper.findByText('New route');
+    const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -59,7 +72,7 @@ describe('NewFlow.tsx', () => {
     useFlowsStore.getState().addNewFlow('Integration');
 
     const wrapper = render(<NewFlow />);
-    const trigger = await wrapper.findByText('New route');
+    const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -85,7 +98,7 @@ describe('NewFlow.tsx', () => {
     useFlowsStore.getState().addNewFlow('Integration');
 
     const wrapper = render(<NewFlow />);
-    const trigger = await wrapper.findByText('New route');
+    const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {
@@ -111,7 +124,7 @@ describe('NewFlow.tsx', () => {
     useFlowsStore.getState().addNewFlow('Integration');
 
     const wrapper = render(<NewFlow />);
-    const trigger = await wrapper.findByText('New route');
+    const trigger = await wrapper.findByTestId('dsl-list-dropdown');
 
     /** Open Select */
     act(() => {

--- a/src/components/DSL/NewFlow.tsx
+++ b/src/components/DSL/NewFlow.tsx
@@ -2,7 +2,6 @@ import { ConfirmationModal } from '../ConfirmationModal';
 import { DSLSelector } from './DSLSelector';
 import { FlowsStoreFacade, useFlowsStore, useSettingsStore } from '@kaoto/store';
 import { IDsl } from '@kaoto/types';
-import { Tooltip } from '@patternfly/react-core';
 import { PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, PropsWithChildren, useCallback, useState } from 'react';
 import { shallow } from 'zustand/shallow';
@@ -23,34 +22,35 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
   const [proposedDsl, setProposedNewDsl] = useState<IDsl>();
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
 
-  const checkBeforeAddNewFlow = useCallback((dsl: IDsl) => {
-    const isSameDsl = FlowsStoreFacade.isSameDsl(dsl.name);
+  const checkBeforeAddNewFlow = useCallback(
+    (dsl: IDsl) => {
+      const isSameDsl = FlowsStoreFacade.isSameDsl(dsl.name);
 
-    if (isSameDsl) {
-      /**
-       * If it's the same DSL as we have in the existing Flows list,
-       * we don't need to do anything special, just add a new flow if
-       * supported
-       */
-      addNewFlow(dsl.name);
-    } else {
-      /**
-       * If it is not the same DSL, this operation might result in
-       * removing the existing flows, so then we warn the user first
-       */
-      setProposedNewDsl(dsl);
-      setIsConfirmationModalOpen(true);
-    }
-  }, [addNewFlow]);
+      if (isSameDsl) {
+        /**
+         * If it's the same DSL as we have in the existing Flows list,
+         * we don't need to do anything special, just add a new flow if
+         * supported
+         */
+        addNewFlow(dsl.name);
+      } else {
+        /**
+         * If it is not the same DSL, this operation might result in
+         * removing the existing flows, so then we warn the user first
+         */
+        setProposedNewDsl(dsl);
+        setIsConfirmationModalOpen(true);
+      }
+    },
+    [addNewFlow],
+  );
 
   return (
     <>
-      <Tooltip content="Create a new route" position="right">
-        <DSLSelector isStatic onSelect={checkBeforeAddNewFlow}>
-          <PlusIcon />
-          <span className="pf-u-m-sm-on-lg">New route</span>
-        </DSLSelector>
-      </Tooltip>
+      <DSLSelector isStatic onSelect={checkBeforeAddNewFlow}>
+        <PlusIcon />
+        <span className="pf-u-m-sm-on-lg">New route</span>
+      </DSLSelector>
 
       <ConfirmationModal
         handleCancel={() => {

--- a/src/components/Extension.tsx
+++ b/src/components/Extension.tsx
@@ -42,5 +42,3 @@ export function Extension(props: Props) {
     </StepErrorBoundary>
   );
 }
-
-export default Extension;

--- a/src/components/Flows/FlowsList.test.tsx
+++ b/src/components/Flows/FlowsList.test.tsx
@@ -1,0 +1,99 @@
+import { FlowsList } from './FlowsList';
+import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
+import { act, fireEvent, render } from '@testing-library/react';
+
+describe('FlowsList.tsx', () => {
+  beforeEach(() => {
+    useFlowsStore.getState().deleteAllFlows();
+    useFlowsStore.getState().addNewFlow('Integration', 'route-1234');
+    useFlowsStore.getState().addNewFlow('Integration', 'route-4321');
+  });
+
+  test('should render the existing flows', async () => {
+    const wrapper = render(<FlowsList />);
+    const flows = await wrapper.findAllByTestId(/flows-list-row-*/);
+
+    expect(flows).toHaveLength(2);
+  });
+
+  test('should render the flows ids', async () => {
+    const wrapper = render(<FlowsList />);
+    const flow1 = await wrapper.findByText('route-1234');
+    const flow2 = await wrapper.findByText('route-4321');
+
+    expect(flow1).toBeInTheDocument();
+    expect(flow2).toBeInTheDocument();
+  });
+
+  test('should make the selected flow visible by clicking on its ID', async () => {
+    const wrapper = render(<FlowsList />);
+    const flowId = await wrapper.findByTestId('goto-btn-route-1234');
+
+    act(() => {
+      fireEvent.click(flowId);
+    });
+
+    expect(useVisualizationStore.getState().visibleFlows).toEqual({
+      'route-1234': true,
+      'route-4321': false,
+    });
+  });
+
+  test('should call onClose when clicking on a flow ID', async () => {
+    const onCloseSpy = jest.fn();
+    const wrapper = render(<FlowsList onClose={onCloseSpy} />);
+    const flowId = await wrapper.findByTestId('goto-btn-route-1234');
+
+    act(() => {
+      fireEvent.click(flowId);
+    });
+
+    expect(onCloseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should toggle the visibility of a flow clicking on the Eye icon', async () => {
+    useVisualizationStore.getState().hideAllFlows();
+    const wrapper = render(<FlowsList />);
+    const toggleFlowId = await wrapper.findByTestId('toggle-btn-route-1234');
+
+    act(() => {
+      fireEvent.click(toggleFlowId);
+    });
+
+    expect(useVisualizationStore.getState().visibleFlows).toEqual({
+      'route-1234': true,
+      'route-4321': false,
+    });
+  });
+
+  test('should render the appropiate Eye icon', async () => {
+    useVisualizationStore.getState().hideAllFlows();
+    const wrapper = render(<FlowsList />);
+    const toggleFlowId = await wrapper.findByTestId('toggle-btn-route-1234');
+
+    act(() => {
+      fireEvent.click(toggleFlowId);
+    });
+
+    /** Eye icon */
+    const flow1 = await wrapper.findByTestId('toggle-btn-route-1234-visible');
+    expect(flow1).toBeInTheDocument();
+
+    /** Eye slash icon */
+    const flow2 = await wrapper.findByTestId('toggle-btn-route-4321-hidden');
+    expect(flow2).toBeInTheDocument();
+  });
+
+  test('should allow to delete a flow clicking on the Trash icon', async () => {
+    useVisualizationStore.getState().hideAllFlows();
+    const wrapper = render(<FlowsList />);
+    const deleteFlowId = await wrapper.findByTestId('delete-btn-route-1234');
+
+    act(() => {
+      fireEvent.click(deleteFlowId);
+    });
+
+    expect(useFlowsStore.getState().flows).toHaveLength(1);
+    expect(useFlowsStore.getState().flows[0].id).toEqual('route-4321');
+  });
+});

--- a/src/components/Flows/FlowsList.tsx
+++ b/src/components/Flows/FlowsList.tsx
@@ -1,0 +1,100 @@
+import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
+import { Button } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon, TrashIcon } from '@patternfly/react-icons';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { FunctionComponent, useCallback, useRef } from 'react';
+import { shallow } from 'zustand/shallow';
+
+interface IFlowsList {
+  onClose?: () => void;
+}
+
+export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
+  const { flows, deleteFlow } = useFlowsStore(
+    (state) => ({
+      flows: state.flows,
+      deleteFlow: state.deleteFlow,
+    }),
+    shallow,
+  );
+
+  const { visibleFlows, toggleFlowVisible, hideAllFlows } = useVisualizationStore(
+    ({ visibleFlows, toggleFlowVisible, hideAllFlows }) => ({
+      visibleFlows,
+      toggleFlowVisible,
+      hideAllFlows,
+    }),
+    shallow,
+  );
+
+  const columnNames = useRef({
+    id: 'Route Id',
+    isVisible: 'Visibility',
+    delete: 'Delete',
+  });
+
+  const onSelectFlow = useCallback(
+    (flowId: string): void => {
+      hideAllFlows();
+      toggleFlowVisible(flowId);
+      props.onClose?.();
+    },
+    [hideAllFlows, props, toggleFlowVisible],
+  );
+
+  return (
+    <TableComposable variant="compact" data-testid="flows-list-table">
+      <Thead>
+        <Tr>
+          <Th>{columnNames.current.id}</Th>
+          <Th>{columnNames.current.isVisible}</Th>
+          <Th>{columnNames.current.delete}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {flows.map((flow) => (
+          <Tr key={flow.id} data-testid={`flows-list-row-${flow.id}`} isHoverable>
+            <Td dataLabel={columnNames.current.id}>
+              <Button
+                data-testid={`goto-btn-${flow.id}`}
+                onClick={() => {
+                  onSelectFlow(flow.id);
+                }}
+                variant="plain"
+              >
+                <p>{flow.id}</p>
+                <p>{flow.description}</p>
+              </Button>
+            </Td>
+            <Td dataLabel={columnNames.current.isVisible}>
+              <Button
+                data-testid={`toggle-btn-${flow.id}`}
+                icon={
+                  visibleFlows[flow.id] ? (
+                    <EyeIcon data-testid={`toggle-btn-${flow.id}-visible`} />
+                  ) : (
+                    <EyeSlashIcon data-testid={`toggle-btn-${flow.id}-hidden`} />
+                  )
+                }
+                variant="plain"
+                onClick={() => {
+                  toggleFlowVisible(flow.id);
+                }}
+              />
+            </Td>
+            <Td dataLabel={columnNames.current.delete}>
+              <Button
+                data-testid={`delete-btn-${flow.id}`}
+                icon={<TrashIcon />}
+                variant="plain"
+                onClick={() => {
+                  deleteFlow(flow.id);
+                }}
+              />
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </TableComposable>
+  );
+};

--- a/src/components/Flows/FlowsMenu.test.tsx
+++ b/src/components/Flows/FlowsMenu.test.tsx
@@ -1,0 +1,111 @@
+import { FlowsMenu } from './FlowsMenu';
+import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+
+describe('FlowsMenu.tsx', () => {
+  beforeEach(() => {
+    useFlowsStore.getState().deleteAllFlows();
+    useFlowsStore.getState().addNewFlow('Integration', 'route-1234');
+    useFlowsStore.getState().addNewFlow('Integration', 'route-4321');
+  });
+
+  test('should open the flows list when clicking the dropdown', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const dropdown = await wrapper.findByTestId('flows-list-dropdown');
+
+    /** Open List */
+    act(() => {
+      fireEvent.click(dropdown);
+    });
+
+    /** Wait for the List to appear */
+    waitFor(() => {
+      const flowsList = wrapper.queryByTestId('flows-list-table');
+      expect(flowsList).toBeInTheDocument();
+    });
+  });
+
+  test('should open the flows list when clicking the action button', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const dropdown = await wrapper.findByTestId('flows-list-btn');
+
+    /** Open List */
+    act(() => {
+      fireEvent.click(dropdown);
+    });
+
+    /** Wait for the List to appear */
+    waitFor(() => {
+      const flowsList = wrapper.queryByTestId('flows-list-table');
+      expect(flowsList).toBeInTheDocument();
+    });
+  });
+
+  test('should close the flows list when pressing ESC', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const dropdown = await wrapper.findByTestId('flows-list-btn');
+
+    /** Open List */
+    act(() => {
+      fireEvent.click(dropdown);
+    });
+
+    const flowsList = await wrapper.findByTestId('flows-list-table');
+    /** Press Escape key to close the menu */
+    act(() => {
+      fireEvent.focus(flowsList);
+      fireEvent.keyDown(flowsList, { key: 'Escape', code: 'Escape', charCode: 27 });
+    });
+
+    /** Wait for the List to appear */
+    waitFor(() => {
+      expect(flowsList).not.toBeInTheDocument();
+    });
+  });
+
+  test('should render the route id when a single route is visible', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const routeId = await wrapper.findByTestId('flows-list-route-id');
+
+    act(() => {
+      useVisualizationStore.getState().hideAllFlows();
+      useVisualizationStore.getState().toggleFlowVisible('route-4321', true);
+    });
+
+    expect(routeId).toHaveTextContent('route-4321');
+  });
+
+  test('should NOT render the route id but "Routes" when there is no flow visible', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const routeId = await wrapper.findByTestId('flows-list-route-id');
+
+    act(() => {
+      useVisualizationStore.getState().hideAllFlows();
+    });
+
+    expect(routeId).toHaveTextContent('Routes');
+  });
+
+  test('should NOT render the route id but "Routes" when there is more than 1 flow visible', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const routeId = await wrapper.findByTestId('flows-list-route-id');
+
+    act(() => {
+      useVisualizationStore.getState().showAllFlows();
+    });
+
+    expect(routeId).toHaveTextContent('Routes');
+  });
+
+  test('should render the visible routes count', async () => {
+    const wrapper = render(<FlowsMenu />);
+    const routeCount = await wrapper.findByTestId('flows-list-route-count');
+
+    act(() => {
+      useVisualizationStore.getState().hideAllFlows();
+      useVisualizationStore.getState().toggleFlowVisible('route-4321', true);
+    });
+
+    expect(routeCount).toHaveTextContent('1/2');
+  });
+});

--- a/src/components/Flows/FlowsMenu.tsx
+++ b/src/components/Flows/FlowsMenu.tsx
@@ -1,0 +1,70 @@
+import { FlowsList } from './FlowsList';
+import { VisualizationService } from '@kaoto/services';
+import { useVisualizationStore } from '@kaoto/store';
+import { Badge, MenuToggle, MenuToggleAction, MenuToggleElement } from '@patternfly/react-core';
+import { Select } from '@patternfly/react-core/next';
+import { ListIcon } from '@patternfly/react-icons';
+import { FunctionComponent, Ref, useState } from 'react';
+import { shallow } from 'zustand/shallow';
+
+export const FlowsMenu: FunctionComponent = () => {
+  const visibleFlowsInformation = useVisualizationStore(
+    ({ visibleFlows }) => VisualizationService.getVisibleFlowsInformation(visibleFlows),
+    shallow,
+  );
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  /** Toggle the DSL dropdown */
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+    <MenuToggle
+      data-testid="flows-list-dropdown"
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isFullWidth
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="flows-list-btn"
+            key="flows-list-btn"
+            data-testid="flows-list-btn"
+            aria-label="flows list"
+            onClick={onToggleClick}
+          >
+            <ListIcon />
+            <span data-testid="flows-list-route-id" className="pf-u-m-sm-on-lg">
+              {visibleFlowsInformation.singleFlowId ?? 'Routes'}
+            </span>
+            <Badge data-testid="flows-list-route-count" isRead>
+              {visibleFlowsInformation.currentVisible}/{visibleFlowsInformation.flowsCount}
+            </Badge>
+          </MenuToggleAction>,
+        ],
+      }}
+    />
+  );
+
+  return (
+    <Select
+      id="flows-list-select"
+      isOpen={isOpen}
+      onOpenChange={(isOpen) => {
+        setIsOpen(isOpen);
+      }}
+      toggle={toggle}
+      minWidth="300px"
+    >
+      <FlowsList
+        onClose={() => {
+          setIsOpen(false);
+        }}
+      />
+    </Select>
+  );
+};

--- a/src/components/KaotoDrawer.tsx
+++ b/src/components/KaotoDrawer.tsx
@@ -73,5 +73,3 @@ export const KaotoDrawer = ({
     </Drawer>
   );
 };
-
-export default KaotoDrawer;

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -1,14 +1,13 @@
 import logo from '../assets/images/logo-kaoto-dark.png';
 import { AboutModal } from './AboutModal';
+import { AppearanceModal } from './AppearanceModal';
+import { ConfirmationModal } from './ConfirmationModal';
 import { NewFlow } from './DSL/NewFlow';
+import { DeploymentsModal } from './DeploymentsModal';
 import { ExportCanvasToPng } from './ExportCanvasToPng';
+import { FlowsMenu } from './Flows/FlowsMenu';
+import { SettingsModal } from './SettingsModal';
 import { fetchDefaultNamespace, startDeployment } from '@kaoto/api';
-import {
-  AppearanceModal,
-  ConfirmationModal,
-  DeploymentsModal,
-  SettingsModal,
-} from '@kaoto/components';
 import { LOCAL_STORAGE_UI_THEME_KEY, THEME_DARK_CLASS } from '@kaoto/constants';
 import {
   useDeploymentStore,
@@ -317,6 +316,11 @@ export const KaotoToolbar = ({
           {/* NEW FLOW DROPDOWN BUTTON */}
           <ToolbarItem>
             <NewFlow />
+          </ToolbarItem>
+
+          {/* FLOWS LIST DROPDOWN BUTTON */}
+          <ToolbarItem>
+            <FlowsMenu />
           </ToolbarItem>
 
           <ToolbarItem variant="separator" />

--- a/src/components/PlusButtonEdge.tsx
+++ b/src/components/PlusButtonEdge.tsx
@@ -1,5 +1,6 @@
+import { BranchBuilder } from './BranchBuilder';
 import './CustomEdge.css';
-import { BranchBuilder, MiniCatalog } from '@kaoto/components';
+import { MiniCatalog } from './MiniCatalog';
 import { usePosition, useShowBranchTab } from '@kaoto/hooks';
 import { StepsService, ValidationService } from '@kaoto/services';
 import { useFlowsStore } from '@kaoto/store';
@@ -55,7 +56,7 @@ const PlusButtonEdge = ({
   const views = useFlowsStore((state) => state.views, shallow);
   const { disableBranchesTab, disableBranchesTabMsg } = useShowBranchTab(
     sourceNode?.data.step,
-    views
+    views,
   );
 
   const [edgePath, edgeCenterX, edgeCenterY] = getBezierPath({
@@ -106,7 +107,7 @@ const PlusButtonEdge = ({
                 queryParams={{
                   type: ValidationService.insertableStepTypes(
                     sourceNode?.data.step,
-                    targetNode?.data.step
+                    targetNode?.data.step,
                   ),
                   previousStep: sourceNode?.data.step.id,
                   followingStep: targetNode?.data.step.id,

--- a/src/components/SourceCodeEditor.tsx
+++ b/src/components/SourceCodeEditor.tsx
@@ -1,5 +1,5 @@
+import { StepErrorBoundary } from './StepErrorBoundary';
 import { fetchCapabilities, fetchIntegrationJson, fetchIntegrationSourceCode } from '@kaoto/api';
-import { StepErrorBoundary } from '@kaoto/components';
 import { useFlowsStore, useIntegrationSourceStore, useSettingsStore } from '@kaoto/store';
 import { CodeEditorMode, ICapabilities, IFlowsWrapper, ISettings } from '@kaoto/types';
 import { usePrevious } from '@kaoto/utils';
@@ -15,7 +15,7 @@ interface ISourceCodeEditor {
   initialData?: string;
   language?: Language;
   theme?: string;
-  mode?: CodeEditorMode | CodeEditorMode.FREE_EDIT;
+  mode?: CodeEditorMode;
   schemaUri?: string;
   editable?: boolean | false;
   syncAction?: () => {};
@@ -33,7 +33,7 @@ export const SourceCodeEditor = (props: ISourceCodeEditor) => {
       metadata,
       setFlowsWrapper,
     }),
-    shallow
+    shallow,
   );
   const previousFlows = usePrevious(flows);
 
@@ -48,7 +48,7 @@ export const SourceCodeEditor = (props: ISourceCodeEditor) => {
       fetchCapabilities().then((capabilities: ICapabilities) => {
         capabilities.dsls.forEach((dsl) => {
           if (dsl.name === flows[0].dsl) {
-            const tmpSettings = { ...settings, dsl: dsl };
+            const tmpSettings = { ...settings, dsl };
             setSettings(tmpSettings);
             fetchTheSourceCode({ flows, properties, metadata }, tmpSettings);
           }
@@ -64,7 +64,6 @@ export const SourceCodeEditor = (props: ISourceCodeEditor) => {
       ...currentFlowsWrapper,
       flows: currentFlowsWrapper.flows.map((flow) => ({
         ...flow,
-        metadata: { ...flow.metadata, ...settings },
         dsl: settings.dsl.name,
       })),
     };
@@ -90,7 +89,6 @@ export const SourceCodeEditor = (props: ISourceCodeEditor) => {
           settings.name = tmpInt.metadata.name;
           setSettings({ name: tmpInt.metadata.name });
         }
-        tmpInt.metadata = { ...tmpInt.metadata, ...settings };
         setFlowsWrapper(flowsWrapper);
       })
       .catch((e) => {
@@ -119,7 +117,7 @@ export const SourceCodeEditor = (props: ISourceCodeEditor) => {
     editor?.onDidAttemptReadOnlyEdit(() => {
       messageContribution?.showMessage(
         'Cannot edit in read-only editor mode.',
-        editor.getPosition()
+        editor.getPosition(),
       );
     });
 

--- a/src/components/VisualizationStep.tsx
+++ b/src/components/VisualizationStep.tsx
@@ -1,8 +1,8 @@
 import { AppendStepButton } from './AppendStepButton';
 import { BranchBuilder } from './BranchBuilder';
+import { MiniCatalog } from './MiniCatalog';
 import { PrependStepButton } from './PrependStepButton';
 import './Visualization.css';
-import { MiniCatalog } from '@kaoto/components';
 import { usePosition } from '@kaoto/hooks';
 import { StepsService, VisualizationService } from '@kaoto/services';
 import { useSettingsStore, useVisualizationStore } from '@kaoto/store';
@@ -104,7 +104,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     return VisualizationService.getNodeClass(
       visualizationStore.selectedStepUuid,
       data.step.UUID,
-      ' stepNode__Selected'
+      ' stepNode__Selected',
     );
   };
 
@@ -112,7 +112,7 @@ const VisualizationStep = ({ data }: NodeProps<IVizStepNodeData>) => {
     return VisualizationService.getNodeClass(
       visualizationStore.hoverStepUuid,
       data.branchInfo?.rootStepUuid ?? data.step.UUID,
-      ' stepNode__Hover'
+      ' stepNode__Hover',
     );
   };
 

--- a/src/components/VisualizationStepViews.test.tsx
+++ b/src/components/VisualizationStepViews.test.tsx
@@ -1,11 +1,11 @@
-import { JsonSchemaConfigurator } from '@kaoto/components';
+import { JsonSchemaConfigurator } from './JsonSchemaConfigurator';
 import { act, fireEvent, render } from '@testing-library/react';
 import { AlertProvider } from '../layout';
 import { debeziumMongoDBStep } from '../stubs';
 import { VisualizationStepViews } from './VisualizationStepViews';
 
-jest.mock('@kaoto/components', () => {
-  const actual = jest.requireActual('@kaoto/components');
+jest.mock('./JsonSchemaConfigurator', () => {
+  const actual = jest.requireActual('./JsonSchemaConfigurator');
 
   const JsonSchemaConfiguratorMock: typeof JsonSchemaConfigurator = (props) => (<>
     <p>JsonSchemaConfigurator mock</p>

--- a/src/components/VisualizationStepViews.tsx
+++ b/src/components/VisualizationStepViews.tsx
@@ -1,5 +1,7 @@
+import { Extension } from './Extension';
+import { JsonSchemaConfigurator } from './JsonSchemaConfigurator';
+import { StepErrorBoundary } from './StepErrorBoundary';
 import { dynamicImport } from './import';
-import { Extension, JsonSchemaConfigurator, StepErrorBoundary } from '@kaoto/components';
 import { StepsService } from '@kaoto/services';
 import { useFlowsStore } from '@kaoto/store';
 import { IStepProps, IStepPropsParameters } from '@kaoto/types';
@@ -34,8 +36,14 @@ const VisualizationStepViews = ({
   saveConfig,
   step,
 }: IStepViewsProps) => {
-  const debouncedSaveConfig = useDebouncedCallback(saveConfig, 1_000, { leading: false, trailing: true });
-  const views = useFlowsStore((state) => state.views.filter((view) => view.step === step.UUID), shallow);
+  const debouncedSaveConfig = useDebouncedCallback(saveConfig, 1_000, {
+    leading: false,
+    trailing: true,
+  });
+  const views = useFlowsStore(
+    (state) => state.views.filter((view) => view.step === step.UUID),
+    shallow,
+  );
 
   const hasDetailView = views?.some((v) => v.id === 'detail-step');
   const detailsTabIndex = views?.length! + 1; // provide an index that won't be used by custom views
@@ -81,15 +89,14 @@ const VisualizationStepViews = ({
   };
 
   useEffect(() => {
-    setActiveTabKey(()=>
-    step.parameters?.length ? configTabIndex : detailsTabIndex);
+    setActiveTabKey(() => (step.parameters?.length ? configTabIndex : detailsTabIndex));
     let tempSchemaObject: { [label: string]: { type: string; value?: any; description?: string } } =
       {};
 
     let tempModelObject = {} as IStepPropsParameters;
 
     step.parameters?.forEach((p) =>
-      StepsService.buildStepSchemaAndModel(p, tempModelObject, tempSchemaObject)
+      StepsService.buildStepSchemaAndModel(p, tempModelObject, tempSchemaObject),
     );
 
     setStepPropertySchema(tempSchemaObject);
@@ -165,7 +172,13 @@ const VisualizationStepViews = ({
           {views?.length! > 0 &&
             views?.map((view, index) => {
               const StepExtension = lazy(() => dynamicImport(view.scope, view.module, view.url));
-              const kaotoApi = stepsService.createKaotoApi(step, (values) => {saveConfig(step, values)}, alertKaoto);
+              const kaotoApi = stepsService.createKaotoApi(
+                step,
+                (values) => {
+                  saveConfig(step, values);
+                },
+                alertKaoto,
+              );
 
               return (
                 <Tab

--- a/src/layout/ErrorBoundary.tsx
+++ b/src/layout/ErrorBoundary.tsx
@@ -25,5 +25,3 @@ export class ErrorBoundary extends Component<Props, State> {
     return this.props.children;
   }
 }
-
-export default ErrorBoundary;

--- a/src/services/FlowsService.test.ts
+++ b/src/services/FlowsService.test.ts
@@ -5,7 +5,7 @@ describe('FlowsService', () => {
     const newFlow = FlowsService.getNewFlow('Integration');
 
     expect(newFlow).toMatchObject({
-      id: /Integration-[0-9]*/,
+      id: /Integration-\d*/,
       dsl: 'Integration',
       description: '',
       metadata: {},

--- a/src/services/FlowsService.ts
+++ b/src/services/FlowsService.ts
@@ -14,7 +14,8 @@ export class FlowsService {
     flowId?: string,
     options?: { metadata: IIntegration['metadata'] },
   ): IIntegration {
-    const id = flowId ?? `${dsl}-${getRandomArbitraryNumber()}`;
+    const randomNumber = getRandomArbitraryNumber();
+    const id = flowId ?? `route-${randomNumber.toString(10).slice(0, 4)}`;
 
     return {
       id,

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -1,9 +1,6 @@
 import { StepsService } from './stepsService';
 import { ValidationService } from './validationService';
-import {
-  useFlowsStore,
-  useVisualizationStore,
-} from '@kaoto/store';
+import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
 import {
   HandleDeleteStepFn,
   IStepProps,
@@ -40,7 +37,7 @@ export class VisualizationService {
     step: IStepProps,
     nodeId: string,
     layout: string,
-    dataProps?: { [prop: string]: any }
+    dataProps?: { [prop: string]: any },
   ): IVizStepNode {
     return {
       data: {
@@ -71,7 +68,7 @@ export class VisualizationService {
     node: IVizStepNode,
     rootNode: IVizStepNode,
     rootNextNode: IVizStepNode,
-    edgeType?: string
+    edgeType?: string,
   ): IVizStepPropsEdge[] {
     const branchPlaceholderEdges: IVizStepPropsEdge[] = [];
     let edgeProps = VisualizationService.buildEdgeParams(rootNode, node, edgeType ?? 'default');
@@ -83,7 +80,7 @@ export class VisualizationService {
 
     if (rootNextNode) {
       branchPlaceholderEdges.push(
-        VisualizationService.buildEdgeParams(node, rootNextNode, 'default')
+        VisualizationService.buildEdgeParams(node, rootNextNode, 'default'),
       );
     }
 
@@ -102,7 +99,7 @@ export class VisualizationService {
 
       const parentNodeIndex = VisualizationService.findNodeIdxWithUUID(
         node.data.branchInfo?.parentStepUuid,
-        stepNodes
+        stepNodes,
       );
 
       if (node.data.branchInfo) {
@@ -115,11 +112,11 @@ export class VisualizationService {
         ) {
           const branchStepNextIdx = VisualizationService.findNodeIdxWithUUID(
             node.data.nextStepUuid,
-            stepNodes
+            stepNodes,
           );
           if (stepNodes[branchStepNextIdx]) {
             specialEdges.push(
-              VisualizationService.buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert')
+              VisualizationService.buildEdgeParams(node, stepNodes[branchStepNextIdx], 'insert'),
             );
           }
         }
@@ -129,12 +126,12 @@ export class VisualizationService {
           const parentStepNode: IVizStepNode = stepNodes[parentNodeIndex];
           const showDeleteEdge = ValidationService.reachedMinBranches(
             parentStepNode.data.step.branches.length,
-            parentStepNode.data.step.minBranches
+            parentStepNode.data.step.minBranches,
           );
           let edgeProps = VisualizationService.buildEdgeParams(
             parentStepNode,
             node,
-            showDeleteEdge ? 'delete' : 'default'
+            showDeleteEdge ? 'delete' : 'default',
           );
 
           if (node.data.branchInfo?.branchIdentifier)
@@ -148,11 +145,11 @@ export class VisualizationService {
           const parentStepNode: IVizStepNode = stepNodes[parentNodeIndex];
           const parentStepNextIdx = VisualizationService.findNodeIdxWithUUID(
             node.data.branchInfo?.parentStepNextUuid,
-            stepNodes
+            stepNodes,
           );
           const showDeleteEdge = ValidationService.reachedMinBranches(
             parentStepNode.data.step.branches.length,
-            parentStepNode.data.step.minBranches
+            parentStepNode.data.step.minBranches,
           );
 
           specialEdges.push(
@@ -160,8 +157,8 @@ export class VisualizationService {
               node,
               stepNodes[parentNodeIndex],
               stepNodes[parentStepNextIdx],
-              showDeleteEdge ? 'delete' : 'default'
-            )
+              showDeleteEdge ? 'delete' : 'default',
+            ),
           );
         }
 
@@ -169,13 +166,13 @@ export class VisualizationService {
         if (node.data.isLastStep && !StepsService.isEndStep(node.data.step)) {
           const parentStepNextIdx = VisualizationService.findNodeIdxWithUUID(
             node.data.branchInfo?.parentStepNextUuid,
-            stepNodes
+            stepNodes,
           );
 
           if (stepNodes[parentStepNextIdx]) {
             // it needs to merge back
             specialEdges.push(
-              VisualizationService.buildEdgeParams(node, stepNodes[parentStepNextIdx], 'default')
+              VisualizationService.buildEdgeParams(node, stepNodes[parentStepNextIdx], 'default'),
             );
           }
         }
@@ -193,7 +190,7 @@ export class VisualizationService {
   static buildEdgeParams(
     sourceStep: IVizStepNode,
     targetStep: IVizStepNode,
-    type?: string
+    type?: string,
   ): IVizStepPropsEdge {
     return {
       arrowHeadType: 'arrowclosed',
@@ -235,8 +232,8 @@ export class VisualizationService {
           VisualizationService.buildEdgeParams(
             node,
             nodes[nextNodeIdx],
-            node.data.branchInfo || node.data.step.branches?.length > 0 ? 'default' : 'insert'
-          )
+            node.data.branchInfo || node.data.step.branches?.length > 0 ? 'default' : 'insert',
+          ),
         );
       }
     });
@@ -248,7 +245,7 @@ export class VisualizationService {
     step: IStepProps,
     newId: string,
     props?: { [prop: string]: any },
-    branchInfo?: IVizStepNodeDataBranch
+    branchInfo?: IVizStepNodeDataBranch,
   ): IVizStepNode {
     return {
       data: {
@@ -274,21 +271,22 @@ export class VisualizationService {
    * Builds React Flow nodes and edges from current integration JSON.
    * @param handleDeleteStep
    */
-  buildNodesAndEdges(handleDeleteStep: HandleDeleteStepFn) {
-    const layout = useVisualizationStore.getState().layout;
+  private buildNodesAndEdges(handleDeleteStep: HandleDeleteStepFn) {
+    const { layout, visibleFlows } = useVisualizationStore.getState();
 
     // build all nodes
     let stepNodes: IVizStepNode[] = [];
 
-    const integrations = useFlowsStore.getState().flows;
-    stepNodes = integrations.reduce((acc, currentIntegration) => acc.concat(
-      VisualizationService.buildNodesFromSteps(
-        currentIntegration.id,
-        currentIntegration.steps,
-        layout,
-        { handleDeleteStep },
-      ),
-    ), [] as IVizStepNode[]);
+    const flows = useFlowsStore.getState().flows;
+    stepNodes = flows.reduce((acc, flow) => {
+      if (!visibleFlows[flow.id]) {
+        return acc;
+      }
+
+      return acc.concat(
+        VisualizationService.buildNodesFromSteps(flow.id, flow.steps, layout, { handleDeleteStep }),
+      );
+    }, [] as IVizStepNode[]);
 
     // build edges only for main nodes
     const filteredNodes = stepNodes.filter((node) => !node.data.branchInfo);
@@ -312,7 +310,7 @@ export class VisualizationService {
     steps: IStepProps[],
     layout: string,
     props?: { [prop: string]: any },
-    branchInfo?: IVizStepNodeDataBranch
+    branchInfo?: IVizStepNodeDataBranch,
   ): IVizStepNode[] {
     let stepNodes: IVizStepNode[] = [];
     let id = 0;
@@ -378,7 +376,7 @@ export class VisualizationService {
               // parentStepUuid is always the parent of the branch step, no matter how nested
               parentStepNextUuid: steps[index + 1]?.UUID ?? branchInfo?.rootStepNextUuid,
               parentStepUuid: steps[index].UUID,
-            })
+            }),
           );
         });
       }
@@ -414,7 +412,7 @@ export class VisualizationService {
   static async getLayoutedElements(
     nodes: IVizStepNode[],
     edges: IVizStepPropsEdge[],
-    direction: string
+    direction: string,
   ) {
     const dagreGraph = new dagre.graphlib.Graph();
     dagreGraph.setDefaultEdgeLabel(() => ({}));
@@ -440,7 +438,7 @@ export class VisualizationService {
       const sourceNode = nodes.find((node) => node.id === edge.source);
       const dagreWeightedValues = VisualizationService.getDagreWeightedValues(
         isHorizontal,
-        sourceNode
+        sourceNode,
       );
 
       dagreGraph.setEdge(edge.source, edge.target, dagreWeightedValues);
@@ -469,7 +467,7 @@ export class VisualizationService {
 
   static getDagreWeightedValues(
     isHorizontal: boolean,
-    sourceNode?: IVizStepNode
+    sourceNode?: IVizStepNode,
   ): { minlen: number; weight: number } {
     return {
       minlen: isHorizontal ? (sourceNode?.data.step.branches?.length > 1 ? 2 : 1) : 1.5,
@@ -496,7 +494,7 @@ export class VisualizationService {
     stepNodes: IVizStepNode[],
     id: string,
     type: string,
-    props: { [prop: string]: any }
+    props: { [prop: string]: any },
   ) {
     return stepNodes.unshift({
       data: {
@@ -524,7 +522,7 @@ export class VisualizationService {
     position: { x: number; y: number },
     groupHeight: number,
     groupWidth: number,
-    props?: { [prop: string]: any }
+    props?: { [prop: string]: any },
   ) {
     return stepNodes.unshift({
       id: getRandomArbitraryNumber().toString(),
@@ -560,22 +558,13 @@ export class VisualizationService {
    * @param handleDeleteStep
    * @param rebuildNodes
    */
-  async redrawDiagram(handleDeleteStep: HandleDeleteStepFn, rebuildNodes: boolean) {
-    let stepNodes = useVisualizationStore.getState().nodes;
-    let stepEdges = useVisualizationStore.getState().edges;
-    if (rebuildNodes) {
-      const ne = this.buildNodesAndEdges(handleDeleteStep);
-      stepNodes = ne.stepNodes;
-      stepEdges = ne.stepEdges;
-    }
-    VisualizationService.getLayoutedElements(
-      stepNodes,
-      stepEdges,
-      useVisualizationStore.getState().layout
-    ).then((res) => {
-      const { layoutedNodes, layoutedEdges } = res;
-      useVisualizationStore.getState().setNodes(layoutedNodes);
-      useVisualizationStore.getState().setEdges(layoutedEdges);
+  async redrawDiagram(handleDeleteStep: HandleDeleteStepFn): Promise<void> {
+    const ne = this.buildNodesAndEdges(handleDeleteStep);
+    const layout = useVisualizationStore.getState().layout;
+
+    VisualizationService.getLayoutedElements(ne.stepNodes, ne.stepEdges, layout).then((res) => {
+      useVisualizationStore.getState().setNodes(res.layoutedNodes);
+      useVisualizationStore.getState().setEdges(res.layoutedEdges);
     });
   }
 
@@ -605,7 +594,7 @@ export class VisualizationService {
       return !(
         ValidationService.reachedMaxBranches(
           nodeData.step.branches.length,
-          nodeData.step.maxBranches
+          nodeData.step.maxBranches,
         ) && nodeData.nextStepUuid
       );
 
@@ -624,7 +613,7 @@ export class VisualizationService {
       // check if the previous step contains (nested) branches.
       const prevNodeIdx = VisualizationService.findNodeIdxWithUUID(
         nodeData.previousStepUuid,
-        useVisualizationStore.getState().nodes
+        useVisualizationStore.getState().nodes,
       );
       return !!(
         useVisualizationStore.getState().nodes[prevNodeIdx] &&
@@ -652,5 +641,44 @@ export class VisualizationService {
     if (StepsService.containsBranches(nodeData.step) && !nodeData.nextStepUuid) return true;
     // if it doesn't contain branches, don't show the steps tab
     return !StepsService.containsBranches(nodeData.step);
+  }
+
+  static getEmptySelectedStep(): IStepProps {
+    return {
+      maxBranches: 0,
+      minBranches: 0,
+      name: '',
+      type: '',
+      UUID: '',
+      integrationId: '',
+    };
+  }
+
+  static getVisibleFlowsInformation(visibleFlows: Record<string, boolean>): {
+    singleFlowId: string | undefined;
+    currentVisible: number;
+    flowsCount: number;
+  } {
+    const flowsArray = Object.entries(visibleFlows);
+    const visibleFlowsIdArray = flowsArray.filter((flow) => flow[1]).map((flow) => flow[0]);
+
+    /** If there's only one flow visible, we return its ID */
+    if (visibleFlowsIdArray.length === 1) {
+      return {
+        singleFlowId: visibleFlowsIdArray[0],
+        currentVisible: 1,
+        flowsCount: flowsArray.length,
+      };
+    }
+
+    /**
+     * Otherwise, we return undefined to signal the UI that there
+     * could be more than one or no flow visible
+     */
+    return {
+      singleFlowId: undefined,
+      currentVisible: visibleFlowsIdArray.length,
+      flowsCount: flowsArray.length,
+    };
   }
 }

--- a/src/store/visualizationStore.test.tsx
+++ b/src/store/visualizationStore.test.tsx
@@ -1,5 +1,5 @@
 import { useVisualizationStore } from './visualizationStore';
-import { IStepProps } from '@kaoto/types';
+import { IStepProps, IVizStepPropsEdge } from '@kaoto/types';
 import { MarkerType } from '@reactflow/core';
 import { act, renderHook } from '@testing-library/react';
 
@@ -64,6 +64,19 @@ describe('visualizationStore', () => {
     expect(result.current.edges).toHaveLength(1);
   });
 
+  it('setEdges', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    expect(result.current.edges).toEqual([]);
+
+    act(() => {
+      result.current.setEdges([
+        { id: 'id-1234', source: 'step-1', target: 'step-3' },
+      ] as IVizStepPropsEdge[]);
+    });
+
+    expect(result.current.edges).toEqual([{ id: 'id-1234', source: 'step-1', target: 'step-3' }]);
+  });
+
   it('setHoverStepUuid', () => {
     const { result } = renderHook(() => useVisualizationStore());
     expect(result.current.hoverStepUuid).toBe('');
@@ -98,6 +111,17 @@ describe('visualizationStore', () => {
     expect(result.current.selectedStepUuid).toBe('jackfruit');
   });
 
+  it('setLayout', () => {
+    const { result } = renderHook(() => useVisualizationStore());
+    expect(result.current.layout).toBe('LR');
+
+    act(() => {
+      result.current.setLayout('TB');
+    });
+
+    expect(result.current.layout).toBe('TB');
+  });
+
   it('updateNode', () => {
     const { result } = renderHook(() => useVisualizationStore());
     act(() => {
@@ -111,11 +135,65 @@ describe('visualizationStore', () => {
           position: { x: 0, y: 0 },
           data: { label: '', step: {} as IStepProps },
         },
-        0
+        0,
       );
     });
 
     expect(result.current.nodes).toHaveLength(1);
     expect(result.current.nodes[0].id).toEqual('starfruit');
+  });
+
+  describe('Visibility handlers', () => {
+    beforeEach(() => {
+      useVisualizationStore.getState().toggleFlowVisible('route-1234', false);
+      useVisualizationStore.getState().toggleFlowVisible('route-4321', false);
+    });
+
+    it('should allow consumers to set the visibility of a given flow', () => {
+      useVisualizationStore.getState().toggleFlowVisible('route-1234', true);
+      const visibleFlows = useVisualizationStore.getState().visibleFlows;
+
+      expect(visibleFlows).toEqual({
+        'route-1234': true,
+        'route-4321': false,
+      });
+    });
+
+    it('should allow consumers to toggle the visibility of a given flow', () => {
+      useVisualizationStore.getState().toggleFlowVisible('route-1234');
+      const visibleFlows = useVisualizationStore.getState().visibleFlows;
+
+      expect(visibleFlows).toEqual({
+        'route-1234': true,
+        'route-4321': false,
+      });
+    });
+
+    it('should allow consumers show all flows', () => {
+      useVisualizationStore.getState().showAllFlows();
+      const visibleFlows = useVisualizationStore.getState().visibleFlows;
+
+      expect(visibleFlows).toEqual({
+        'route-1234': true,
+        'route-4321': true,
+      });
+    });
+
+    it('should allow consumers to hide all flows', () => {
+      useVisualizationStore.getState().hideAllFlows();
+      const visibleFlows = useVisualizationStore.getState().visibleFlows;
+
+      expect(visibleFlows).toEqual({
+        'route-1234': false,
+        'route-4321': false,
+      });
+    });
+
+    it('should allow consumers to clear all flows', () => {
+      useVisualizationStore.getState().setVisibleFlows({});
+      const visibleFlows = useVisualizationStore.getState().visibleFlows;
+
+      expect(visibleFlows).toEqual({});
+    });
   });
 });

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -32,6 +32,13 @@ export type RFState = {
    * @param nodeToUpdate
    */
   updateNode: (nodeToUpdate: IVizStepNode, nodeIndex: number) => void;
+
+  /** Visibility related handlers */
+  visibleFlows: Record<string, boolean>;
+  toggleFlowVisible: (flowId: string, isVisible?: boolean) => void;
+  showAllFlows: () => void;
+  hideAllFlows: () => void;
+  setVisibleFlows: (flows: Record<string, boolean>) => void;
 };
 
 // this is our useStore hook that we can use in our components to get parts of the store and call actions
@@ -74,6 +81,51 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
     newNodes[nodeIndex] = newNode;
     set(() => ({ nodes: newNodes }));
   },
+
+  /** Visibility related handlers */
+  visibleFlows: {},
+  toggleFlowVisible: (flowId, isVisible) => {
+    set(({ visibleFlows }) => {
+      const currentVisibility = !!visibleFlows[flowId];
+      const isFlowVisible = isVisible === undefined ? !currentVisibility : isVisible;
+
+      return {
+        visibleFlows: { ...visibleFlows, [flowId]: isFlowVisible },
+      };
+    });
+  },
+  showAllFlows: () => {
+    set(({ visibleFlows }) => ({
+      visibleFlows: toggleFlowsVisibility(visibleFlows, true),
+    }));
+  },
+  hideAllFlows: () => {
+    set(({ visibleFlows }) => ({
+      visibleFlows: toggleFlowsVisibility(visibleFlows, false),
+    }));
+  },
+  setVisibleFlows: (visibleFlows) => {
+    set(() => ({
+      visibleFlows,
+    }));
+  },
 }));
 
-export default useVisualizationStore;
+/**
+ * TODO: The following function should be moved
+ * to the VisualizationService, the problem at the
+ * moment is that VisualizationService should be split
+ * into a service that doesn't import the VisualizationStore
+ * and a VisualizationFacade which does.
+ *
+ * This will prevent the circular dependency created by
+ * importing the Store into the service and the other way around
+ */
+const toggleFlowsVisibility = (
+  visibleFlows: Record<string, boolean>,
+  isVisible: boolean,
+): Record<string, boolean> =>
+  Object.keys(visibleFlows).reduce((acc, flowId) => {
+    acc[flowId] = isVisible;
+    return acc;
+  }, {} as Record<string, boolean>);


### PR DESCRIPTION
### Context
Currently, all existing flows are being shown. This behavior is not useful when there are many flows at the same time or somewhat complex flows.

In addition to that, there's no mechanism to delete an existing flow.

### Changes
This pull request provides a way to toggle the visibility of individual flows, by leveraging a flows list that also provides the functionality of deleting individual flows.

### Notes
Some tests are still pending.

relates to: https://github.com/KaotoIO/kaoto-ui/issues/801