### PR TITLE
fix(vscode): Provide missing capabilities for @kie-core-tools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.css';
+import { CapabilitiesProvider } from './providers';
 import { useFlowsStore } from './store';
 import { bindUndoRedo } from './utils';
 import { AlertProvider, AppLayout, MASLoading } from '@kaoto/layout';
@@ -22,15 +23,17 @@ bindUndoRedo(undo, redo);
 
 export const App = () => {
   return (
-    <AlertProvider>
-      <Router>
-        <Suspense fallback={<MASLoading />}>
-          <AppLayout>
-            <AppRoutes />
-          </AppLayout>
-        </Suspense>
-      </Router>
-    </AlertProvider>
+    <CapabilitiesProvider>
+      <AlertProvider>
+        <Router>
+          <Suspense fallback={<MASLoading />}>
+            <AppLayout>
+              <AppRoutes />
+            </AppLayout>
+          </Suspense>
+        </Router>
+      </AlertProvider>
+    </CapabilitiesProvider>
   );
 };
 

--- a/src/kogito-integration/KaotoEditor.tsx
+++ b/src/kogito-integration/KaotoEditor.tsx
@@ -1,12 +1,17 @@
-import "./KaotoEditor.css";
-import { Suspense, forwardRef, useState, useCallback, useImperativeHandle, useRef } from "react";
-import { HashRouter as Router } from "react-router-dom";
-import { WorkspaceEdit } from "@kie-tools-core/workspace/dist/api";
-import { Notification } from "@kie-tools-core/notifications/dist/api";
-import { ChannelType, EditorApi, StateControlCommand } from "@kie-tools-core/editor/dist/api";
-import { AlertProvider, MASLoading, AppLayout } from "@kaoto/layout";
-import { AppRoutes } from "@kaoto/routes";
-import { KaotoIntegrationProviderRef, KogitoEditorIntegrationProvider, ContentOperation } from "./KogitoEditorIntegrationProvider";
+import './KaotoEditor.css';
+import {
+  ContentOperation,
+  KaotoIntegrationProviderRef,
+  KogitoEditorIntegrationProvider,
+} from './KogitoEditorIntegrationProvider';
+import { AlertProvider, AppLayout, MASLoading } from '@kaoto/layout';
+import { AppRoutes } from '@kaoto/routes';
+import { ChannelType, EditorApi, StateControlCommand } from '@kie-tools-core/editor/dist/api';
+import { Notification } from '@kie-tools-core/notifications/dist/api';
+import { WorkspaceEdit } from '@kie-tools-core/workspace/dist/api';
+import { Suspense, forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
+import { HashRouter as Router } from 'react-router-dom';
+import { CapabilitiesProvider } from '../providers';
 
 interface Props {
   /**
@@ -52,31 +57,30 @@ export const KaotoEditor = forwardRef<EditorApi, Props>((props, forwardedRef) =>
    * the editorContent, which is the state that has the kaoto yaml.
    */
   const getContent = useCallback(() => {
-    return editorContent || "";
+    return editorContent || '';
   }, [editorContent]);
-
 
   /**
    * Callback is exposed to the Channel that is called when a new file is opened. It sets the originalContent to the received value.
    */
-  const setContent = useCallback(
-    (path: string, content: string) => {
-      setEditorContent(content);
-      setContentPath(path);
-    },
-    []
-  );
+  const setContent = useCallback((path: string, content: string) => {
+    setEditorContent(content);
+    setContentPath(path);
+  }, []);
 
-  const onContentChanged = useCallback((newContent: string, operation: ContentOperation) => {
-    setEditorContent(newContent);
-    if (operation === ContentOperation.EDIT) {
-      props.onNewEdit(new WorkspaceEdit(newContent));
-    } else if (operation === ContentOperation.UNDO) {
-      props.onStateControlCommandUpdate(StateControlCommand.UNDO);
-    } else if (operation === ContentOperation.REDO) {
-      props.onStateControlCommandUpdate(StateControlCommand.REDO);
-    }
-  }, [props]);
+  const onContentChanged = useCallback(
+    (newContent: string, operation: ContentOperation) => {
+      setEditorContent(newContent);
+      if (operation === ContentOperation.EDIT) {
+        props.onNewEdit(new WorkspaceEdit(newContent));
+      } else if (operation === ContentOperation.UNDO) {
+        props.onStateControlCommandUpdate(StateControlCommand.UNDO);
+      } else if (operation === ContentOperation.REDO) {
+        props.onStateControlCommandUpdate(StateControlCommand.REDO);
+      }
+    },
+    [props],
+  );
 
   /**
    * The useImperativeHandler gives the control of the Editor component to who has it's reference, making it possible to communicate with the Editor.
@@ -102,24 +106,28 @@ export const KaotoEditor = forwardRef<EditorApi, Props>((props, forwardedRef) =>
   return (
     <>
       {editorContent !== undefined && contentPath !== undefined ? (
-        <KogitoEditorIntegrationProvider
-        content={editorContent}
-        contentPath={contentPath}
-        onContentChanged={onContentChanged}
-        onReady={props.onReady}
-        ref={providerRef}
-      >
-        <AlertProvider>
-          <Router>
-            <Suspense fallback={<MASLoading />}>
-              <AppLayout>
-                <AppRoutes />
-              </AppLayout>
-            </Suspense>
-          </Router>
-        </AlertProvider>
-      </KogitoEditorIntegrationProvider>
-      ) : <MASLoading />}
+        <CapabilitiesProvider>
+          <KogitoEditorIntegrationProvider
+            content={editorContent}
+            contentPath={contentPath}
+            onContentChanged={onContentChanged}
+            onReady={props.onReady}
+            ref={providerRef}
+          >
+            <AlertProvider>
+              <Router>
+                <Suspense fallback={<MASLoading />}>
+                  <AppLayout>
+                    <AppRoutes />
+                  </AppLayout>
+                </Suspense>
+              </Router>
+            </AlertProvider>
+          </KogitoEditorIntegrationProvider>
+        </CapabilitiesProvider>
+      ) : (
+        <MASLoading />
+      )}
     </>
   );
 });

--- a/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
+++ b/src/kogito-integration/KogitoEditorIntegrationProvider.tsx
@@ -105,7 +105,7 @@ function KogitoEditorIntegrationProviderInternal(
     [pastStates, redo, undo],
   );
 
-  // Update the integrationJson to reflect an KaotoEditor content change (only if not triggered via Kaoto UI).
+  // Update the integrationJson to reflect a KaotoEditor content change (only if not triggered via Kaoto UI).
   useCancelableEffect(
     useCallback(
       ({ canceled }) => {

--- a/src/layout/AppLayout.test.tsx
+++ b/src/layout/AppLayout.test.tsx
@@ -1,122 +1,18 @@
 import { AppLayout } from './AppLayout';
-import { fetchBackendVersion, fetchCapabilities } from '@kaoto/api';
-import { useSettingsStore } from '@kaoto/store';
-import { act, render } from '@testing-library/react';
-
-jest.mock('@kaoto/api', () => {
-  const actual = jest.requireActual('@kaoto/api');
-
-  return {
-    ...actual,
-    fetchBackendVersion: jest.fn(),
-    fetchCapabilities: jest.fn(),
-  };
-});
+import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 
 describe('AppLayout.tsx', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-    (fetchBackendVersion as jest.Mock).mockRejectedValue(null);
-    (fetchCapabilities as jest.Mock).mockResolvedValue([]);
-  });
-
-  afterEach(() => {
-    jest.clearAllTimers();
-    jest.useRealTimers();
-    (fetchBackendVersion as jest.Mock).mockClear();
-    (fetchCapabilities as jest.Mock).mockClear();
-  });
-
-  test('component renders in loading mode', async () => {
-    const wrapper = render(
-      <AppLayout>
+  test('component renders correctly', async () => {
+    act(() => {
+      render(<AppLayout>
         <span data-testid="children">This is a placeholder</span>
-      </AppLayout>,
-    );
-
-    const element = wrapper.queryByTestId('children');
-    expect(element).not.toBeInTheDocument();
-  });
-
-  test('component times out and display error message', async () => {
-    const wrapper = render(
-      <AppLayout>
-        <span data-testid="children">This is a placeholder</span>
-      </AppLayout>,
-    );
-
-    for (let i = 0; i <= 120; i++) {
-      await act(async () => {
-        jest.advanceTimersByTime(1_100);
-      });
-    }
-
-    const element = wrapper.queryByText('Kaoto API is unreachable');
-    expect(element).toBeInTheDocument();
-  });
-
-  test('component display its children once the API has been reached', async () => {
-    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
-
-    const wrapper = render(
-      <AppLayout>
-        <span data-testid="children">This is a placeholder</span>
-      </AppLayout>,
-    );
-
-    await act(async () => {
-      jest.advanceTimersByTime(1_100);
+      </AppLayout>);
     });
 
-    const element = wrapper.queryByText('This is a placeholder');
-    expect(element).toBeInTheDocument();
-  });
-
-  test('component fetch capabilities and saves it to the settings store', async () => {
-    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
-    (fetchCapabilities as jest.Mock).mockResolvedValueOnce({
-      dsls: [
-        {
-          output: 'true',
-          input: 'true',
-          validationSchema: '/v1/capabilities/Integration/schema',
-          deployable: 'true',
-          name: 'Integration',
-          description: 'An Integration defines a workflow of actions and steps.',
-          'step-kinds': '[CAMEL-CONNECTOR, EIP, EIP-BRANCH]',
-        },
-      ],
+    await waitFor(() => {
+      const element = screen.getByTestId('children');
+      expect(element).toBeInTheDocument();
     });
-
-    render(
-      <AppLayout>
-        <span data-testid="children">This is a placeholder</span>
-      </AppLayout>,
-    );
-
-    await act(async () => {
-      jest.advanceTimersByTime(1_100);
-    });
-
-    expect(useSettingsStore.getState().settings.capabilities[0].name).toEqual('Integration');
-  });
-
-  test('component fetch capabilities and errors out', async () => {
-    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
-    (fetchCapabilities as jest.Mock).mockRejectedValueOnce(new Error('Wild error!'));
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
-
-    render(
-      <AppLayout>
-        <span data-testid="children">This is a placeholder</span>
-      </AppLayout>,
-    );
-
-    await act(async () => {
-      jest.advanceTimersByTime(1_100);
-    });
-
-    expect(useSettingsStore.getState().settings.capabilities).toEqual([]);
-    expect(consoleSpy).toHaveBeenCalledWith('Error when fetching capabilities', expect.any(Error));
   });
 });

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,65 +1,6 @@
-import { WaitingPage } from '../components/WaitingPage';
-import { useSettingsStore } from '../store';
-import { fetchBackendVersion, fetchCapabilities } from '@kaoto/api';
-import { sleep } from '@kaoto/utils';
 import { Panel } from '@patternfly/react-core';
-import { ReactNode, useEffect, useState } from 'react';
-import { shallow } from 'zustand/shallow';
+import { FunctionComponent, PropsWithChildren } from 'react';
 
-interface IAppLayout {
-  children: ReactNode;
-}
-
-export const AppLayout = ({ children }: IAppLayout) => {
-  const [backendAvailable, setBackendAvailable] = useState(false);
-  const [message, setMessage] = useState('Trying to reach the Kaoto API');
-  const [fetching, setFetching] = useState(true);
-  const { namespace, setSettings } = useSettingsStore(
-    ({ settings, setSettings }) => ({ namespace: settings.namespace, setSettings }),
-    shallow,
-  );
-
-  useEffect(() => {
-    // Method that tries to connect to capabilities/version endpoint and evaluate if the API is available
-    const tryApiAvailable = (retries: number) => {
-      fetchBackendVersion()
-        .then((response) => {
-          if (response) {
-            setBackendAvailable(true);
-            setMessage('Trying to reach the Kaoto API');
-            setSettings({ backendVersion: response });
-          }
-        })
-        .catch(() => {
-          if (retries > 0) {
-            sleep(1_000).then(() => {
-              tryApiAvailable(retries - 1);
-            });
-          } else {
-            setBackendAvailable(false);
-            setMessage('Kaoto API is unreachable');
-            setFetching(false);
-          }
-        });
-    };
-    // try to fetch api for 120seconds
-    tryApiAvailable(120);
-  }, []);
-
-  useEffect(() => {
-    /** Dispatch call for getting the available capabilities without waiting for it */
-    fetchCapabilities(namespace).then((capabilities) => {
-      if (Array.isArray(capabilities?.dsls)) {
-        setSettings({ capabilities: capabilities.dsls });
-      }
-    }).catch((reason) => {
-      console.error('Error when fetching capabilities', reason);
-    });
-  }, [namespace, setSettings]);
-
-  return (
-    <Panel style={{ flexGrow: 1 }}>
-      {backendAvailable ? children : <WaitingPage fetching={fetching} message={message} />}
-    </Panel>
-  );
+export const AppLayout: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  return <Panel style={{ flexGrow: 1 }}>{children}</Panel>;
 };

--- a/src/providers/capabilities.provider.test.tsx
+++ b/src/providers/capabilities.provider.test.tsx
@@ -1,0 +1,180 @@
+import { CapabilitiesProvider } from './capabilities.provider';
+import { fetchBackendVersion, fetchCapabilities } from '@kaoto/api';
+import { initDsl, useSettingsStore } from '@kaoto/store';
+import { act, render } from '@testing-library/react';
+
+jest.mock('@kaoto/api', () => {
+  const actual = jest.requireActual('@kaoto/api');
+
+  return {
+    ...actual,
+    fetchBackendVersion: jest.fn(),
+    fetchCapabilities: jest.fn(),
+  };
+});
+
+describe('capabilities.provider.tsx', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (fetchBackendVersion as jest.Mock).mockRejectedValue(null);
+    (fetchCapabilities as jest.Mock).mockResolvedValue({ dsls: [initDsl] });
+    consoleSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    (fetchBackendVersion as jest.Mock).mockClear();
+    (fetchCapabilities as jest.Mock).mockClear();
+  });
+
+  test('component renders in loading mode', async () => {
+    const wrapper = await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    const element = wrapper.queryByTestId('children');
+    expect(element).not.toBeInTheDocument();
+  });
+
+  test('component times out and display error message', async () => {
+    const wrapper = await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    for (let i = 0; i <= 120; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1_100);
+      });
+    }
+
+    const element = wrapper.queryByText('Kaoto API is unreachable');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('component times out and display error message when there are no capabilities', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockResolvedValueOnce({ ds: [] });
+
+    const wrapper = await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    for (let i = 0; i <= 120; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1_100);
+      });
+    }
+
+    const element = wrapper.queryByText('Kaoto API is unreachable');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('component times out and display error message when the capabilities API fails', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockRejectedValueOnce(new Error('Wild error!'));
+
+    const wrapper = await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    for (let i = 0; i <= 120; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(1_100);
+      });
+    }
+
+    const element = wrapper.queryByText('Kaoto API is unreachable');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('component display its children once the API has been reached', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockResolvedValueOnce({ dsls: [initDsl] });
+
+    const wrapper = await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_100);
+    });
+
+    const element = wrapper.queryByText('This is a placeholder');
+    expect(element).toBeInTheDocument();
+  });
+
+  test('component fetch capabilities and saves it to the settings store', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockResolvedValueOnce({
+      dsls: [
+        {
+          output: 'true',
+          input: 'true',
+          validationSchema: '/v1/capabilities/Integration/schema',
+          deployable: 'true',
+          name: 'Integration',
+          description: 'An Integration defines a workflow of actions and steps.',
+          'step-kinds': '[CAMEL-CONNECTOR, EIP, EIP-BRANCH]',
+        },
+      ],
+    });
+
+    await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_100);
+    });
+
+    expect(useSettingsStore.getState().settings.capabilities[0].name).toEqual('Integration');
+  });
+
+  test('component fetch capabilities and errors out', async () => {
+    (fetchBackendVersion as jest.Mock).mockResolvedValueOnce('1.0-backend-version');
+    (fetchCapabilities as jest.Mock).mockRejectedValueOnce(new Error('Wild error!'));
+
+    await act(async () =>
+      render(
+        <CapabilitiesProvider>
+          <span data-testid="children">This is a placeholder</span>
+        </CapabilitiesProvider>,
+      ),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1_100);
+    });
+
+    expect(useSettingsStore.getState().settings.capabilities).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith('Error when fetching capabilities', expect.any(Error));
+  });
+});

--- a/src/providers/capabilities.provider.tsx
+++ b/src/providers/capabilities.provider.tsx
@@ -1,0 +1,79 @@
+import { WaitingPage } from '../components/WaitingPage';
+import { useSettingsStore } from '../store';
+import { IDsl } from '../types';
+import { sleep } from '../utils';
+import { fetchBackendVersion, fetchCapabilities } from '@kaoto/api';
+import { FunctionComponent, PropsWithChildren, createContext, useCallback, useEffect, useState } from 'react';
+import { shallow } from 'zustand/shallow';
+
+export const Capabilities = createContext<IDsl[]>([]);
+
+export const CapabilitiesProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const [backendAvailable, setBackendAvailable] = useState(false);
+  const [message, setMessage] = useState('Trying to reach the Kaoto API');
+  const [fetching, setFetching] = useState(true);
+  const { namespace, capabilities, setSettings } = useSettingsStore(
+    (state) => ({
+      namespace: state.settings.namespace,
+      capabilities: state.settings.capabilities,
+      setSettings: state.setSettings,
+    }),
+    shallow,
+  );
+
+  const notifyBackendUnavailable = useCallback(() => {
+    setBackendAvailable(false);
+    setMessage('Kaoto API is unreachable');
+    setFetching(false);
+  }, []);
+
+  useEffect(() => {
+    // Method that tries to connect to capabilities/version endpoint and evaluate if the API is available
+    const tryApiAvailable = (retries: number) => {
+      fetchBackendVersion()
+        .then((response) => {
+          if (response) {
+            setBackendAvailable(true);
+            setSettings({ backendVersion: response });
+          }
+        })
+        .catch(() => {
+          if (retries > 0) {
+            sleep(1_000).then(() => {
+              tryApiAvailable(retries - 1);
+            });
+          } else {
+            notifyBackendUnavailable();
+          }
+        });
+    };
+    // try to fetch api for 120seconds
+    tryApiAvailable(120);
+  }, []);
+
+  useEffect(() => {
+    /** Dispatch call for getting the available capabilities without waiting for it */
+    fetchCapabilities(namespace)
+      .then((response) => {
+        if (!Array.isArray(response?.dsls) || !response?.dsls?.length) {
+          throw new Error('Invalid response from capabilities endpoint');
+        }
+
+        setSettings({ capabilities: response.dsls });
+      })
+      .catch((reason) => {
+        console.error('Error when fetching capabilities', reason);
+        notifyBackendUnavailable();
+      });
+  }, []);
+
+  return (
+    <Capabilities.Provider value={capabilities}>
+      {backendAvailable && capabilities.length ? (
+        children
+      ) : (
+        <WaitingPage fetching={fetching} message={message} />
+      )}
+    </Capabilities.Provider>
+  );
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './capabilities.provider';


### PR DESCRIPTION
### Context
Currently, we're fetching the capabilities once upon loading the app, and later on, we iterate over the already fetched array to save HTTP calls.

This presents a problem for our integration with `@kie-core-tools` as the capabilities are fetched in a child component (`AppLayout.tsx`) of the provider component (`KaotoEditor.tsx`).

### Changes
The solution is to fetch the capabilities in an earlier phase, in the new `CapabilitiesProvider` (`capabilities.provider.tsx`) to ensure the information is available.

fixes: https://github.com/KaotoIO/vscode-kaoto/issues/293
fixes: https://github.com/KaotoIO/kaoto-ui/issues/1804