### PR TITLE
chore: Update to typescript 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "tsc-watch": "^6.0.4",
     "tsconfig-paths-webpack-plugin": "^4.0.1",
     "tslib": "^2.5.3",
-    "typescript": "^4.9.4",
+    "typescript": "^5.1.3",
     "url-loader": "4.1.1",
     "web-worker": "^1.2.0",
     "webpack": "5.85.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15541,10 +15541,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.9.4:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
It turned out step extensions are already with typescript 5.0 while kaoto-ui is with 4.9.