### PR TITLE
fix(beans): Restore default padding from the table row

### DIFF
--- a/src/components/metadata/MetadataEditorModal.css
+++ b/src/components/metadata/MetadataEditorModal.css
@@ -10,10 +10,3 @@
 .metadataEditorModalDetailsView {
     width: 50vw;
 }
-
-.propertyRow {
-    --pf-c-table--m-compact--cell--PaddingTop: 0px;
-    --pf-c-table--m-compact--cell--PaddingBottom: 0px;
-    --pf-c-table--m-compact--cell--PaddingRight: 0px;
-    --pf-c-table--m-compact--cell--PaddingLeft: 0px;
-}

--- a/src/components/metadata/PropertyPlaceholderRow.tsx
+++ b/src/components/metadata/PropertyPlaceholderRow.tsx
@@ -65,7 +65,7 @@ export function PropertyPlaceholderRow({
   }
 
   return (
-    <TreeRowWrapper row={{ props: treeRow!.props }} className="pf-m-selected propertyRow">
+    <TreeRowWrapper row={{ props: treeRow!.props }} className="pf-m-selected">
       <Td dataLabel="NAME" treeRow={treeRow}>
         <TextInput
           autoFocus={true}

--- a/src/components/metadata/PropertyRow.tsx
+++ b/src/components/metadata/PropertyRow.tsx
@@ -81,7 +81,6 @@ export function PropertyRow({
     <TreeRowWrapper
       key={`${propertyName}-${path.join('-')}`}
       row={{ props: treeRow!.props }}
-      className="propertyRow"
     >
       <Td dataLabel="NAME" treeRow={treeRow}>
         <TextInput


### PR DESCRIPTION
### Before
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/7c18121b-dbab-4864-84ba-bb078481504b)


### After
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/a5bf20df-70e2-47ac-9cf6-791d7bf381d2)



fixes: https://github.com/KaotoIO/kaoto-ui/issues/2003