### PR TITLE
fix(publish): Fix package publish

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,6 +3,11 @@ nodeLinker: node-modules
 # https://yarnpkg.com/configuration/yarnrc#enableScripts
 enableScripts: false
 
+npmPublishRegistry: "https://registry.npmjs.org"
+npmRegistries:
+  "https://registry.npmjs.org":
+    npmAuthToken: ${NODE_AUTH_TOKEN:-}
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
     spec: "@yarnpkg/plugin-workspace-tools"


### PR DESCRIPTION
### Context
After upgrading to yarn v3, the `publish` command needs to be updated as well.

Based on the related issue: https://github.com/yarnpkg/berry/issues/4341 