### PR TITLE
fix(source): Deleting last route doesn't sync the code

### DIFF
--- a/src/components/DSL/NewFlow.test.tsx
+++ b/src/components/DSL/NewFlow.test.tsx
@@ -15,6 +15,24 @@ describe('NewFlow.tsx', () => {
     });
   });
 
+  test('should set the new DSL into the settings store', async () => {
+    const wrapper = render(<NewFlow />);
+    const trigger = await wrapper.findByTestId('dsl-list-dropdown');
+
+    /** Open Select */
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    /** Select an option */
+    act(() => {
+      const element = wrapper.getByText('Kamelet');
+      fireEvent.click(element);
+    });
+
+    expect(useSettingsStore.getState().settings.dsl).toEqual(capabilitiesStub[2]);
+  });
+
   test('should add a new flow with the same type upon clicking on the action button', async () => {
     const wrapper = render(<NewFlow />);
     const trigger = await wrapper.findByTestId('dsl-list-btn');

--- a/src/components/DSL/NewFlow.tsx
+++ b/src/components/DSL/NewFlow.tsx
@@ -32,6 +32,7 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
          * we don't need to do anything special, just add a new flow if
          * supported
          */
+        setSettings({ dsl, namespace });
         addNewFlow(dsl.name);
       } else {
         /**
@@ -42,7 +43,7 @@ export const NewFlow: FunctionComponent<PropsWithChildren> = () => {
         setIsConfirmationModalOpen(true);
       }
     },
-    [addNewFlow],
+    [addNewFlow, namespace, setSettings],
   );
 
   return (

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -1,4 +1,3 @@
-import { usePrevious } from '../hooks';
 import { useFlowsVisibility } from '../hooks/flows-visibility.hook';
 import { DeleteButtonEdge } from './DeleteButtonEdge';
 import { KaotoDrawer } from './KaotoDrawer';
@@ -83,18 +82,8 @@ const Visualization = () => {
   const visualizationService = useMemo(() => new VisualizationService(), []);
   const stepsService = useMemo(() => new StepsService(), []);
 
-  const previousFlows = usePrevious(flows);
-  const previousMetadata = usePrevious(metadata);
-
   // Update SourceCode editor content after an integrationJson change (the user interacted with the Kaoto UI).
   useEffect(() => {
-    if (
-      (previousFlows === flows && previousMetadata === metadata) ||
-      !Array.isArray(flows[0]?.steps)
-    ) {
-      return;
-    }
-
     const updatedFlowWrapper: IFlowsWrapper = {
       flows: flows.map((flow) => ({
         ...flow,
@@ -277,7 +266,6 @@ const Visualization = () => {
               zoomOnDoubleClick={false}
               className="panelCustom"
             >
-              {/*<MiniMap nodeBorderRadius={2} className={'visualization__minimap'} />*/}
               <VisualizationControls />
               <Background color="#aaa" gap={16} />
             </ReactFlow>

--- a/src/store/FlowsStore.test.ts
+++ b/src/store/FlowsStore.test.ts
@@ -245,7 +245,7 @@ describe('FlowsStore', () => {
 
       act(() => {
         result.current.addNewFlow('Integration'); // MOCK_FLOW_ID
-        result.current.deleteStep(MOCK_FLOW_ID, 'step-1234');
+        result.current.deleteStep('non-existing-flow', 'step-1234');
       });
 
       expect(result.current.flows).toMatchObject([

--- a/src/store/FlowsStore.ts
+++ b/src/store/FlowsStore.ts
@@ -169,26 +169,29 @@ export const useFlowsStore = create<IFlowsStore>()(
       },
 
       /** General flow management */
-      addNewFlow: (dsl) =>
+      addNewFlow: (dsl) => {
         set((state) => {
           const flow = FlowsService.getNewFlow(dsl);
           const flows = state.flows.concat(flow);
           VisualizationService.displaySingleFlow(flow.id);
 
-          return { ...state, currentDsl: dsl, flows };
-        }),
-      deleteFlow: (flowId) =>
+          return { flows };
+        });
+      },
+      deleteFlow: (flowId) => {
         set((state) => {
-          const filteredFlows = state.flows.filter((flow) => flowId !== flow.id);
-          VisualizationService.deleteFlowFromVisibleFlows(flowId);
+          const flows = state.flows.filter((flow) => flowId !== flow.id);
 
-          return {
-            ...state,
-            flows: filteredFlows,
-          };
-        }),
+          return { flows };
+        });
+
+        VisualizationService.deleteFlowFromVisibleFlows(flowId);
+      },
       deleteAllFlows: () => {
-        set((state) => getInitialState({ ...state, flows: [] }));
+        set((state) => {
+          return getInitialState({ ...state, flows: [] });
+        });
+
         VisualizationService.removeAllVisibleFlows();
       },
 


### PR DESCRIPTION
### Context
Currently, there's a check in the `Visualization.tsx` component that ensures that at least one flow exists in the `FlowsStore`.

This check prevented to sync of the source code when all flows were deleted.

### Changes
The fix is to sync the source code whenever there's a change in the Flows array. In addition to that, the current DSL needs to be updated [whenever a new flow is added](https://github.com/KaotoIO/kaoto-ui/pull/2115/files#diff-a16b0f9b3604fc7b64098ed9eb1ff564b5333d8a6a7656a2f650c245d60144d1R35).

fixes: https://github.com/KaotoIO/kaoto-ui/issues/2086