### PR TITLE
Replace placeholder - first step insert on index 0

### DIFF
--- a/src/services/stepsService.ts
+++ b/src/services/stepsService.ts
@@ -29,6 +29,7 @@ import { findPath, getDeepValue } from '@kaoto/utils';
  * A collection of business logic to handle logical model objects of the integration,
  * which is represented by a collection of "Step".
  * This class focuses on handling logical model objects. For handling visualization,
+ * see {@link VisualizationService}.
  * Note: Methods are declared in alphabetical order.
  * @see IStepProps
  * @see IStepPropsBranch
@@ -448,7 +449,7 @@ export class StepsService {
           useFlowsStore.getState().insertStep(node.step.integrationId, step, { mode: 'replace', path: newPath });
         }
       } else {
-        useFlowsStore.getState().insertStep(node.step.integrationId, step, { mode: 'append' });
+        useFlowsStore.getState().insertStep(node.step.integrationId, step, { mode: 'insert', index: 0 });
       }
 
       return validation;


### PR DESCRIPTION
fixes: https://github.com/KaotoIO/kaoto-ui/issues/1962

Instead of appending the step instead of the placeholder - add it to index 0. 
This prevents the mentioned issue, when there are other steps already defined in the route.