### PR TITLE
Revert "chore(deps): update dependency prettier to v3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "msw": "^1.2.2",
     "msw-storybook-addon": "^1.8.0",
     "null-loader": "^4.0.1",
-    "prettier": "3.0.0",
+    "prettier": "2.8.8",
     "prop-types": "15.8.1",
     "react-refresh": "^0.14.0",
     "rimraf": "5.0.1",

--- a/src/components/DSL/DSLSelector.test.tsx
+++ b/src/components/DSL/DSLSelector.test.tsx
@@ -1,5 +1,5 @@
-import { ISettings } from '../../types';
 import { capabilitiesStub } from '../../stubs';
+import { ISettings } from '../../types';
 import { DSLSelector } from './DSLSelector';
 import { useSettingsStore, useVisualizationStore } from '@kaoto/store';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';

--- a/src/components/DSL/DSLSelector.tsx
+++ b/src/components/DSL/DSLSelector.tsx
@@ -1,3 +1,4 @@
+import { useFlowsVisibility } from '../../hooks/flows-visibility.hook';
 import { useSettingsStore } from '@kaoto/store';
 import { IDsl } from '@kaoto/types';
 import { MenuToggle, MenuToggleAction, MenuToggleElement, Tooltip } from '@patternfly/react-core';
@@ -10,7 +11,6 @@ import {
   useCallback,
   useState,
 } from 'react';
-import { useFlowsVisibility } from '../../hooks/flows-visibility.hook';
 import { shallow } from 'zustand/shallow';
 
 interface IDSLSelector extends PropsWithChildren {

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -125,10 +125,7 @@ const toggleFlowsVisibility = (
   visibleFlows: Record<string, boolean>,
   isVisible: boolean,
 ): Record<string, boolean> =>
-  Object.keys(visibleFlows).reduce(
-    (acc, flowId) => {
-      acc[flowId] = isVisible;
-      return acc;
-    },
-    {} as Record<string, boolean>,
-  );
+  Object.keys(visibleFlows).reduce((acc, flowId) => {
+    acc[flowId] = isVisible;
+    return acc;
+  }, {} as Record<string, boolean>);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3797,7 +3797,7 @@ __metadata:
     msw: ^1.2.2
     msw-storybook-addon: ^1.8.0
     null-loader: ^4.0.1
-    prettier: 3.0.0
+    prettier: 2.8.8
     prop-types: 15.8.1
     react: 18.2.0
     react-dom: 18.2.0
@@ -18530,16 +18530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.0":
-  version: 3.0.0
-  resolution: "prettier@npm:3.0.0"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.0.0, prettier@npm:^2.8.0":
+"prettier@npm:2.8.8, prettier@npm:^2.0.0, prettier@npm:^2.8.0":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:


### PR DESCRIPTION
This version is blocking the local usage with `VSCode`

Reverts KaotoIO/kaoto-ui#2103