### PR TITLE
Add basic set of multiflow tests

### DIFF
--- a/cypress/e2e/03-step_integration/step_integration.cy.js
+++ b/cypress/e2e/03-step_integration/step_integration.cy.js
@@ -14,7 +14,7 @@ describe('3 step integration', () => {
     cy.dragAndDropFromCatalog('timer', 'slot', 'start');
 
     // CHECK the code editor contains the new timer step
-    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    cy.openCodeEditor();
     cy.get('.code-editor').should('contain.text', 'timer');
 
     // add an action from the mini catalog

--- a/cypress/e2e/04-source_code/source_code.cy.js
+++ b/cypress/e2e/04-source_code/source_code.cy.js
@@ -14,7 +14,7 @@ describe('source code and drag and drop', () => {
     cy.dragAndDropFromCatalog('timer-source', 'kafka-source', 'start');
 
     // CHECK that the code editor contains the new timer source step
-    cy.get('[data-testid="toolbar-show-code-btn"]').click();
+    cy.openCodeEditor();
     cy.get('.pf-c-code-editor__code').contains('timer-source').should('exist');
   });
 });

--- a/cypress/e2e/10-branching_actions_from_canvas/branches_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/branches_from_canvas.cy.js
@@ -30,8 +30,6 @@ describe('Test for Branching actions from the canvas', () => {
         cy.get('[data-testid="viz-step-slot"]').should('have.length', 1);
         cy.get('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-slot');
 
-        cy.waitAndsyncUpCodeChanges()
-
         // CHECK after Sync your code button click
         cy.get('[data-testid="viz-step-choice"]').should('have.length', 2);
         cy.get('[data-testid="viz-step-slot"]').should('have.length', 1);

--- a/cypress/e2e/10-branching_actions_from_canvas/branches_step_actions_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/branches_step_actions_from_canvas.cy.js
@@ -25,7 +25,6 @@ describe('User completes normal actions on steps in a branch', () => {
 
     it('User deletes a step in a branch', () => {
         cy.deleteStep('digitalocean');
-        cy.waitAndsyncUpCodeChanges();
 
         // CHECK that digitalocean step is deleted
         cy.get('[data-testid="viz-step-digitalocean"]').should('not.exist');

--- a/cypress/e2e/10-branching_actions_from_canvas/nested_branches_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/nested_branches_from_canvas.cy.js
@@ -69,8 +69,6 @@ describe('Test for Nested Branching actions from the canvas', () => {
         cy.get('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-slot');
         cy.get('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-log');
 
-        cy.waitAndsyncUpCodeChanges()
-
         // CHECK after Sync your code button click
         cy.get('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-slot');
         cy.get('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-log');
@@ -100,8 +98,6 @@ describe('Test for Nested Branching actions from the canvas', () => {
         cy.get('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-amqp');
         cy.get('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-activemq');
         cy.get('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-slot');
-
-        cy.waitAndsyncUpCodeChanges()
 
         // CHECK after Sync your code button click
         cy.get('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-amqp');
@@ -134,8 +130,6 @@ describe('Test for Nested Branching actions from the canvas', () => {
         cy.get('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-amqp');
         cy.get('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-slot');
 
-        cy.waitAndsyncUpCodeChanges()
-
         // CHECK after Sync your code button click
         cy.get('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-activemq');
         cy.get('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-amqp');
@@ -167,8 +161,6 @@ describe('Test for Nested Branching actions from the canvas', () => {
         cy.get('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-activemq');
         cy.get('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-log');
         cy.get('[data-testid="viz-step-activemq"]').should('be.visible');
-
-        cy.waitAndsyncUpCodeChanges()
 
         // CHECK after Sync your code button click
         cy.get('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-slot');

--- a/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
+++ b/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
@@ -42,8 +42,6 @@ describe('User completes normal actions on steps in a branch', () => {
         cy.get('[data-testid="viz-step-amqp"]').should('not.exist');
         cy.get('[data-testid="viz-step-slot"]').should('have.length', 2).and('be.visible');
 
-        cy.waitAndsyncUpCodeChanges()
-
         // CHECK that amqp step is deleted and empty step is added
         cy.get('[data-testid="viz-step-amqp"]').should('not.exist');
         cy.get('[data-testid="viz-step-slot"]').should('have.length', 2).and('be.visible');

--- a/cypress/e2e/11-multi_flow/canvas_multi_flow.cy.js
+++ b/cypress/e2e/11-multi_flow/canvas_multi_flow.cy.js
@@ -1,0 +1,80 @@
+describe('Test for Multi route actions from the canvas', () => {
+  beforeEach(() => {
+    cy.intercept('/v1/deployments*').as('getDeployments');
+    cy.intercept('/v1/steps/id/*').as('getStepDetails');
+    cy.intercept('/v1/integrations/dsls').as('getDSLs');
+    cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+    cy.intercept('POST', '/v2/integrations*').as('getIntegration');
+
+    cy.openHomePage();
+    cy.zoomOutXTimes(3);
+  });
+
+  it('User changes route type in the canvas', () => {
+    cy.switchIntegrationType('Integration');
+    cy.get('.pf-c-chip__text').contains('Integration');
+    cy.switchIntegrationType('Camel Route');
+    cy.get('.pf-c-chip__text').contains('Camel Route');
+    cy.switchIntegrationType('Kamelet');
+    cy.get('.pf-c-chip__text').contains('Kamelet');
+    cy.switchIntegrationType('KameletBinding');
+    cy.get('.pf-c-chip__text').contains('KameletBinding');
+  });
+
+  it('User shows and hides a route', () => {
+    cy.switchIntegrationType('Integration');
+    cy.createNewRoute();
+    cy.createNewRoute();
+
+    cy.toggleRouteVisibility(0);
+    cy.toggleRouteVisibility(1);
+
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 3);
+
+    cy.toggleRouteVisibility(0);
+    cy.toggleRouteVisibility(1);
+    cy.toggleRouteVisibility(2);
+
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 0);
+  });
+
+  it('User deletes routes in the canvas', () => {
+    cy.switchIntegrationType('Integration');
+    cy.createNewRoute();
+    cy.createNewRoute();
+    cy.showAllRoutes();
+
+    cy.deleteRoute(0);
+    cy.deleteRoute(0);
+    cy.deleteRoute(0);
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 0);
+  });
+
+  it('User creates multiple routes in canvas', () => {
+    cy.switchIntegrationType('Integration');
+    cy.createNewRoute();
+    cy.createNewRoute();
+
+    cy.hideAllRoutes();
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 0);
+    cy.toggleRouteVisibility(0);
+
+    cy.replaceEmptyStepMiniCatalog('timer');
+    cy.appendStepMiniCatalog('timer', 'log');
+    cy.hideAllRoutes();
+
+    cy.toggleRouteVisibility(1);
+    cy.replaceEmptyStepMiniCatalog('timer');
+    cy.appendStepMiniCatalog('timer', 'log');
+    cy.hideAllRoutes();
+
+    cy.toggleRouteVisibility(2);
+    cy.replaceEmptyStepMiniCatalog('timer');
+    cy.appendStepMiniCatalog('timer', 'log');
+
+    cy.showAllRoutes();
+    cy.get('[data-testid="viz-step-timer"]').should('have.length', 3);
+    cy.get('[data-testid="viz-step-log"]').should('have.length', 3);
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 3);
+  });
+});

--- a/cypress/e2e/11-multi_flow/code_editor_multi_flow.js
+++ b/cypress/e2e/11-multi_flow/code_editor_multi_flow.js
@@ -1,0 +1,79 @@
+describe('Test for Multi route actions from the code editor', () => {
+  beforeEach(() => {
+    cy.intercept('/v1/deployments*').as('getDeployments');
+    cy.intercept('/v1/steps/id/*').as('getStepDetails');
+    cy.intercept('/v1/integrations/dsls').as('getDSLs');
+    cy.intercept('/v1/view-definitions').as('getViewDefinitions');
+    cy.intercept('POST', '/v2/integrations*').as('getIntegration');
+
+    cy.openHomePage();
+    cy.uploadFixture('IntegrationMultiFlow.yaml');
+
+    cy.zoomOutXTimes(3);
+  });
+
+  it('User deletes first route from multi-route using code editor', () => {
+    cy.editorDeleteLine(0, 15);
+    cy.syncUpCodeChanges();
+
+    cy.showAllRoutes();
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 1);
+  });
+
+  it('User deletes second route from multi-route using code editor', () => {
+    cy.editorDeleteLine(15, 12);
+    cy.syncUpCodeChanges();
+
+    cy.showAllRoutes();
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 1);
+  });
+
+  it('User deletes step from first route using code editor', () => {
+    cy.editorDeleteLine(11, 2);
+    cy.syncUpCodeChanges();
+
+    cy.showAllRoutes();
+    cy.get('[data-testid="viz-step-set-body"]').should('not.exist');
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 2);
+  });
+
+  it('User adds step to the first route using code editor', () => {
+    const stepToInsert = `      - set-header:
+          constant: test`;
+    const insertLine = 11;
+    cy.editorAddText(insertLine, stepToInsert);
+    cy.syncUpCodeChanges();
+
+    // CHECK the set-header step was added
+    cy.get('[data-testid="viz-step-set-header"]').should('be.visible');
+  });
+
+  // Blocked by - https://github.com/KaotoIO/kaoto-ui/issues/1910
+  it.skip('User adds step to the second route using code editor', () => {
+    cy.showAllRoutes();
+    const stepToInsert = `      - set-body:
+          constant: test`;
+    const insertLine = 25;
+    cy.editorAddText(insertLine, stepToInsert);
+    cy.syncUpCodeChanges();
+    // CHECK the insert-field-action step was added
+    cy.get('[data-testid="viz-step-set-body"]').should('be.visible');
+  });
+
+  it('User reverts route deletion using code editor', () => {
+    cy.editorDeleteLine(15, 12);
+    cy.syncUpCodeChanges();
+
+    cy.showAllRoutes();
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 1);
+
+    // First click undo button => reverted automatic adjustments
+    cy.editorClickUndoXTimes();
+    // Second click undo button => changes reverted & alert is displayed
+    cy.editorClickUndoXTimes();
+    cy.syncUpCodeChanges();
+
+    cy.showAllRoutes();
+    cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 2);
+  });
+});

--- a/cypress/fixtures/IntegrationMultiFlow.yaml
+++ b/cypress/fixtures/IntegrationMultiFlow.yaml
@@ -1,0 +1,27 @@
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: ''
+spec:
+  flows:
+  - from:
+      uri: cron:cron
+      parameters:
+        schedule: '1000'
+      steps:
+      - set-body:
+          simple: body
+      - to:
+          uri: log:log1
+---
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: ''
+spec:
+  flows:
+  - from:
+      uri: timer:test
+      steps:
+      - to:
+          uri: log:log2

--- a/cypress/support/kaoto-ui-commands/default.js
+++ b/cypress/support/kaoto-ui-commands/default.js
@@ -1,95 +1,183 @@
 import 'cypress-file-upload';
 
 Cypress.Commands.add('openHomePage', () => {
-    let url = Cypress.config().baseUrl;
-    cy.visit(url);
-    cy.waitOpenHomePage();
+  let url = Cypress.config().baseUrl;
+  cy.visit(url);
+  cy.waitOpenHomePage();
 });
 
 Cypress.Commands.add('zoomOutXTimes', (times) => {
-    times = times ?? 1;
-    Array.from({ length: times }).forEach(() => {
-        cy.get('.react-flow__controls-button.react-flow__controls-zoomout').click()
-    });
+  times = times ?? 1;
+  Array.from({ length: times }).forEach(() => {
+    cy.get('.react-flow__controls-button.react-flow__controls-zoomout').click();
+  });
 });
 
 Cypress.Commands.add('waitVisualizationUpdate', () => {
-    cy.get('body').then((body) => {
-        /**
-         * If the code editor is visible, it means that we would need
-         * to wait for the getIntegration call, otherwise, the operation
-         * is synchronous
-         */
-        if (body.find('.code-editor').length > 0) {
-            cy.wait('@getIntegration');
-        }
-    });
+  cy.get('body').then((body) => {
+    /**
+     * If the code editor is visible, it means that we would need
+     * to wait for the getIntegration call, otherwise, the operation
+     * is synchronous
+     */
+    if (body.find('.code-editor').length > 0) {
+      cy.wait('@getIntegration');
+    }
+  });
 });
 
 Cypress.Commands.add('waitOpenHomePage', () => {
-    cy.wait('@getDeployments');
-    cy.wait('@getViewDefinitions');
+  cy.wait('@getDeployments');
+  cy.wait('@getViewDefinitions');
 });
 
 Cypress.Commands.add('closeCatalogOrCodeEditor', () => {
-    cy.get('[data-testid="kaoto-left-drawer"]').within(() => {
-        cy.get('.pf-c-drawer__close > .pf-c-button').click();
-    });
+  cy.get('[data-testid="kaoto-left-drawer"]').within(() => {
+    cy.get('.pf-c-drawer__close > .pf-c-button').click();
+  });
 });
 
 Cypress.Commands.add('openMenuDropDown', () => {
-    cy.get('.pf-c-toolbar__content-section').click();
-    cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
+  cy.get('.pf-c-toolbar__content-section').click();
+  cy.get('[data-testid="toolbar-kebab-dropdown-btn"]').click();
 });
 
 Cypress.Commands.add('openAboutModal', () => {
-    cy.openMenuDropDown();
-    cy.get('[data-testid="kaotoToolbar-kebab__about"]').click();
+  cy.openMenuDropDown();
+  cy.get('[data-testid="kaotoToolbar-kebab__about"]').click();
 });
 
 Cypress.Commands.add('openAppearanceModal', () => {
-    cy.openMenuDropDown();
-    cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
+  cy.openMenuDropDown();
+  cy.get('[data-testid="kaotoToolbar-kebab__appearance"]').click();
 });
 
 Cypress.Commands.add('openSettingsModal', () => {
-    cy.openMenuDropDown();
-    cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
+  cy.openMenuDropDown();
+  cy.get('[data-testid="kaotoToolbar-kebab__settings"]').click();
 });
 
 Cypress.Commands.add('closeAppearanceModal', () => {
-    cy.get('[data-ouia-component-id="appearance-modal"] > button[aria-label="Close"]').click();
+  cy.get('[data-ouia-component-id="appearance-modal"] > button[aria-label="Close"]').click();
 });
 
 Cypress.Commands.add('closeAboutModal', () => {
-    cy.get('.pf-c-button.pf-m-plain').click();
+  cy.get('.pf-c-button.pf-m-plain').click();
 });
 
 Cypress.Commands.add('closeMenuModal', () => {
-    cy.get('[data-ouia-component-id="settings-modal"] > button[aria-label="Close"]').click();
+  cy.get('[data-ouia-component-id="settings-modal"] > button[aria-label="Close"]').click();
 });
 
 Cypress.Commands.add('cancelMenuModal', () => {
-    cy.get('[data-testid="settings-modal--cancel"]').click();
+  cy.get('[data-testid="settings-modal--cancel"]').click();
 });
 
 Cypress.Commands.add('saveMenuModal', (integrationChanged) => {
-    integrationChanged = integrationChanged ?? false;
-    cy.get('[data-testid="settings-modal--save"]').click();
-    cy.get('.pf-c-alert').should('contain.text', 'Configuration settings saved successfully.');
-    cy.get('.pf-c-alert__action').children('button').click();
-    cy.wait('@getIntegration');
-    if (integrationChanged) {
-        cy.waitVisualizationUpdate();
-        cy.wait('@getDSLs');
-    }
+  integrationChanged = integrationChanged ?? false;
+  cy.get('[data-testid="settings-modal--save"]').click();
+  cy.get('.pf-c-alert').should('contain.text', 'Configuration settings saved successfully.');
+  cy.get('.pf-c-alert__action').children('button').click();
+  cy.wait('@getIntegration');
+  if (integrationChanged) {
+    cy.waitVisualizationUpdate();
+    cy.wait('@getDSLs');
+  }
 });
 
 Cypress.Commands.add('switchAppearanceTheme', (object) => {
-    object = object ?? '';
-    if (object === 'editor') {
-        cy.get('[data-testid="appearance--theme-editor-switch"]').click({ force: true });
-    } else {
-        cy.get('[data-testid="appearance--theme-ui-switch"]').click({ force: true });
+  object = object ?? '';
+  if (object === 'editor') {
+    cy.get('[data-testid="appearance--theme-editor-switch"]').click({ force: true });
+  } else {
+    cy.get('[data-testid="appearance--theme-ui-switch"]').click({ force: true });
+  }
+});
+
+/**
+ * Select from integration type dropdown
+ * Possible values are - Integration, Camel Route, Kamelet, KameletBinding
+ */
+Cypress.Commands.add('switchIntegrationType', (type) => {
+  cy.get('[data-testid="dsl-list-dropdown"]').click({ force: true });
+
+  cy.get('.pf-c-menu__item-text')
+    .contains(type)
+    .then((element) => {
+      cy.wrap(element).click();
+    });
+    cy.get('[data-testid="confirmation-modal-confirm"]').click({ force: true });
+  cy.wait('@getViewDefinitions');
+});
+
+Cypress.Commands.add('createNewRoute', () => {
+  cy.get('[data-testid="dsl-list-btn"]').click({ force: true });
+  cy.wait('@getViewDefinitions');
+});
+
+Cypress.Commands.add('disableRouteVisibility', (index) => {
+  cy.toggleFlowsList();
+  cy.get('svg[data-testid^="toggle-btn-route"]').each(($element) => {
+    const attributeValue = $element.attr('data-testid');
+    if (attributeValue.endsWith('visible')) {
+      cy.wrap($element).click();
     }
+  });
+  cy.closeFlowsListIfVisible();
+});
+
+Cypress.Commands.add('allignAllRoutesVisibility', (switchvisibility) => {
+  cy.toggleFlowsList();
+  cy.get('[data-testid=flows-list-table]').then((body) => {
+    if (body.find(`svg[data-testid$="${switchvisibility}"]`).length > 0) {
+      cy.get(`svg[data-testid$="${switchvisibility}"]`).then(($element) => {
+        if ($element.attr('data-testid').endsWith(`${switchvisibility}`)) {
+          cy.wrap($element[0]).click();
+          cy.closeFlowsListIfVisible();
+          cy.allignAllRoutesVisibility(switchvisibility);
+        }
+      });
+    }
+  });
+  cy.closeFlowsListIfVisible();
+});
+
+Cypress.Commands.add('hideAllRoutes', () => {
+  cy.allignAllRoutesVisibility('visible');
+});
+
+Cypress.Commands.add('showAllRoutes', () => {
+  cy.allignAllRoutesVisibility('hidden');
+});
+
+Cypress.Commands.add('toggleRouteVisibility', (index) => {
+  cy.toggleFlowsList();
+  cy.get('button[data-testid^="toggle-btn-route"]').then((buttons) => {
+    cy.wrap(buttons[index]).click();
+  });
+  cy.closeFlowsListIfVisible();
+});
+
+Cypress.Commands.add('deleteRoute', (index) => {
+  cy.toggleFlowsList();
+  cy.get('button[data-testid^="delete-btn-route"]').then((buttons) => {
+    cy.wrap(buttons[index]).click();
+  });
+  cy.closeFlowsListIfVisible();
+});
+
+Cypress.Commands.add('closeFlowsListIfVisible', () => {
+  cy.get('body').then((body) => {
+    if (body.find('[data-testid="flows-list-table"]').length > 0) {
+      cy.get('[data-testid="flows-list-table"]').then(($element) => {
+        if ($element.length > 0) {
+          cy.toggleFlowsList();
+        }
+      });
+    }
+  });
+});
+
+Cypress.Commands.add('toggleFlowsList', () => {
+  cy.get('[data-testid="flows-list-dropdown"]').click({ force: true });
 });

--- a/cypress/support/kaoto-ui-commands/steps.js
+++ b/cypress/support/kaoto-ui-commands/steps.js
@@ -80,6 +80,7 @@ Cypress.Commands.add('openStepConfigurationTab', (step, EIP, stepIndex) => {
     if (!EIP) {
         cy.get('[data-testid="kaoto-right-drawer"]').should('be.visible');
     }
+    cy.waitVisualizationUpdate();
 });
 
 Cypress.Commands.add('closeStepConfigurationTab', () => {

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -37,10 +37,10 @@ export const ConfirmationModal: FunctionComponent<IConfirmationModal> = ({
     <div className="confirmation-modal" data-testid="confirmation-modal">
       <Modal
         actions={[
-          <Button key="confirm" variant="primary" onClick={onConfirm}>
+          <Button key="confirm" variant="primary" data-testid="confirmation-modal-confirm" onClick={onConfirm}>
             Confirm
           </Button>,
-          <Button key="cancel" variant="link" onClick={onCancel}>
+          <Button key="cancel" variant="link" data-testid="confirmation-modal-cancel" onClick={onCancel}>
             Cancel
           </Button>,
         ]}


### PR DESCRIPTION
Add basic set of multiflow tests - both for canvas and editor.

The basic tests include:
Editor - based:

1. User deletes first route from multi-route using code editor
2. User deletes second route from multi-route using code editor
3. User deletes step from first route using code editor
4. User adds step to the first route using code editor
5. User reverts route deletion using code editor

Canvas - based:

1. User changes route type in the canvas
2. User shows and hides a route
3. User deletes routes in the canvas
4. User creates multiple routes in canvas