### PR TITLE
feat(code-editor): Remember left panel status

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './document-title.hook';
+export * from './local-storage.hook';
 export * from './position.hook';
 export * from './previous.hook';
 export * from './show-branch-tab.hook';

--- a/src/hooks/local-storage.hook.test.ts
+++ b/src/hooks/local-storage.hook.test.ts
@@ -1,0 +1,67 @@
+import { act } from 'react-dom/test-utils';
+import { useLocalStorage } from './local-storage.hook';
+import { renderHook } from '@testing-library/react';
+
+describe('useLocalStorage', () => {
+  const key = 'kaoto-test';
+
+  beforeAll(() => {
+    localStorage.removeItem(key);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(key);
+  });
+
+  it.each([
+    ['localStorage value', 'default value', 'localStorage value'],
+    ['42', -1, 42],
+    ['true', false, true],
+    ['false', true, false],
+    [JSON.stringify({ prop: true }), { bar: false }, { prop: true }],
+  ])(
+    'should get the localStorage value and use it if found',
+    (initialValue, defaultValue, expectedValue) => {
+      localStorage.setItem(key, initialValue);
+
+      const [value] = renderHook(() => useLocalStorage(key, defaultValue)).result.current;
+
+      expect(value).toEqual(expectedValue);
+    },
+  );
+
+  it.each(['value', 42, true, false, { prop: true }])(
+    'should get the localStorage value and use it if found',
+    (defaultValue) => {
+      const [value] = renderHook(() => useLocalStorage(key, defaultValue)).result.current;
+
+      expect(value).toEqual(defaultValue);
+    },
+  );
+
+  it('should return default value for a non parsable string', () => {
+    localStorage.setItem(key, '^(%U!@#%^&');
+
+    const [value] = renderHook(() => useLocalStorage(key, 42)).result.current;
+
+    expect(value).toBe(42);
+  });
+
+  it('should store the initial value to localStorage using the key', () => {
+    renderHook(() => useLocalStorage(key, 'initial'));
+
+    expect(localStorage.getItem(key)).toBe('initial');
+  });
+
+  it('should allow consumers to update the value', () => {
+    const result = renderHook(() => useLocalStorage(key, 42)).result;
+    const [_, setValue] = result.current;
+
+    act(() => {
+      setValue(888);
+    });
+
+    expect(result.current[0]).toBe(888);
+  });
+
+});

--- a/src/hooks/local-storage.hook.ts
+++ b/src/hooks/local-storage.hook.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+export const useLocalStorage = <T>(key: string, defaultValue: T) => {
+  const [value, setValue] = useState<T>(() => {
+    const storedValue = localStorage.getItem(key);
+
+    if (storedValue === null) {
+      return defaultValue;
+    } else if (typeof defaultValue === 'string') {
+      return storedValue;
+    }
+
+    try {
+      const returnValue = JSON.parse(storedValue);
+      return returnValue;
+    } catch (error) {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    const valueToStore = typeof value === 'string' ? value : JSON.stringify(value);
+    localStorage.setItem(key, valueToStore);
+  }, [key, value]);
+
+  return [value, setValue] as const;
+};

--- a/src/layout/Dashboard.tsx
+++ b/src/layout/Dashboard.tsx
@@ -1,13 +1,7 @@
-import {
-  Catalog,
-  Console,
-  KaotoDrawer,
-  KaotoToolbar,
-  SourceCodeEditor,
-  Visualization,
-} from '../components';
+import { Console, KaotoDrawer, KaotoToolbar, Visualization } from '../components';
+import { useLocalStorage } from '../hooks';
 import './Dashboard.css';
-import { useSettingsStore } from '@kaoto/store';
+import { LeftPanel } from './DashboardLeftPanel';
 import {
   Banner,
   DrawerColorVariant,
@@ -18,22 +12,18 @@ import {
   PageSection,
 } from '@patternfly/react-core';
 import { TerminalIcon } from '@patternfly/react-icons';
-import { useRef, useState } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 
-const Dashboard = () => {
-  const [bottomDrawerExpanded, setBottomDrawerExpanded] = useState(false);
-  const [leftDrawerExpanded, setLeftDrawerExpanded] = useState(false);
-  const leftDrawerModel = useRef('catalog');
-  const { settings } = useSettingsStore((state) => state);
-
-  const drawerCatalog = (
-    <DrawerContentBody style={{ padding: '10px' }}>
-      <Catalog handleClose={() => setLeftDrawerExpanded(false)} />
-    </DrawerContentBody>
+export const Dashboard = () => {
+  const [bottomDrawerExpanded, setBottomDrawerExpanded] = useLocalStorage(
+    'bottomDrawerExpanded',
+    false,
   );
-
-  const [leftDrawerContent, setLeftDrawerContent] = useState(drawerCatalog);
+  const [leftDrawerExpanded, setLeftDrawerExpanded] = useLocalStorage('leftDrawerExpanded', false);
+  const [leftDrawerMode, setLeftDrawerMode] = useLocalStorage<'code' | 'catalog'>(
+    'leftDrawerMode',
+    'catalog',
+  );
 
   const drawerConsole = (
     <DrawerContentBody tabIndex={bottomDrawerExpanded ? 0 : -1}>
@@ -45,31 +35,24 @@ const Dashboard = () => {
     </DrawerContentBody>
   );
 
-  const drawerCodeEditor = (
-    <DrawerContentBody hasPadding={false}>
-      <SourceCodeEditor mode={settings.editorMode} schemaUri={settings.dsl.validationSchema} />
-    </DrawerContentBody>
-  );
-
   const handleToggleCodeEditor = () => {
-    if (leftDrawerModel.current === 'code') {
+    if (leftDrawerMode === 'code') {
       // it's already showing the code editor, just toggle it
       setLeftDrawerExpanded(!leftDrawerExpanded);
     } else {
-      setLeftDrawerContent(drawerCodeEditor);
-      leftDrawerModel.current = 'code';
+      setLeftDrawerMode('code');
       setLeftDrawerExpanded(true);
     }
   };
+
   const handleToggleCatalog = () => {
-    if (leftDrawerModel.current === 'catalog') {
+    if (leftDrawerMode === 'catalog') {
       // it's already showing the catalog, just toggle it
       setLeftDrawerExpanded(!leftDrawerExpanded);
     } else {
       // currently showing code editor content;
       // set to catalog, only close if already open
-      setLeftDrawerContent(drawerCatalog);
-      leftDrawerModel.current = 'catalog';
+      setLeftDrawerMode('catalog');
 
       if (!leftDrawerExpanded) {
         setLeftDrawerExpanded(!leftDrawerExpanded);
@@ -112,7 +95,12 @@ const Dashboard = () => {
                 <KaotoDrawer
                   colorVariant={DrawerColorVariant.light200}
                   dataTestId={'kaoto-left-drawer'}
-                  panelContent={leftDrawerContent}
+                  panelContent={
+                    <LeftPanel
+                      onCatalogClose={() => setLeftDrawerExpanded(false)}
+                      mode={leftDrawerMode}
+                    />
+                  }
                   id={'kaoto-left-drawer'}
                   isExpanded={leftDrawerExpanded}
                   minSize={'525px'}
@@ -147,5 +135,3 @@ const Dashboard = () => {
     </>
   );
 };
-
-export { Dashboard };

--- a/src/layout/DashboardLeftPanel.tsx
+++ b/src/layout/DashboardLeftPanel.tsx
@@ -1,0 +1,24 @@
+import { Catalog, SourceCodeEditor } from '../components';
+import { IDataTestID } from '../types';
+import { useSettingsStore } from '@kaoto/store';
+import { DrawerContentBody } from '@patternfly/react-core';
+import { FunctionComponent } from 'react';
+
+interface ILeftPanel extends IDataTestID {
+  mode: 'code' | 'catalog';
+  onCatalogClose: () => void;
+}
+
+export const LeftPanel: FunctionComponent<ILeftPanel> = (props) => {
+  const { settings } = useSettingsStore((state) => state);
+
+  return props.mode === 'code' ? (
+    <DrawerContentBody hasPadding={false}>
+      <SourceCodeEditor mode={settings.editorMode} schemaUri={settings.dsl.validationSchema} />
+    </DrawerContentBody>
+  ) : (
+    <DrawerContentBody style={{ padding: '10px' }}>
+      <Catalog handleClose={props.onCatalogClose} />
+    </DrawerContentBody>
+  );
+};


### PR DESCRIPTION
### Context
Currently, opening the left panel is not preserved upon refreshing the UI.

### Changes
This pull request adds a new useLocalStorage hook to save the configuration value into localStorage to preserve it for the next refresh.

### How to test?
1. Checkout the branch
2. Run Kaoto locally and open the source code editor
3. Refresh the page, the source code editor should stay open
4. Open the steps catalog
5. Refresh the page, the steps catalog should stay open

Fixes: https://github.com/KaotoIO/kaoto-ui/issues/1996