### PR TITLE
fix(viz): Use metadata.name as flow identifier

### DIFF
--- a/cypress/e2e/11-multi_flow/code_editor_multi_flow.cy.js
+++ b/cypress/e2e/11-multi_flow/code_editor_multi_flow.cy.js
@@ -94,8 +94,7 @@ spec:
     cy.get('[data-testid="viz-step-set-header"]').should('be.visible');
   });
 
-  // Blocked by - https://github.com/KaotoIO/kaoto-ui/issues/1910
-  it.skip('User adds step to the second route using code editor', () => {
+  it('User adds step to the second route using code editor', () => {
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
     cy.showAllRoutes();

--- a/cypress/fixtures/IntegrationMultiFlow.yaml
+++ b/cypress/fixtures/IntegrationMultiFlow.yaml
@@ -1,7 +1,7 @@
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
-  name: ''
+  name: 'Integration-1'
 spec:
   flows:
   - from:
@@ -17,7 +17,7 @@ spec:
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
-  name: ''
+  name: 'Integration-2'
 spec:
   flows:
   - from:

--- a/cypress/support/kaoto-ui-commands/editor.js
+++ b/cypress/support/kaoto-ui-commands/editor.js
@@ -18,11 +18,10 @@ Cypress.Commands.add('openCodeEditor', () => {
 });
 
 Cypress.Commands.add('editorAddText', (line, text) => {
-    const arr = text.split('\n');
-    Array.from({ length: arr.length }).forEach((_, i) => {
+    text.split('\n').forEach((lineToWrite, i) => {
         cy.get('.code-editor')
             .click()
-            .type('{pageUp}{pageUp}' + '{downArrow}'.repeat(line + i) + '{enter}{upArrow}' + arr[i], {
+            .type('{pageUp}{pageUp}' + '{downArrow}'.repeat(line + i) + '{enter}{upArrow}' + lineToWrite, {
                 delay: 1,
             });
     });

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,4 +1,4 @@
-import { stepsCatalog } from './src/stubs';
+import { capabilitiesStub, stepsCatalog } from './src/stubs';
 import '@testing-library/jest-dom';
 import { TextEncoder } from 'util';
 import 'whatwg-fetch';
@@ -12,5 +12,13 @@ jest.mock('@kaoto/api', () => {
   return {
     ...actual,
     fetchCatalogSteps: jest.fn().mockResolvedValue(stepsCatalog),
+    fetchDefaultNamespace: jest.fn().mockResolvedValue({ namespace: 'default' }),
+    fetchDeployments: jest.fn().mockResolvedValue([]),
+    startDeployment: jest.fn().mockResolvedValue(''),
+    stopDeployment: jest.fn().mockResolvedValue(''),
+
+    fetchCapabilities: jest.fn().mockResolvedValue(capabilitiesStub),
+    fetchIntegrationSourceCode: jest.fn().mockResolvedValue(''),
+    fetchViews: jest.fn().mockResolvedValue([]),
   };
 });

--- a/src/components/Flows/FlowsList.test.tsx
+++ b/src/components/Flows/FlowsList.test.tsx
@@ -1,3 +1,4 @@
+import { FlowsService } from '../../services/FlowsService';
 import { FlowsList } from './FlowsList';
 import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
 import { act, fireEvent, render } from '@testing-library/react';
@@ -5,8 +6,11 @@ import { act, fireEvent, render } from '@testing-library/react';
 describe('FlowsList.tsx', () => {
   beforeEach(() => {
     useFlowsStore.getState().deleteAllFlows();
-    useFlowsStore.getState().addNewFlow('Integration', 'route-1234');
-    useFlowsStore.getState().addNewFlow('Integration', 'route-4321');
+
+    jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-1234');
+    jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-4321');
+    useFlowsStore.getState().addNewFlow('Integration');
+    useFlowsStore.getState().addNewFlow('Integration');
   });
 
   test('should render the existing flows', async () => {

--- a/src/components/Flows/FlowsMenu.test.tsx
+++ b/src/components/Flows/FlowsMenu.test.tsx
@@ -1,3 +1,4 @@
+import { FlowsService } from '../../services';
 import { FlowsMenu } from './FlowsMenu';
 import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
@@ -5,8 +6,11 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react';
 describe('FlowsMenu.tsx', () => {
   beforeEach(() => {
     useFlowsStore.getState().deleteAllFlows();
-    useFlowsStore.getState().addNewFlow('Integration', 'route-1234');
-    useFlowsStore.getState().addNewFlow('Integration', 'route-4321');
+
+    jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-1234');
+    jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-4321');
+    useFlowsStore.getState().addNewFlow('Integration');
+    useFlowsStore.getState().addNewFlow('Integration');
   });
 
   test('should open the flows list when clicking the dropdown', async () => {

--- a/src/components/KaotoToolbar.test.tsx
+++ b/src/components/KaotoToolbar.test.tsx
@@ -1,48 +1,76 @@
 import { KaotoToolbar } from './KaotoToolbar';
+import { fetchDefaultNamespace } from '@kaoto/api';
 import { AlertProvider } from '@kaoto/layout';
-import { screen, render, fireEvent, act } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
+import { useSettingsStore } from '@kaoto/store';
 
 describe('KaotoToolbar.tsx', () => {
-  test('component renders correctly', () => {
-    render(
-      <AlertProvider>
-        <KaotoToolbar
-          leftDrawerExpanded
-          toggleCatalog={jest.fn()}
-          toggleCodeEditor={jest.fn()}
-          hideLeftPanel={jest.fn()}
-        />
-      </AlertProvider>
+  test('component renders correctly', async () => {
+    const wrapper = await act(async () =>
+      render(
+        <AlertProvider>
+          <KaotoToolbar
+            leftDrawerExpanded
+            toggleCatalog={jest.fn()}
+            toggleCodeEditor={jest.fn()}
+            hideLeftPanel={jest.fn()}
+          />
+        </AlertProvider>,
+      ),
     );
-    const element = screen.getByTestId('viz-toolbar');
+
+    const element = wrapper.getByTestId('viz-toolbar');
     expect(element).toBeInTheDocument();
   });
 
-  test('logo renders correctly', () => {
-    render(
-      <AlertProvider>
-        <KaotoToolbar
-          leftDrawerExpanded
-          toggleCatalog={jest.fn()}
-          toggleCodeEditor={jest.fn()}
-          hideLeftPanel={jest.fn()}
-        />
-      </AlertProvider>
+  test('logo renders correctly', async () => {
+    const wrapper = await act(async () =>
+      render(
+        <AlertProvider>
+          <KaotoToolbar
+            leftDrawerExpanded
+            toggleCatalog={jest.fn()}
+            toggleCodeEditor={jest.fn()}
+            hideLeftPanel={jest.fn()}
+          />
+        </AlertProvider>,
+      ),
     );
-    const element = screen.getByTestId('kaoto-logo');
+
+    const element = wrapper.getByTestId('kaoto-logo');
     expect(element).toBeInTheDocument();
+  });
+
+  test('should fetch the default namespace', async () => {
+    await act(async () =>
+      render(
+        <AlertProvider>
+          <KaotoToolbar
+            leftDrawerExpanded
+            toggleCatalog={jest.fn()}
+            toggleCodeEditor={jest.fn()}
+            hideLeftPanel={jest.fn()}
+          />
+        </AlertProvider>,
+      ),
+    );
+
+    expect(fetchDefaultNamespace).toHaveBeenCalled();
+    expect(useSettingsStore.getState().settings.namespace).toBe('default');
   });
 
   test('open about modal', async () => {
-    const wrapper = render(
-      <AlertProvider>
-        <KaotoToolbar
-          leftDrawerExpanded
-          toggleCatalog={jest.fn()}
-          toggleCodeEditor={jest.fn()}
-          hideLeftPanel={jest.fn()}
-        />
-      </AlertProvider>
+    const wrapper = await act(async () =>
+      render(
+        <AlertProvider>
+          <KaotoToolbar
+            leftDrawerExpanded
+            toggleCatalog={jest.fn()}
+            toggleCodeEditor={jest.fn()}
+            hideLeftPanel={jest.fn()}
+          />
+        </AlertProvider>,
+      ),
     );
 
     const kebabDropdownMenu = wrapper.getByTestId('toolbar-kebab-dropdown-toggle');

--- a/src/components/KaotoToolbar.tsx
+++ b/src/components/KaotoToolbar.tsx
@@ -87,7 +87,7 @@ export const KaotoToolbar = ({
   useEffect(() => {
     fetchDefaultNamespace().then((data) => {
       const namespace = data.namespace;
-      setSettings({ namespace});
+      setSettings({ namespace });
     });
   }, []);
 
@@ -394,7 +394,7 @@ export const KaotoToolbar = ({
           setSourceCode('');
 
           /** TODO: Check whether this configuration is required to be kept inside of settingsStore */
-          setSettings({ name: 'integration', namespace: 'default' });
+          setSettings({ namespace: 'default' });
           setIsConfirmationModalOpen(false);
         }}
         isModalOpen={isConfirmationModalOpen}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1,39 +1,49 @@
 import { AlertProvider } from '../layout';
 import { SettingsModal } from './SettingsModal';
-import { fireEvent, screen } from '@testing-library/dom';
-import { render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+import { act, render } from '@testing-library/react';
 
 describe('SettingsModal.tsx', () => {
-  test('component renders if open', () => {
-    render(
-      <AlertProvider>
-        <SettingsModal handleCloseModal={jest.fn()} isModalOpen={true} />
-      </AlertProvider>
+  test('component renders if open', async () => {
+    const wrapper = await act(async () =>
+      render(
+        <AlertProvider>
+          <SettingsModal handleCloseModal={jest.fn()} isModalOpen={true} />
+        </AlertProvider>,
+      ),
     );
-    const element = screen.queryByTestId('settings-modal');
+    const element = wrapper.queryByTestId('settings-modal');
     expect(element).toBeInTheDocument();
   });
 
-  test('component does not render if closed', () => {
-    render(
-      <AlertProvider>
-        <SettingsModal handleCloseModal={jest.fn()} isModalOpen={false} />
-      </AlertProvider>
+  test('component does not render if closed', async () => {
+    const wrapper = await act(async () =>
+      render(
+        <AlertProvider>
+          <SettingsModal handleCloseModal={jest.fn()} isModalOpen={false} />
+        </AlertProvider>,
+      ),
     );
-    const element = screen.queryByTestId('settings-modal');
+    const element = wrapper.queryByTestId('settings-modal');
     expect(element).not.toBeInTheDocument();
   });
 
-  test('handleCloseModal is called', () => {
+  test('handleCloseModal is called', async () => {
     const mockClose = jest.fn();
 
-    render(
-      <AlertProvider>
-        <SettingsModal handleCloseModal={mockClose} isModalOpen={true} />
-      </AlertProvider>
+    const wrapper = await act(async () =>
+      render(
+        <AlertProvider>
+          <SettingsModal handleCloseModal={mockClose} isModalOpen={true} />
+        </AlertProvider>,
+      ),
     );
-    const saveButton = screen.getByTestId('settings-modal--save');
-    fireEvent.click(saveButton);
+
+    await act(async () => {
+      const saveButton = wrapper.getByTestId('settings-modal--save');
+      fireEvent.click(saveButton);
+    });
+
     expect(mockClose).toHaveBeenCalled();
   });
 });

--- a/src/components/Visualization.test.tsx
+++ b/src/components/Visualization.test.tsx
@@ -1,23 +1,10 @@
 import { AlertProvider } from '../layout';
-import { capabilitiesStub } from '../stubs';
 import { integrationJSONStub, stepsStub } from '../stubs/steps';
 import { Visualization } from './Visualization';
-import { fetchCapabilities, fetchIntegrationSourceCode, fetchViews } from '@kaoto/api';
 import { RFState, useFlowsStore, useVisualizationStore } from '@kaoto/store';
 import { IFlowsWrapper } from '@kaoto/types';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-
-jest.mock('@kaoto/api', () => {
-  const actual = jest.requireActual('@kaoto/api');
-
-  return {
-    ...actual,
-    fetchViews: jest.fn(),
-    fetchCapabilities: jest.fn(),
-    fetchIntegrationSourceCode: jest.fn(),
-  };
-});
 
 beforeAll(() => {
   // Setup ResizeObserver and offset* properties
@@ -45,10 +32,6 @@ beforeAll(() => {
   });
 
   (window.SVGElement as any).prototype.getBBox = () => ({ x: 0, y: 0, width: 0, height: 0 });
-
-  jest.mocked(fetchCapabilities).mockResolvedValue(capabilitiesStub);
-  jest.mocked(fetchIntegrationSourceCode).mockResolvedValue('');
-  jest.mocked(fetchViews).mockResolvedValue([]);
 });
 
 beforeEach(() => {

--- a/src/services/FlowsService.test.ts
+++ b/src/services/FlowsService.test.ts
@@ -17,231 +17,233 @@ describe('FlowsService', () => {
       });
     });
 
-    it('should generate a new flow with the provided ID', () => {
-      const newFlow = FlowsService.getNewFlow('Integration', 'Arbitrary-Id');
+    it('should generate a new flow with the provided metadata.name', () => {
+      const newFlow = FlowsService.getNewFlow('Integration', {
+        metadata: { name: 'my-integration', prop1: 100 },
+      });
 
       expect(newFlow).toMatchObject({
-        id: 'Arbitrary-Id',
+        id: 'my-integration',
         dsl: 'Integration',
         description: '',
-        metadata: {},
+        metadata: { name: 'my-integration', prop1: 100 },
         params: [],
         steps: [],
       });
     });
-  });
 
-  it('should generate a new flow with the provided metadata', () => {
-    const newFlow = FlowsService.getNewFlow('Integration', 'Arbitrary-Id', {
-      metadata: { prop1: 100 },
+    it('should generate a new flow with the provided metadata', () => {
+      const newFlow = FlowsService.getNewFlow('Integration', {
+        metadata: { prop1: 100 },
+      });
+
+      expect(newFlow).toMatchObject({
+        id: /route-\d{4}/,
+        dsl: 'Integration',
+        description: '',
+        metadata: { prop1: 100 },
+        params: [],
+        steps: [],
+      });
     });
 
-    expect(newFlow).toMatchObject({
-      id: 'Arbitrary-Id',
-      dsl: 'Integration',
-      description: '',
-      metadata: { prop1: 100 },
-      params: [],
-      steps: [],
-    });
-  });
+    describe('regenerateUuids(): should (re)generate UUIDs for all steps', () => {
+      it('should generate UUIDs for the main steps array', () => {
+        const result = FlowsService.regenerateUuids('Camel Route-1', integrationSteps);
 
-  describe('regenerateUuids(): should (re)generate UUIDs for all steps', () => {
-    it('should generate UUIDs for the main steps array', () => {
-      const result = FlowsService.regenerateUuids('Camel Route-1', integrationSteps);
+        expect(result).toMatchObject<Partial<IStepProps>[]>([
+          { UUID: 'Camel Route-1_timer-0' },
+          { UUID: 'Camel Route-1_choice-1' },
+        ]);
+      });
 
-      expect(result).toMatchObject<Partial<IStepProps>[]>([
-        { UUID: 'Camel Route-1_timer-0' },
-        { UUID: 'Camel Route-1_choice-1' },
-      ]);
-    });
+      it('should generate UUIDs for branches', () => {
+        const result = FlowsService.regenerateUuids('Camel Route-1', integrationSteps);
 
-    it('should generate UUIDs for branches', () => {
-      const result = FlowsService.regenerateUuids('Camel Route-1', integrationSteps);
+        expect(result).toMatchObject<Partial<IStepProps>[]>([
+          { UUID: 'Camel Route-1_timer-0', branches: [] },
+          {
+            UUID: 'Camel Route-1_choice-1',
+            branches: [
+              {
+                branchUuid: 'Camel Route-1_choice-1_branch-0',
+                steps: expect.any(Array),
+                identifier: 'true path',
+              },
+              {
+                branchUuid: 'Camel Route-1_choice-1_branch-1',
+                steps: expect.any(Array),
+                identifier: 'otherwise',
+              },
+            ],
+          },
+        ]);
+      });
 
-      expect(result).toMatchObject<Partial<IStepProps>[]>([
-        { UUID: 'Camel Route-1_timer-0', branches: [] },
-        {
-          UUID: 'Camel Route-1_choice-1',
-          branches: [
-            {
-              branchUuid: 'Camel Route-1_choice-1_branch-0',
-              steps: expect.any(Array),
-              identifier: 'true path',
-            },
-            {
-              branchUuid: 'Camel Route-1_choice-1_branch-1',
-              steps: expect.any(Array),
-              identifier: 'otherwise',
-            },
-          ],
-        },
-      ]);
-    });
+      it('should generate UUIDs for nested steps', () => {
+        const result = FlowsService.regenerateUuids('Camel Route-1', integrationSteps);
 
-    it('should generate UUIDs for nested steps', () => {
-      const result = FlowsService.regenerateUuids('Camel Route-1', integrationSteps);
+        expect(result).toMatchObject<Partial<IStepProps>[]>([
+          { UUID: 'Camel Route-1_timer-0', branches: [] },
+          {
+            UUID: 'Camel Route-1_choice-1',
+            branches: [
+              {
+                branchUuid: 'Camel Route-1_choice-1_branch-0',
+                steps: [
+                  {
+                    UUID: 'Camel Route-1_choice-1_branch-0_log-0',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 0,
+                    maxBranches: 0,
+                    name: 'log',
+                    type: 'MIDDLE',
+                  },
+                ],
+                identifier: 'true path',
+              },
+              {
+                branchUuid: 'Camel Route-1_choice-1_branch-1',
+                steps: [
+                  {
+                    UUID: 'Camel Route-1_choice-1_branch-1_log-0',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 0,
+                    maxBranches: 0,
+                    name: 'log',
+                    type: 'MIDDLE',
+                  },
+                ],
+                identifier: 'otherwise',
+              },
+            ],
+          },
+        ]);
+      });
 
-      expect(result).toMatchObject<Partial<IStepProps>[]>([
-        { UUID: 'Camel Route-1_timer-0', branches: [] },
-        {
-          UUID: 'Camel Route-1_choice-1',
-          branches: [
-            {
-              branchUuid: 'Camel Route-1_choice-1_branch-0',
-              steps: [
-                {
-                  UUID: 'Camel Route-1_choice-1_branch-0_log-0',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 0,
-                  maxBranches: 0,
-                  name: 'log',
-                  type: 'MIDDLE',
-                },
-              ],
-              identifier: 'true path',
-            },
-            {
-              branchUuid: 'Camel Route-1_choice-1_branch-1',
-              steps: [
-                {
-                  UUID: 'Camel Route-1_choice-1_branch-1_log-0',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 0,
-                  maxBranches: 0,
-                  name: 'log',
-                  type: 'MIDDLE',
-                },
-              ],
-              identifier: 'otherwise',
-            },
-          ],
-        },
-      ]);
-    });
+      it('should generate UUIDs for nested steps at two levels deep', () => {
+        const nestedIntegrationSteps: IStepProps[] = JSON.parse(JSON.stringify(integrationSteps));
+        nestedIntegrationSteps[1].branches![0].steps = integrationSteps;
 
-    it('should generate UUIDs for nested steps at two levels deep', () => {
-      const nestedIntegrationSteps: IStepProps[] = JSON.parse(JSON.stringify(integrationSteps));
-      nestedIntegrationSteps[1].branches![0].steps = integrationSteps;
+        const result = FlowsService.regenerateUuids('Camel Route-1', nestedIntegrationSteps);
 
-      const result = FlowsService.regenerateUuids('Camel Route-1', nestedIntegrationSteps);
+        expect(result).toMatchObject<Partial<IStepProps>[]>([
+          { UUID: 'Camel Route-1_timer-0', branches: [] },
+          {
+            UUID: 'Camel Route-1_choice-1',
+            branches: [
+              {
+                branchUuid: 'Camel Route-1_choice-1_branch-0',
+                steps: [
+                  {
+                    UUID: 'Camel Route-1_choice-1_branch-0_timer-0',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 0,
+                    maxBranches: 0,
+                    name: 'timer',
+                    type: 'START',
+                    branches: [],
+                  },
+                  {
+                    UUID: 'Camel Route-1_choice-1_branch-0_choice-1',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 1,
+                    maxBranches: -1,
+                    name: 'choice',
+                    type: 'MIDDLE',
+                    branches: [
+                      {
+                        branchUuid: 'Camel Route-1_choice-1_branch-0_choice-1_branch-0',
+                        steps: [
+                          {
+                            UUID: 'Camel Route-1_choice-1_branch-0_choice-1_branch-0_log-0',
+                            integrationId: 'Camel Route-1',
+                            minBranches: 0,
+                            maxBranches: 0,
+                            name: 'log',
+                            type: 'MIDDLE',
+                          },
+                        ],
+                        identifier: 'true path',
+                      },
+                      {
+                        branchUuid: 'Camel Route-1_choice-1_branch-0_choice-1_branch-1',
+                        steps: [
+                          {
+                            UUID: 'Camel Route-1_choice-1_branch-0_choice-1_branch-1_log-0',
+                            integrationId: 'Camel Route-1',
+                            minBranches: 0,
+                            maxBranches: 0,
+                            name: 'log',
+                            type: 'MIDDLE',
+                          },
+                        ],
+                        identifier: 'otherwise',
+                      },
+                    ],
+                  },
+                ],
+                identifier: 'true path',
+              },
+              {
+                branchUuid: 'Camel Route-1_choice-1_branch-1',
+                steps: [
+                  {
+                    UUID: 'Camel Route-1_choice-1_branch-1_log-0',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 0,
+                    maxBranches: 0,
+                    name: 'log',
+                    type: 'MIDDLE',
+                  },
+                ],
+                identifier: 'otherwise',
+              },
+            ],
+          },
+        ]);
+      });
 
-      expect(result).toMatchObject<Partial<IStepProps>[]>([
-        { UUID: 'Camel Route-1_timer-0', branches: [] },
-        {
-          UUID: 'Camel Route-1_choice-1',
-          branches: [
-            {
-              branchUuid: 'Camel Route-1_choice-1_branch-0',
-              steps: [
-                {
-                  UUID: 'Camel Route-1_choice-1_branch-0_timer-0',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 0,
-                  maxBranches: 0,
-                  name: 'timer',
-                  type: 'START',
-                  branches: [],
-                },
-                {
-                  UUID: 'Camel Route-1_choice-1_branch-0_choice-1',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 1,
-                  maxBranches: -1,
-                  name: 'choice',
-                  type: 'MIDDLE',
-                  branches: [
-                    {
-                      branchUuid: 'Camel Route-1_choice-1_branch-0_choice-1_branch-0',
-                      steps: [
-                        {
-                          UUID: 'Camel Route-1_choice-1_branch-0_choice-1_branch-0_log-0',
-                          integrationId: 'Camel Route-1',
-                          minBranches: 0,
-                          maxBranches: 0,
-                          name: 'log',
-                          type: 'MIDDLE',
-                        },
-                      ],
-                      identifier: 'true path',
-                    },
-                    {
-                      branchUuid: 'Camel Route-1_choice-1_branch-0_choice-1_branch-1',
-                      steps: [
-                        {
-                          UUID: 'Camel Route-1_choice-1_branch-0_choice-1_branch-1_log-0',
-                          integrationId: 'Camel Route-1',
-                          minBranches: 0,
-                          maxBranches: 0,
-                          name: 'log',
-                          type: 'MIDDLE',
-                        },
-                      ],
-                      identifier: 'otherwise',
-                    },
-                  ],
-                },
-              ],
-              identifier: 'true path',
-            },
-            {
-              branchUuid: 'Camel Route-1_choice-1_branch-1',
-              steps: [
-                {
-                  UUID: 'Camel Route-1_choice-1_branch-1_log-0',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 0,
-                  maxBranches: 0,
-                  name: 'log',
-                  type: 'MIDDLE',
-                },
-              ],
-              identifier: 'otherwise',
-            },
-          ],
-        },
-      ]);
-    });
+      it('should regenerate UUIDs when a branch is removed', () => {
+        const localIntegrationSteps = integrationSteps.slice(1);
+        const result = FlowsService.regenerateUuids('Camel Route-1', localIntegrationSteps);
 
-    it('should regenerate UUIDs when a branch is removed', () => {
-      const localIntegrationSteps = integrationSteps.slice(1);
-      const result = FlowsService.regenerateUuids('Camel Route-1', localIntegrationSteps);
-
-      expect(result).toMatchObject<Partial<IStepProps>[]>([
-        {
-          UUID: 'Camel Route-1_choice-0',
-          branches: [
-            {
-              branchUuid: 'Camel Route-1_choice-0_branch-0',
-              steps: [
-                {
-                  UUID: 'Camel Route-1_choice-0_branch-0_log-0',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 0,
-                  maxBranches: 0,
-                  name: 'log',
-                  type: 'MIDDLE',
-                },
-              ],
-              identifier: 'true path',
-            },
-            {
-              branchUuid: 'Camel Route-1_choice-0_branch-1',
-              steps: [
-                {
-                  UUID: 'Camel Route-1_choice-0_branch-1_log-0',
-                  integrationId: 'Camel Route-1',
-                  minBranches: 0,
-                  maxBranches: 0,
-                  name: 'log',
-                  type: 'MIDDLE',
-                },
-              ],
-              identifier: 'otherwise',
-            },
-          ],
-        },
-      ]);
+        expect(result).toMatchObject<Partial<IStepProps>[]>([
+          {
+            UUID: 'Camel Route-1_choice-0',
+            branches: [
+              {
+                branchUuid: 'Camel Route-1_choice-0_branch-0',
+                steps: [
+                  {
+                    UUID: 'Camel Route-1_choice-0_branch-0_log-0',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 0,
+                    maxBranches: 0,
+                    name: 'log',
+                    type: 'MIDDLE',
+                  },
+                ],
+                identifier: 'true path',
+              },
+              {
+                branchUuid: 'Camel Route-1_choice-0_branch-1',
+                steps: [
+                  {
+                    UUID: 'Camel Route-1_choice-0_branch-1_log-0',
+                    integrationId: 'Camel Route-1',
+                    minBranches: 0,
+                    maxBranches: 0,
+                    name: 'log',
+                    type: 'MIDDLE',
+                  },
+                ],
+                identifier: 'otherwise',
+              },
+            ],
+          },
+        ]);
+      });
     });
   });
 });

--- a/src/services/FlowsService.ts
+++ b/src/services/FlowsService.ts
@@ -12,17 +12,16 @@ import cloneDeep from 'lodash.clonedeep';
 export class FlowsService {
   static getNewFlow(
     dsl: string,
-    flowId?: string,
     options?: { metadata: IIntegration['metadata'] },
   ): IIntegration {
-    const randomNumber = getRandomArbitraryNumber();
-    const id = flowId ?? `route-${randomNumber.toString(10).slice(0, 4)}`;
+    const metadata = options?.metadata ?? {};
+    const id = metadata.name ?? this.getNewFlowId();
 
     return {
       id,
       dsl,
       description: '',
-      metadata: options?.metadata ?? {},
+      metadata: {...metadata, name: metadata.name ?? id},
       params: [],
       steps: [],
     };
@@ -54,5 +53,10 @@ export class FlowsService {
     });
 
     return newSteps;
+  }
+
+  static getNewFlowId(): string {
+    const randomNumber = getRandomArbitraryNumber();
+    return `route-${randomNumber.toString(10).slice(0, 4)}`
   }
 }

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -3,6 +3,7 @@ import branchSteps from '../store/data/branchSteps';
 import nodes from '../store/data/nodes';
 import steps from '../store/data/steps';
 import { useVisualizationStore } from '../store/visualizationStore';
+import { FlowsService } from './FlowsService';
 import { VisualizationService } from './visualizationService';
 import {
   IStepProps,
@@ -29,6 +30,10 @@ describe('visualizationService', () => {
 
   beforeEach(() => {
     service = new VisualizationService();
+
+    useFlowsStore.setState({
+      flows: [{ ...FlowsService.getNewFlow('Camel Route'), id: 'Camel Route-1' }],
+    });
   });
 
   it('buildBranchNodeParams(): should build params for a branch node', () => {
@@ -137,10 +142,14 @@ describe('visualizationService', () => {
   });
 
   describe('redrawDiagram', () => {
+    beforeEach(() => {
+      jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-1234');
+      jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-4321');
+    });
+
     it('should process only visible flows', async () => {
-      useFlowsStore.getState().deleteAllFlows();
-      useFlowsStore.getState().addNewFlow('Integration', 'route-1234');
-      useFlowsStore.getState().addNewFlow('Integration', 'route-4321');
+      useFlowsStore.getState().addNewFlow('Integration');
+      useFlowsStore.getState().addNewFlow('Integration');
 
       const getLayoutedElementsSpy = jest.spyOn(VisualizationService, 'getLayoutedElements');
 
@@ -180,9 +189,8 @@ describe('visualizationService', () => {
     });
 
     it('should process more than one visible flow', async () => {
-      useFlowsStore.getState().deleteAllFlows();
-      useFlowsStore.getState().addNewFlow('Integration', 'route-1234');
-      useFlowsStore.getState().addNewFlow('Integration', 'route-4321');
+      useFlowsStore.getState().addNewFlow('Integration');
+      useFlowsStore.getState().addNewFlow('Integration');
       useVisualizationStore.getState().showAllFlows();
 
       const getLayoutedElementsSpy = jest.spyOn(VisualizationService, 'getLayoutedElements');
@@ -319,14 +327,14 @@ describe('visualizationService', () => {
     expect(stepNodes[0].id).toContain(stepNodes[0].data.step.UUID);
   });
 
-  it.skip('buildNodesFromSteps(): should build visualization nodes from an array of steps with branches', () => {
+  it('buildNodesFromSteps(): should build visualization nodes from an array of steps with branches', () => {
     const stepNodes = VisualizationService.buildNodesFromSteps(
       'Camel Route-1',
       branchSteps,
       'RIGHT',
     );
     expect(stepNodes[0].data.step.UUID).toBeDefined();
-    expect(stepNodes).toHaveLength(branchSteps.length);
+    expect(stepNodes).toHaveLength(11); // 4 Main steps + 7 branch steps
   });
 
   it('containsAddStepPlaceholder(): should determine if there is an ADD STEP placeholder in the steps', () => {
@@ -544,7 +552,7 @@ describe('visualizationService', () => {
     expect(nodes).toHaveLength(1);
   });
 
-  it.skip('insertBranchGroupNode', () => {
+  it('insertBranchGroupNode', () => {
     const nodes: IVizStepNode[] = [];
     VisualizationService.insertBranchGroupNode(nodes, { x: 0, y: 0 }, 150, groupWidth);
     expect(nodes).toHaveLength(1);

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -671,11 +671,17 @@ export class VisualizationService {
   }
 
   static setVisibleFlows(flowsIds: string[]): void {
+    const previousVisibleFlows = useVisualizationStore.getState().visibleFlows;
+
     const visibleFlows = flowsIds.reduce(
       (acc, flow, index) => ({
         ...acc,
-        /** Make visible only the first flow */
-        [flow]: index === 0,
+        /**
+         * We keep the previous visibility state if any
+         * otherwise, we set the first flow to visible
+         * and the rest to invisible
+         */
+        [flow]: previousVisibleFlows[flow] ?? index === 0,
       }),
       {} as Record<string, boolean>,
     );

--- a/src/store/deploymentStore.test.tsx
+++ b/src/store/deploymentStore.test.tsx
@@ -12,7 +12,7 @@ describe('deploymentStore', () => {
     // check parameters individually for accuracy
     expect(result.current.deployment.crd).toEqual('The best deployment ever');
     expect(result.current.deployment.errors).toHaveLength(0);
-    expect(result.current.deployment.name).toEqual('integration');
+    expect(result.current.deployment.name).toEqual('');
     expect(result.current.deployment.status).toEqual('Stopped');
     expect(result.current.deployment.type).toEqual('Camel Route');
   });

--- a/src/store/settingsStore.tsx
+++ b/src/store/settingsStore.tsx
@@ -22,7 +22,7 @@ export const initDsl: IDsl = {
 export const initialSettings: ISettings = {
   description: '',
   dsl: initDsl,
-  name: 'integration',
+  name: '',
   namespace: '',
   editorIsLightMode: localStorage.getItem(LOCAL_STORAGE_EDITOR_THEME_KEY) === 'true',
   uiLightMode: isUILightMode === 'true',

--- a/src/stubs/initial-flows.ts
+++ b/src/stubs/initial-flows.ts
@@ -4,7 +4,7 @@ export const initialFlows: IIntegration[] = [
   {
     id: 'Camel Route-1',
     dsl: 'Camel Route',
-    metadata: { name: 'integration', namespace: '' },
+    metadata: { name: 'Camel Route-1', namespace: '' },
     steps: [
       {
         name: 'timer',
@@ -386,7 +386,7 @@ export const initialFlows: IIntegration[] = [
   {
     id: 'Camel Route-2',
     dsl: 'Camel Route',
-    metadata: { name: 'integration', namespace: '' },
+    metadata: { name: 'Camel Route-2', namespace: '' },
     steps: [
       {
         name: 'timer',

--- a/src/stubs/integration-steps.ts
+++ b/src/stubs/integration-steps.ts
@@ -607,7 +607,7 @@ export const flowWithBranch: IIntegration = {
   dsl: 'Camel Route',
   description: '',
   metadata: {
-    name: 'integration',
+    name: 'route-1814',
     namespace: '',
   },
   params: [],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,7 @@ export interface ISettings {
   uiLightMode: boolean;
   editorMode: CodeEditorMode;
 
-  // name of integration or deployment
+  // name used for VS Code
   name: string;
   // Cluster namespace
   namespace: string;


### PR DESCRIPTION
### Context
Currently, the UI creates the flows IDs in two places:
1. Upon syncing the code through the useFlowsStore.setFlowsWrapper() method
2. Upon creating a new flow when using the New Flow button

For the .1, since the UI doesn't have a previous ID because we're starting from the source code, the UI creates an ID using the DSL name and the position index, i.e. "Camel Route-1".

For the .2, the UI uses a service to generate an ID with the word "route-####" while "####" it's a 4 digits random number.

### Changes
In this commit, the UI leverages the IFlowsWrapper.flows[0].metadata.name property as an ID for each flow, this way, whenever a sync happens, the IDs will be the same.

fixes: https://github.com/KaotoIO/vscode-kaoto/issues/280
fixes: https://github.com/KaotoIO/kaoto-ui/issues/1910