### PR TITLE
fix(code-editor): Update schema upon syncing the code

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.1).
+ * Mock Service Worker (1.2.2).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/__mocks__/monaco-yaml.js
+++ b/src/__mocks__/monaco-yaml.js
@@ -1,0 +1,5 @@
+/**
+ * We're mocking this module since it spawn a web worker at runtime
+ * for the language server.
+ */
+export const setDiagnosticsOptions = jest.fn();

--- a/src/api/requestService.test.ts
+++ b/src/api/requestService.test.ts
@@ -1,0 +1,64 @@
+import { RequestService } from './requestService';
+
+describe('RequestService', () => {
+  let fetchSpy: jest.SpyInstance;
+  const url = 'http://localhost:8080';
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async () => {
+      return {
+        ok: true,
+        json: async () => {
+          return { message: 'hello' };
+        },
+      } as Response;
+    });
+
+    RequestService.setApiURL(url);
+  });
+
+  afterEach(() => {
+    RequestService.setApiURL('');
+    jest.clearAllMocks();
+  });
+
+  it('should allow setting the API URL', () => {
+    expect(RequestService.getApiURL()).toEqual(url);
+  });
+
+  it('should allow consumers to make a GET request', async () => {
+    RequestService.get({ endpoint: '/capabilities' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${url}/capabilities`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('should allow consumers to make a POST request', async () => {
+    RequestService.post({ endpoint: '/capabilities' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${url}/capabilities`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('should allow consumers to make a PATCH request', async () => {
+    RequestService.patch({ endpoint: '/capabilities' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${url}/capabilities`,
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+
+  it('should allow consumers to make a DELETE request', async () => {
+    RequestService.delete({ endpoint: '/capabilities' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${url}/capabilities`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});

--- a/src/api/requestService.ts
+++ b/src/api/requestService.ts
@@ -36,6 +36,10 @@ export interface IFetch {
 export class RequestService {
   private static apiURL = process.env.KAOTO_API;
 
+  static getApiURL(): string | undefined {
+    return this.apiURL;
+  }
+
   static setApiURL(apiUrl: string): void {
     this.apiURL = apiUrl;
   }
@@ -71,7 +75,8 @@ export class RequestService {
 
     let options: RequestInit = {
       method,
-      body: contentType?.includes('application/json') && stringifyBody ? JSON.stringify(body) : body,
+      body:
+        contentType?.includes('application/json') && stringifyBody ? JSON.stringify(body) : body,
       cache: cache ?? 'default',
       /**
        * TODO: Omit for now, reassess for prod
@@ -94,11 +99,13 @@ export class RequestService {
     }
 
     return fetch(`${this.apiURL}${endpoint}`, options);
-  };
+  }
 
   // converts an object into a query string
   // ex: {type : 'Kamelet'} -> &type=Kamelet
-  private static objectToQueryString(obj: { [x: string]: string | undefined | null | number | boolean }) {
+  private static objectToQueryString(obj: {
+    [x: string]: string | undefined | null | number | boolean;
+  }) {
     return Object.keys(obj)
       .map((key) => key + '=' + obj[key])
       .join('&');

--- a/src/components/SourceCodeEditor.test.tsx
+++ b/src/components/SourceCodeEditor.test.tsx
@@ -1,12 +1,65 @@
 import { SourceCodeEditor } from './SourceCodeEditor';
+import { RequestService } from '@kaoto/api';
+import { useSettingsStore } from '@kaoto/store';
 import { Language } from '@patternfly/react-code-editor';
 import { screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 
+/** This is being mocked in __mocks__/monaco-yaml.js*/
+import { setDiagnosticsOptions } from 'monaco-yaml';
+import { act } from 'react-dom/test-utils';
+
 describe('SourceCodeEditor.tsx', () => {
-  test('component renders correctly', () => {
+  beforeEach(() => {
+    RequestService.setApiURL('http://localhost:8081');
+  });
+
+  afterEach(() => {
+    RequestService.setApiURL('');
+  });
+
+  it('component renders correctly', () => {
     render(<SourceCodeEditor language={Language.yaml} />);
     const emptyStateBrowseBtn = screen.getByRole('textbox');
     expect(emptyStateBrowseBtn).toBeInTheDocument();
+  });
+
+  it('should update the schemaUri upon loading the component', async () => {
+    await act(async () => {
+      render(<SourceCodeEditor language={Language.yaml} />);
+    });
+
+    expect(setDiagnosticsOptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update the schemaUri upon switching DSLs', async () => {
+    await act(async () => {
+      render(<SourceCodeEditor language={Language.yaml} />);
+    });
+
+    act(() => {
+      useSettingsStore.getState().setSettings({
+        ...useSettingsStore.getState().settings,
+        dsl: {
+          ...useSettingsStore.getState().settings.dsl,
+          validationSchema: '/test.json',
+        },
+      });
+    });
+
+    expect(setDiagnosticsOptions).toHaveBeenCalledTimes(2);
+    expect(setDiagnosticsOptions).toHaveBeenCalledWith({
+      enableSchemaRequest: true,
+      hover: false,
+      completion: true,
+      validate: true,
+      format: true,
+      schemas: [
+        {
+          uri: 'http://localhost:8081/test.json',
+          fileMatch: ['*'],
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
### Context
Currently, the validation schema is set whenever the code editor is mounted and in case of the user updates the DSL then the schema no longer applies, showing a yellow squiggle.

The fix is to listen to the dsl property and set the appropriate schema when changes.

### Before
[Screencast from 2023-06-15 21-53-06.webm](https://github.com/KaotoIO/kaoto-ui/assets/16512618/088546d7-f227-4280-8b68-0faf4c267d20)

### After
[Screencast from 2023-06-15 21-49-38.webm](https://github.com/KaotoIO/kaoto-ui/assets/16512618/d729a4d6-5bc1-4e52-8e42-519f081b501d)


fixes: https://github.com/KaotoIO/kaoto-ui/issues/1166