### PR TITLE
chore(e2e): Fix broken e2e

### DIFF
--- a/cypress/e2e/08-code-editor-actions/code_editor_actions.cy.js
+++ b/cypress/e2e/08-code-editor-actions/code_editor_actions.cy.js
@@ -83,7 +83,7 @@ describe('editing properties', () => {
   it('User undoes a change they saved, syncs with canvas', () => {
     cy.uploadFixture('EipAction.yaml');
 
-    cy.editorDeleteLine(31, 7);
+    cy.editorDeleteLine(30, 7);
     cy.syncUpCodeChanges();
 
     // CHECK branch with digitalocean and set header step was deleted
@@ -93,7 +93,7 @@ describe('editing properties', () => {
     // First click undo button => reverted automatic adjustments
     cy.editorClickUndoXTimes();
     // Second click undo button => changes reverted & alert is displayed
-    cy.editorClickUndoXTimes();
+    cy.editorClickUndoXTimes(7);
     // CHECK alert is displayed
     cy.get('.pf-c-alert__title').contains('Any invalid code will be replaced after sync. If you don\'t want to lose your changes please make a backup.');
     cy.syncUpCodeChanges();

--- a/cypress/e2e/11-multi_flow/code_editor_multi_flow.cy.js
+++ b/cypress/e2e/11-multi_flow/code_editor_multi_flow.cy.js
@@ -13,7 +13,7 @@ describe('Test for Multi route actions from the code editor', () => {
   it('User deletes first route from multi-route using code editor', () => {
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
-    cy.editorDeleteLine(0, 15);
+    cy.editorDeleteLine(6, 11);
     cy.syncUpCodeChanges();
 
     cy.showAllRoutes();
@@ -37,19 +37,14 @@ describe('Test for Multi route actions from the code editor', () => {
     cy.get('[data-testid^="rf__node-node_0"]').should('have.length', 3);
   });
 
-  it('User adds new route to Integration multi-route using code editor', () => {
+  /** Skip until https://github.com/KaotoIO/kaoto-backend/issues/738 is done */
+  it.skip('User adds new route to Integration multi-route using code editor', () => {
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
-    const stepToInsert = `---
-apiVersion: camel.apache.org/v1
-kind: Integration
-metadata:
-  name: ''
-spec:
-  flows:
-  - from:
-      uri: null
-      steps: []`;
+    const stepToInsert = `  - route:
+      from:
+        uri: null
+        steps: []`;
 
     cy.editorAddText(28, stepToInsert);
     cy.syncUpCodeChanges();
@@ -63,7 +58,7 @@ spec:
   it('User deletes second route from multi-route using code editor', () => {
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
-    cy.editorDeleteLine(15, 12);
+    cy.editorDeleteLine(17, 7);
     cy.syncUpCodeChanges();
 
     cy.showAllRoutes();
@@ -73,7 +68,7 @@ spec:
   it('User deletes step from first route using code editor', () => {
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
-    cy.editorDeleteLine(11, 2);
+    cy.editorDeleteLine(13, 2);
     cy.syncUpCodeChanges();
 
     cy.showAllRoutes();
@@ -84,9 +79,9 @@ spec:
   it('User adds step to the first route using code editor', () => {
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
-    const stepToInsert = `      - set-header:
-          constant: test`;
-    const insertLine = 11;
+    const stepToInsert = `        - set-header:
+            constant: test`;
+    const insertLine = 13;
     cy.editorAddText(insertLine, stepToInsert);
     cy.syncUpCodeChanges();
 
@@ -98,9 +93,9 @@ spec:
     cy.uploadFixture('IntegrationMultiFlow.yaml');
 
     cy.showAllRoutes();
-    const stepToInsert = `      - set-body:
-          constant: test`;
-    const insertLine = 25;
+    const stepToInsert = `        - set-body:
+            constant: test`;
+    const insertLine = 22;
     cy.editorAddText(insertLine, stepToInsert);
     cy.syncUpCodeChanges();
     // CHECK the insert-field-action step was added
@@ -119,7 +114,7 @@ spec:
     // First click undo button => reverted automatic adjustments
     cy.editorClickUndoXTimes();
     // Second click undo button => changes reverted & alert is displayed
-    cy.editorClickUndoXTimes();
+    cy.editorClickUndoXTimes(12);
     cy.syncUpCodeChanges();
 
     cy.showAllRoutes();

--- a/cypress/fixtures/IntegrationMultiFlow.yaml
+++ b/cypress/fixtures/IntegrationMultiFlow.yaml
@@ -1,27 +1,24 @@
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
-  name: 'Integration-1'
+  name: Integration-1
 spec:
   flows:
-  - from:
-      uri: cron:cron
-      parameters:
-        schedule: '1000'
-      steps:
-      - set-body:
-          simple: body
-      - to:
-          uri: log:log1
----
-apiVersion: camel.apache.org/v1
-kind: Integration
-metadata:
-  name: 'Integration-2'
-spec:
-  flows:
-  - from:
-      uri: timer:test
-      steps:
-      - to:
-          uri: log:log2
+  - route:
+      id: route-1234
+      from:
+        uri: cron:cron
+        parameters:
+          schedule: '1000'
+        steps:
+        - set-body:
+            simple: body
+        - to:
+            uri: log:log1
+  - route:
+      id: route-4321
+      from:
+        uri: timer:test
+        steps:
+        - to:
+            uri: log:log2

--- a/cypress/support/kaoto-ui-commands/editor.js
+++ b/cypress/support/kaoto-ui-commands/editor.js
@@ -29,16 +29,32 @@ Cypress.Commands.add('editorAddText', (line, text) => {
 
 Cypress.Commands.add('editorDeleteLine', (line, repeatCount) => {
     repeatCount = repeatCount ?? 1;
+    // Open the Go to Line dialog
     cy.get('.code-editor')
         .click()
         .type(
-            '{pageUp}' +
-            '{downArrow}'.repeat(line) +
-            '{shift}' +
-            '{downArrow}'.repeat(repeatCount) +
-            '{backspace}',
-            { delay: 1 }
+            '{ctrl}' +
+            '{g}',
+            { delay: 1 },
         );
+
+    // Type the line number to delete
+    cy.get('input[aria-describedby="quickInput_message"][aria-controls="quickInput_list"]')
+        .click()
+        .type(
+            `${line + 1}` +
+            '{enter}',
+            { delay: 1 },
+        );
+
+    // Delete the line as many times as specified
+    for (let i = 0; i < repeatCount; i++) {
+        cy.focused()
+            .type(
+                '{ctrl}{shift}{k}',
+                { delay: 1 },
+            );
+        }
 });
 
 Cypress.Commands.add('editorClickUndoXTimes', (times) => {


### PR DESCRIPTION
### Context
With the introduction of https://github.com/KaotoIO/kaoto-backend/pull/734, the multiple flows support for Integration CRDs is no longer an individual CRD per flow but rather a single CRD with many flows in it.

### Changes
This commit takes that into consideration by updating the fixtures and the associated lines.

In addition to that, the editorDeleteLine was refactored to leverage the monaco GoToLine functionality to consistently reach a given line.