### PR TITLE
fix(multiple-flows): Delete causes routes status out of sync

### DIFF
--- a/src/components/DSL/DSLSelector.tsx
+++ b/src/components/DSL/DSLSelector.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useState,
 } from 'react';
+import { useFlowsVisibility } from '../../hooks/flows-visibility.hook';
 import { shallow } from 'zustand/shallow';
 
 interface IDSLSelector extends PropsWithChildren {
@@ -23,6 +24,7 @@ export const DSLSelector: FunctionComponent<IDSLSelector> = (props) => {
     (state) => ({ capabilities: state.settings.capabilities, currentDsl: state.settings.dsl }),
     shallow,
   );
+  const { totalFlowsCount } = useFlowsVisibility();
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<IDsl | undefined>(
     props.isStatic ? undefined : props.selectedDsl ?? capabilities[0],
@@ -85,7 +87,7 @@ export const DSLSelector: FunctionComponent<IDSLSelector> = (props) => {
               data-testid="dsl-list-btn"
               aria-label="DSL list"
               onClick={onNewSameTypeRoute}
-              isDisabled={!currentDsl.supportsMultipleFlows}
+              isDisabled={!currentDsl.supportsMultipleFlows && totalFlowsCount > 0}
             >
               {props.children}
             </MenuToggleAction>
@@ -110,7 +112,9 @@ export const DSLSelector: FunctionComponent<IDSLSelector> = (props) => {
       <SelectList>
         {capabilities.map((capability) => {
           const isOptionDisabled =
-            capability.name === currentDsl.name && !capability.supportsMultipleFlows;
+            capability.name === currentDsl.name &&
+            !capability.supportsMultipleFlows &&
+            totalFlowsCount > 0;
 
           return (
             <SelectOption

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -125,7 +125,10 @@ const toggleFlowsVisibility = (
   visibleFlows: Record<string, boolean>,
   isVisible: boolean,
 ): Record<string, boolean> =>
-  Object.keys(visibleFlows).reduce((acc, flowId) => {
-    acc[flowId] = isVisible;
-    return acc;
-  }, {} as Record<string, boolean>);
+  Object.keys(visibleFlows).reduce(
+    (acc, flowId) => {
+      acc[flowId] = isVisible;
+      return acc;
+    },
+    {} as Record<string, boolean>,
+  );


### PR DESCRIPTION
### Context
At the moment, disabling the New Route button is done without taking into account if there are existing flows or not.

### Changes
The fix is to consider whether there are existing flows in addition to checking if the current DSL supports multiple flows.

[Screencast from 2023-07-07 18-29-42.webm](https://github.com/KaotoIO/kaoto-ui/assets/16512618/b2d5c392-5129-4615-b6cb-2c95b3125b34)

fixes: https://github.com/KaotoIO/kaoto-ui/issues/2077
fixes: https://github.com/KaotoIO/kaoto-ui/issues/2085