### PR TITLE
Revert "Updating to version 1.1.0-dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaoto/kaoto-ui",
-  "version": "1.1.0-dev",
+  "version": "1.1.0-M1",
   "federatedModuleName": "kaoto",
   "engines": {
     "node": ">=16.x"


### PR DESCRIPTION
### Context
Due to the fix for `yarn npm publish` coming after the version bump, we need to revert the version back to tag the commit properly.

This reverts commit be0c141097948e7dfaec9dbb175d0e7621723c83.