### PR TITLE
chore: Update deprecated set-output API

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🎥 Should we record?
-        run: echo '::set-output name=record::${{  env.CYPRESS_PROJECT_ID != '' }}'
+        run: echo "{record}={${{  env.CYPRESS_PROJECT_ID != '' }}}" >> $GITHUB_OUTPUT
         id: should-we-record
 
       - name: 👩‍🏭 Cypress install


### PR DESCRIPTION
### Context
`set-output` have been deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

fixes: https://github.com/KaotoIO/kaoto-standalone/issues/15