### PR TITLE
Fix e2e tests after backend quarkus update

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,6 +57,8 @@ jobs:
         ports:
           # will assign a random free host port
           - 8081/tcp
+        env:
+          QUARKUS_HTTP_CORS_ORIGINS: "http://localhost:1337"
     steps:
       - name: 👷‍♀️ Checkout
         uses: actions/checkout@v3
@@ -111,6 +113,8 @@ jobs:
         ports:
           # will assign a random free host port
           - 8081/tcp
+        env:
+          QUARKUS_HTTP_CORS_ORIGINS: "http://localhost:1337"
     steps:
       - name: 👷‍♀️ Checkout
         uses: actions/checkout@v3
@@ -166,6 +170,8 @@ jobs:
         ports:
           # will assign a random free host port
           - 8081/tcp
+        env:
+          QUARKUS_HTTP_CORS_ORIGINS: "http://localhost:1337"
     steps:
       - name: 👷‍♀️ Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
CORS needs to be set after Quarkus3 update on backend https://github.com/KaotoIO/kaoto-backend/pull/695  
[More info](https://github.com/KaotoIO/kaoto-backend#cors)