### PR TITLE
feat(stepsService): updateStep can receive parameters values

### DIFF
--- a/src/services/stepsService.test.ts
+++ b/src/services/stepsService.test.ts
@@ -161,6 +161,14 @@ describe('stepsService', () => {
       expect(stopDeployment).toHaveBeenCalled();
     });
 
+    it('updateStep(): should delegate the update to updateStepParameters method', () => {
+      const updateStepParametersSpy = jest.spyOn(stepsService, 'updateStepParameters').mockImplementationOnce(() => {});
+
+      stepsService.createKaotoApi(step, jest.fn(), jest.fn()).updateStep({ name: 'pineapple' } as IStepProps);
+
+      expect(updateStepParametersSpy).toHaveBeenCalled();
+    });
+
     it('updateStepParams(): should call the provided callback for updating step params', () => {
       const saveConfig = jest.fn();
       stepsService.createKaotoApi(step, saveConfig, jest.fn()).updateStepParams({ name: 'pizza' });

--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -137,9 +137,9 @@ export class StepsService {
         });
       },
       /** TODO: Evaluate if makes sense to keep this duplicated method in the API */
-      updateStep: (newStep: IStepProps) => {
+      updateStep: (newStep: IStepProps, newValues?: Record<string, unknown>) => {
         /** TODO: Passing an empty object to avoid setting new parameters to the step */
-        this.updateStepParameters(newStep, {});
+        this.updateStepParameters(newStep, newValues ?? {});
       },
       updateStepParams,
     };


### PR DESCRIPTION
### Context
Currently, we have two methods for the step extensions to update a step. One for updating the step and another one to update the step and its parameters.

### Changes
Allow the consumer of the `updateStep` API to update also the parameters values.

### Notes
This is needed for the Rest DSL step extension