### PR TITLE
Fix - sync connector yaml without need to open code editor

### DIFF
--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -310,7 +310,7 @@ export const KaotoToolbar = ({
 
           {/* CURRENT DSL */}
           <ToolbarItem>
-            <Chip isReadOnly>{currentDsl || 'None'}</Chip>
+            <Chip data-testid="toolbar-current-dsl" isReadOnly>{currentDsl || 'None'}</Chip>
           </ToolbarItem>
 
           {/* NEW FLOW DROPDOWN BUTTON */}

--- a/src/store/integrationSourceStore.tsx
+++ b/src/store/integrationSourceStore.tsx
@@ -2,10 +2,14 @@ import { create } from 'zustand';
 
 interface ISourceCodeStore {
   sourceCode: string;
+  syncedSourceCode: string;
   setSourceCode: (val?: string) => void;
+  setSyncedSourceCode: (val?: string) => void;
 }
 
 export const useIntegrationSourceStore = create<ISourceCodeStore>((set) => ({
   sourceCode: '',
+  syncedSourceCode: '',
   setSourceCode: (val?: string) => set({ sourceCode: val }),
+  setSyncedSourceCode: (val?: string) => set({ syncedSourceCode: val }),
 }));


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto-ui/issues/1796
Fixes https://github.com/KaotoIO/kaoto-ui/issues/1361
Fixes https://github.com/KaotoIO/kaoto-ui/issues/1368
The code editor doesn't need to be opened for the code sync to be performed prior to integration deployment to Kubernetes cluster.