### PR TITLE
Make search input width static

### DIFF
--- a/src/components/Catalog.tsx
+++ b/src/components/Catalog.tsx
@@ -106,7 +106,7 @@ export const Catalog = ({ handleClose }: { handleClose: () => void }) => {
             <>
               <ToolbarItem style={{ padding: '0', marginRight: '0' }}>
                 <InputGroup>
-                  <SearchInput
+                  <SearchInput style={{ width: '250px' }}
                     name={'stepSearch'}
                     id={'stepSearch'}
                     type={'search'}


### PR DESCRIPTION
Fix for https://github.com/KaotoIO/kaoto-ui/issues/1245

Changed the input search to have static width - not causing the "start, actions, end" toggles to change position in the toolbar. The static width causes in FF not to overflow the search bar and doesn't cause moving the toggles to second row. See recordings:

Previous state:

![Peek 2023-06-12 11-09](https://github.com/KaotoIO/kaoto-ui/assets/4180208/9aec6f75-de32-45ad-8b0d-57a9c10f43cc)


With changes:

![Peek 2023-06-12 11-08](https://github.com/KaotoIO/kaoto-ui/assets/4180208/bec5f5d3-7982-4e7e-b68f-f1bf4e5bad41)

fixes: #1245 