### PR TITLE
fix(router): Support dynamic urls for kaoto-standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "css-minimizer-webpack-plugin": "^5.0.1",
     "cypress": "12.17.0",
     "cypress-file-upload": "^5.0.8",
-    "dotenv-webpack": "8.0.1",
+    "dotenv": "^16.3.1",
     "eslint": "8.44.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-import": "^2.27.5",

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,6 @@
   <meta id="appName" name="application-name" content="Kaoto">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
-  <base href="/">
 </head>
 
 <body>

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -5,6 +5,8 @@ import 'whatwg-fetch';
 
 global.TextEncoder = TextEncoder;
 global.KAOTO_VERSION = '1.0-test';
+global.KAOTO_API = '/api';
+global.NODE_ENV = 'test';
 
 jest.mock('@kaoto/api', () => {
   const actual = jest.requireActual('@kaoto/api');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import '@patternfly/patternfly/utilities/Sizing/sizing.css';
 import '@patternfly/patternfly/utilities/Spacing/spacing.css';
 import '@patternfly/patternfly/utilities/Text/text.css';
 import { Suspense } from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { HashRouter as Router } from 'react-router-dom';
 import 'reactflow/dist/style.css';
 
 const { undo, redo } = useFlowsStore.temporal.getState();

--- a/src/api/requestService.ts
+++ b/src/api/requestService.ts
@@ -34,7 +34,7 @@ export interface IFetch {
 }
 
 export class RequestService {
-  private static apiURL = process.env.KAOTO_API;
+  private static apiURL = KAOTO_API;
 
   static getApiURL(): string | undefined {
     return this.apiURL;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,3 +2,4 @@ declare module '*.png';
 declare module '*.svg';
 declare var KAOTO_API: string;
 declare var KAOTO_VERSION: string;
+declare var NODE_ENV: string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,7 +6,14 @@ import { useSettingsStore } from './settingsStore';
 import { useVisualizationStore } from './visualizationStore';
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 
-if (process.env.NODE_ENV === 'development') {
+let isDevMode = false;
+try {
+  isDevMode = NODE_ENV === 'development';
+} catch (error) {
+  console.info('NODE_ENV is not defined');
+}
+
+if (isDevMode) {
   mountStoreDevtool('deploymentStore', useDeploymentStore);
   mountStoreDevtool('flowsStore', useFlowsStore);
   mountStoreDevtool('integrationSourceStore', useIntegrationSourceStore);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-const Dotenv = require('dotenv-webpack');
 const { dependencies, federatedModuleName, version } = require('./package.json');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -53,10 +52,6 @@ const common = (mode) => {
         favicon: path.resolve(__dirname, 'src/assets/images', 'favicon.svg'),
         template: path.resolve(__dirname, 'public', 'index.html'),
       }),
-      new Dotenv({
-        systemvars: true,
-        silent: true,
-      }),
       new MonacoWebpackPlugin({
         languages: ['yaml'],
         globalAPI: true,
@@ -93,6 +88,7 @@ const common = (mode) => {
       // new FederatedTypesPlugin(),
       new webpack.DefinePlugin({
         KAOTO_VERSION: JSON.stringify(version),
+        NODE_ENV: JSON.stringify(mode),
       }),
     ],
     resolve: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,7 @@
 const { merge } = require('webpack-merge');
 const { common } = require('./webpack.common.js');
 const webpack = require('webpack');
+require('dotenv').config();
 
 module.exports = merge(common('development'), {
   devtool: 'inline-source-map',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -18,7 +18,13 @@ module.exports = merge(common('production'), {
   },
   plugins: [
     new webpack.DefinePlugin({
-      KAOTO_API: JSON.stringify(process.env.KAOTO_API || '/api'),
+      /**
+       * This ENV needs to be set when running the yarn build command, i.e.:
+       * KAOTO_API=/api yarn build
+       * this is on purpose since we would fallback to '/api' which is the
+       * default path for kaoto-standalone
+       */
+      KAOTO_API: JSON.stringify(process.env.KAOTO_API ?? '/api'),
     }),
   ],
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3771,7 +3771,7 @@ __metadata:
     cypress: 12.17.0
     cypress-file-upload: ^5.0.8
     dagre: ^0.8.5
-    dotenv-webpack: 8.0.1
+    dotenv: ^16.3.1
     eslint: 8.44.0
     eslint-config-prettier: 8.8.0
     eslint-plugin-import: ^2.27.5
@@ -11408,15 +11408,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-defaults@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "dotenv-defaults@npm:2.0.2"
-  dependencies:
-    dotenv: ^8.2.0
-  checksum: c005960bd048e2189c4799e729c41f362e415e6e0b54313d3f31e853a84b049bf770b25cb21c112c2805bb13a8376edc9de451fb514abf8546392d327c27f6e5
-  languageName: node
-  linkType: hard
-
 "dotenv-expand@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv-expand@npm:10.0.0"
@@ -11431,17 +11422,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-webpack@npm:8.0.1":
-  version: 8.0.1
-  resolution: "dotenv-webpack@npm:8.0.1"
-  dependencies:
-    dotenv-defaults: ^2.0.2
-  peerDependencies:
-    webpack: ^4 || ^5
-  checksum: ee73eda78df90bcf7446763dfe5e518a2054ed6222783856912d2c6a255fdfc041854e125e036ff2603b06fb44f5234713fad5feecb1e66a54fe78a35a98fb87
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:^16.0.0":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
@@ -11449,7 +11429,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^8.0.0, dotenv@npm:^8.2.0":
+"dotenv@npm:^16.3.1":
+  version: 16.3.1
+  resolution: "dotenv@npm:16.3.1"
+  checksum: 15d75e7279018f4bafd0ee9706593dd14455ddb71b3bcba9c52574460b7ccaf67d5cf8b2c08a5af1a9da6db36c956a04a1192b101ee102a3e0cf8817bbcf3dfd
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^8.0.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd


### PR DESCRIPTION
### Context
Currently, Kaoto's UI is using the `KAOTO_API` environment variable to determine the base URL for the API. This environment variable gets loaded by using `dotenv-webpack` at building time.

In addition to that, the `index.html` file used `<base href="/">` to signal where the UI should be loaded from, the problem with this is that when deploying Kaoto in k8s or OCP platforms, the URLs are gonna be dynamic and not `/`.

### Changes
This commit makes a few adjustments, starting with removing `dotenv-webpack` and replacing it with `dotenv` which is later on leveraged in the `webpack.dev.js` file. The reason for this is to leverage the local `.env` file only in `DEV` mode.

For `production` builds, the `KAOTO_API` variable needs to be set by hand to allow both `dev` and `prod` builds locally.

The other relevant change was to move from `BrowserRouter` to `HashRouter`, in order to provide a simple alternative to load Kaoto's UI from dynamic routes since the `basePath` is unknown at the build time.

## NOTE: This will require a follow-up pull request in `vscode-kaoto` to ensure compatibility

relates to: https://github.com/KaotoIO/kaoto-standalone/issues/32