### PR TITLE
fix(vscode): Missing backend version in vscode

### DIFF
--- a/src/components/AppearanceModal.tsx
+++ b/src/components/AppearanceModal.tsx
@@ -38,7 +38,7 @@ const AppearanceModal = ({ handleCloseModal, isModalOpen }: IAppearanceModal) =>
   }, [settings.editorIsLightMode, storedTheme]);
 
   const onToggleSwitchEditorTheme = (newEditorCheckedState: boolean) => {
-    setSettings({ ...settings, editorIsLightMode: newEditorCheckedState });
+    setSettings({ editorIsLightMode: newEditorCheckedState });
     localStorage.setItem(LOCAL_STORAGE_EDITOR_THEME_KEY, `${newEditorCheckedState}`);
   };
 

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -86,9 +86,8 @@ export const KaotoToolbar = ({
   // fetch default namespace from the API,
   useEffect(() => {
     fetchDefaultNamespace().then((data) => {
-      const newSettings = settings;
-      newSettings.namespace = data.namespace;
-      setSettings(newSettings);
+      const namespace = data.namespace;
+      setSettings({ namespace});
     });
   }, []);
 

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -8,7 +8,7 @@ export const ThemeSwitcher = () => {
   const { settings, setSettings } = useSettingsStore();
 
   const onToggleSwitchTheme = (newUiCheckedState: boolean) => {
-    setSettings({ ...settings, uiLightMode: newUiCheckedState });
+    setSettings({ uiLightMode: newUiCheckedState });
     localStorage.setItem(LOCAL_STORAGE_UI_THEME_KEY, `${newUiCheckedState}`);
   };
 

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -98,7 +98,7 @@ const Visualization = () => {
         capabilities.dsls.forEach((dsl) => {
           if (dsl.name === flows[0].dsl) {
             const tmpSettings = { ...settings, dsl };
-            setSettings(tmpSettings);
+            setSettings({ dsl });
             fetchTheSourceCode({ flows, properties, metadata }, tmpSettings);
           }
         });

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -1,4 +1,3 @@
-import svg from '../assets/images/kaoto.svg';
 import { LOCAL_STORAGE_EDITOR_THEME_KEY, LOCAL_STORAGE_UI_THEME_KEY } from '@kaoto/constants';
 import { CodeEditorMode, IDsl, ISettings } from '@kaoto/types';
 import { create } from 'zustand';
@@ -23,7 +22,6 @@ export const initDsl: IDsl = {
 export const initialSettings: ISettings = {
   description: '',
   dsl: initDsl,
-  icon: svg,
   name: 'integration',
   namespace: '',
   editorIsLightMode: localStorage.getItem(LOCAL_STORAGE_EDITOR_THEME_KEY) === 'true',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,6 @@ export interface ISettings {
   uiLightMode: boolean;
   editorMode: CodeEditorMode;
 
-  icon?: string;
   // name of integration or deployment
   name: string;
   // Cluster namespace


### PR DESCRIPTION
### Context
Currently, there's a race condition caused between the `KogitoEditorIntegrationProvider.tsx` and the `KaotoToolbar.tsx` as the latter holds an outdated reference to the settings object, causing the backend version to be removed.

### Changes
The fix is to use the correct API for the 'setSettings()' hook in which we only pass the property to be updated and nothing more.

Also, there's an icon property set in the `settingsStore` which causes the comparison to be slower than needed, as it holds the base64 representation of an image.

fixes: https://github.com/KaotoIO/vscode-kaoto/issues/287