### PR TITLE
feat(inline-edit): Add InlineEdit component

### DIFF
--- a/src/components/InlineEdit/InlineEdit.css
+++ b/src/components/InlineEdit/InlineEdit.css
@@ -1,0 +1,3 @@
+span[data-clickable='true'] {
+  cursor: pointer;
+}

--- a/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -1,0 +1,92 @@
+import { InlineEdit } from './InlineEdit';
+import { minLengthValidator } from './min-length-validator';
+import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
+import { useArgs } from '@storybook/preview-api';
+import { Meta, StoryFn } from '@storybook/react';
+import { ComponentProps, useState } from 'react';
+
+export default {
+  title: 'InlineEdit/InlineEdit',
+  component: InlineEdit,
+  decorators: [
+    (Story) => (
+      <div style={{ margin: '3em' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {},
+} as Meta<typeof InlineEdit>;
+
+const T1: StoryFn<typeof InlineEdit> = (args) => {
+  const [localValue, setLocalValue] = useState(args.value);
+
+  return (
+    <Card>
+      <CardTitle>Inline Edit</CardTitle>
+      <CardBody>
+        <InlineEdit
+          {...args}
+          value={args.value ?? localValue}
+          onChange={args.onChange ?? setLocalValue}
+        />
+      </CardBody>
+      <CardFooter></CardFooter>
+    </Card>
+  );
+};
+export const Default = T1.bind({});
+Default.args = {
+  value: 'This is an editable text',
+};
+
+const T2: StoryFn<typeof InlineEdit> = (_) => {
+  const [{ value }, updateArgs] = useArgs<ComponentProps<typeof InlineEdit>>();
+
+  return (
+    <Card>
+      <CardTitle>Inline Edit</CardTitle>
+      <CardBody>
+        <InlineEdit
+          value={value}
+          onChange={(value) => {
+            updateArgs({ value });
+          }}
+          onClick={() => {
+            alert('Clicked');
+          }}
+        />
+      </CardBody>
+      <CardFooter></CardFooter>
+    </Card>
+  );
+};
+export const Clickable = T2.bind({});
+Clickable.args = {
+  value: 'This is an editable text',
+};
+
+const T3: StoryFn<typeof InlineEdit> = (args) => {
+  const [_, updateArgs] = useArgs<ComponentProps<typeof InlineEdit>>();
+
+  return (
+    <Card>
+      <CardTitle>Inline Edit</CardTitle>
+      <CardBody>
+        <p>The text should be at least 5 characters long</p>
+        <InlineEdit
+          {...args}
+          onChange={(value) => {
+            updateArgs({ value });
+          }}
+        />
+      </CardBody>
+      <CardFooter></CardFooter>
+    </Card>
+  );
+};
+export const Validator = T3.bind({});
+Validator.args = {
+  value: 'This is a text',
+  validator: minLengthValidator,
+};

--- a/src/components/InlineEdit/InlineEdit.test.tsx
+++ b/src/components/InlineEdit/InlineEdit.test.tsx
@@ -1,0 +1,293 @@
+import { Default as InlineEdit } from './InlineEdit.stories';
+import { minLengthValidator } from './min-length-validator';
+import { fireEvent } from '@testing-library/dom';
+import { act, render } from '@testing-library/react';
+
+describe('InlineEdit', () => {
+  const DATA_TESTID = 'inline';
+
+  describe('Readonly mode', () => {
+    it('should render correctly', () => {
+      const wrapper = render(<InlineEdit value="My text" />);
+
+      const textField = wrapper.getByText('My text');
+      expect(textField).toBeInTheDocument();
+    });
+
+    it('should use an empty string as default value', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      expect(wrapper.getByTestId(DATA_TESTID)).toBeInTheDocument();
+      expect(wrapper.getByTestId(DATA_TESTID)).toHaveTextContent('');
+    });
+
+    it.each([
+      [() => {}, true],
+      [undefined, false],
+    ] as const)('should set data-clickable attribute according to onClick', (onClick, value) => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} onClick={onClick} />);
+
+      expect(wrapper.getByTestId(DATA_TESTID)).toHaveAttribute('data-clickable', value.toString());
+    });
+
+    it('should render a pencil icon', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      expect(wrapper.getByTestId(DATA_TESTID + '--edit')).toBeInTheDocument();
+    });
+
+    it('should go to edit mode upon clicking on the pencil icon', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('should go to edit mode and stop click event propagation', () => {
+      const mouseEvent = new MouseEvent('click', { bubbles: true });
+      const stopPropagationSpy = jest.spyOn(mouseEvent, 'stopPropagation');
+
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent(editButton, mouseEvent);
+      });
+
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Editable mode', () => {
+    it('should set focus on input upon editing', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+      expect(input).toHaveFocus();
+    });
+
+    it('should start with a default validation status', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('should set a default validation statuts if the change is the same as the original value', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} value="My text" />);
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      const input = wrapper.getByTestId('inline--text-input');
+
+      act(() => {
+        fireEvent.change(input, { target: { value: 'edited text' } });
+        fireEvent.change(input, { target: { value: 'My text' } });
+      });
+
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+    });
+
+    it('should use the validator if available', () => {
+      const wrapper = render(
+        <InlineEdit data-testid={DATA_TESTID} value="My text" validator={minLengthValidator} />,
+      );
+      const editButton = wrapper.getByTestId('inline--edit');
+
+      act(() => {
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'none' } });
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
+
+      act(() => {
+        const errorMessage = wrapper.getByText(/Value must be at least 5 characters long/, {
+          exact: false,
+        });
+        expect(errorMessage).toBeInTheDocument();
+      });
+    });
+
+    it('should ignore the save action if the validation fails', () => {
+      const wrapper = render(
+        <InlineEdit data-testid={DATA_TESTID} value="My text" validator={minLengthValidator} />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'none' } });
+      });
+
+      const saveButton = wrapper.getByTestId('inline--save');
+      act(() => {
+        fireEvent.click(saveButton);
+      });
+
+      expect(saveButton).toBeInTheDocument();
+      expect(saveButton).toBeDisabled();
+
+      const textField = wrapper.queryByTestId(DATA_TESTID);
+      expect(textField).not.toBeInTheDocument();
+    });
+
+    it('should call the onChange callback if the validation succeeds', () => {
+      const onChange = jest.fn();
+      const wrapper = render(
+        <InlineEdit
+          data-testid={DATA_TESTID}
+          value="My text"
+          onChange={onChange}
+          validator={minLengthValidator}
+        />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'A new hope' } });
+      });
+
+      act(() => {
+        const saveButton = wrapper.getByTestId('inline--save');
+        fireEvent.click(saveButton);
+      });
+
+      expect(onChange).toHaveBeenCalledWith('A new hope');
+    });
+
+    it('should not call the onChange callback if the validation fails', () => {
+      const onChange = jest.fn();
+      const wrapper = render(
+        <InlineEdit
+          data-testid={DATA_TESTID}
+          value="My text"
+          onChange={onChange}
+          validator={minLengthValidator}
+        />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.change(input, { target: { value: 'none' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should not call the onChange callback if the value did not change', () => {
+      const onChange = jest.fn();
+      const wrapper = render(
+        <InlineEdit
+          data-testid={DATA_TESTID}
+          value="My text"
+          onChange={onChange}
+          validator={minLengthValidator}
+        />,
+      );
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should return to read mode when the user presses the Escape key', () => {
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const input = wrapper.getByTestId('inline--text-input');
+        fireEvent.keyDown(input, { key: 'Escape' });
+      });
+
+      const textField = wrapper.queryByTestId(DATA_TESTID);
+      expect(textField).toBeInTheDocument();
+    });
+
+    it('should return to read mode and stop the event propagation when the user clicks on the cancel button', () => {
+      const mouseEvent = new MouseEvent('click', { bubbles: true });
+      const stopPropagationSpy = jest.spyOn(mouseEvent, 'stopPropagation');
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const cancelButton = wrapper.getByTestId('inline--cancel');
+        fireEvent(cancelButton, mouseEvent);
+      });
+
+      const textField = wrapper.queryByTestId(DATA_TESTID);
+      expect(textField).toBeInTheDocument();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('should prevent the form submission', () => {
+      const submitEvent = new Event('submit', { bubbles: true });
+      const preventDefaultSpy = jest.spyOn(submitEvent, 'preventDefault');
+      const wrapper = render(<InlineEdit data-testid={DATA_TESTID} />);
+
+      act(() => {
+        const editButton = wrapper.getByTestId('inline--edit');
+        fireEvent.click(editButton);
+      });
+
+      act(() => {
+        const form = wrapper.getByTestId('inline--form');
+        fireEvent(form, submitEvent);
+      });
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/InlineEdit/InlineEdit.tsx
+++ b/src/components/InlineEdit/InlineEdit.tsx
@@ -1,0 +1,179 @@
+import { IDataTestID, ValidationResult, ValidationStatus } from '../../types';
+import './InlineEdit.css';
+import { Button, Form, FormGroup, InputGroup, TextInput } from '@patternfly/react-core';
+import {
+  CheckIcon,
+  ExclamationCircleIcon,
+  PencilAltIcon,
+  TimesIcon,
+} from '@patternfly/react-icons';
+import {
+  FormEventHandler,
+  FunctionComponent,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  useCallback,
+  useState,
+} from 'react';
+
+interface IInlineEdit extends IDataTestID {
+  value?: string;
+  validator?: (value: string) => ValidationResult;
+  onChange?: (value: string) => void;
+  onClick?: () => void;
+}
+
+export const InlineEdit: FunctionComponent<IInlineEdit> = (props) => {
+  const [localValue, setLocalValue] = useState(props.value ?? '');
+  const [isReadOnly, setIsReadOnly] = useState(true);
+
+  const focusTextInput = useCallback((element: HTMLInputElement) => {
+    element?.focus();
+  }, []);
+
+  const [validationResult, setValidationResult] = useState<ValidationResult>({
+    status: ValidationStatus.Default,
+    errMessages: [],
+  });
+
+  const onEdit: MouseEventHandler<HTMLButtonElement> = useCallback((event) => {
+    setIsReadOnly(false);
+    event.stopPropagation();
+  }, []);
+
+  const onChange = useCallback(
+    (value: string) => {
+      setLocalValue(value);
+
+      if (value === props.value) {
+        setValidationResult({ status: ValidationStatus.Default, errMessages: [] });
+        return;
+      }
+
+      if (typeof props.validator === 'function') {
+        setValidationResult(props.validator(value));
+      }
+    },
+    [props],
+  );
+
+  const saveValue = useCallback(() => {
+    if (
+      validationResult.status !== ValidationStatus.Default &&
+      validationResult.status !== ValidationStatus.Success
+    )
+      return;
+
+    setIsReadOnly(true);
+    if (localValue !== props.value && typeof props.onChange === 'function') {
+      props.onChange(localValue);
+    }
+  }, [localValue, props, validationResult]);
+
+  const cancelValue = useCallback(() => {
+    setLocalValue(props.value ?? '');
+    setValidationResult({ status: ValidationStatus.Default, errMessages: [] });
+    setIsReadOnly(true);
+  }, [props.value]);
+
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      if (event.key === 'Enter') {
+        saveValue();
+      }
+      if (event.key === 'Escape') {
+        cancelValue();
+      }
+      event.stopPropagation();
+    },
+    [cancelValue, saveValue],
+  );
+
+  const onSave: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      saveValue();
+      event.stopPropagation();
+    },
+    [saveValue],
+  );
+
+  const onCancel: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      cancelValue();
+      event.stopPropagation();
+    },
+    [cancelValue],
+  );
+
+  const noop: FormEventHandler<HTMLFormElement> = useCallback((event) => {
+    event.preventDefault();
+  }, []);
+
+  return (
+    <>
+      {isReadOnly ? (
+        <>
+          <span
+            data-clickable={typeof props.onClick === 'function'}
+            data-testid={props['data-testid']}
+            onClick={props.onClick}
+          >
+            {props.value}
+          </span>
+          &nbsp;&nbsp;
+          <Button
+            variant="plain"
+            data-testid={props['data-testid'] + '--edit'}
+            onClick={onEdit}
+            icon={<PencilAltIcon />}
+          />
+        </>
+      ) : (
+        <Form onSubmit={noop} data-testid={props['data-testid'] + '--form'}>
+          <FormGroup
+            type="text"
+            helperTextInvalid={validationResult.errMessages[0]}
+            helperTextInvalidIcon={<ExclamationCircleIcon />}
+            fieldId="edit-value"
+            validated={validationResult.status}
+          >
+            <InputGroup>
+              <TextInput
+                id="edit-value"
+                name="edit-value"
+                aria-label="edit-value"
+                data-testid={props['data-testid'] + '--text-input'}
+                type="text"
+                ref={focusTextInput}
+                onChange={onChange}
+                value={localValue}
+                aria-invalid={validationResult.status === ValidationStatus.Error}
+                onKeyDown={onKeyDown}
+              />
+
+              <Button
+                variant="plain"
+                aria-label="save button for editing value"
+                onClick={onSave}
+                data-testid={props['data-testid'] + '--save'}
+                aria-disabled={validationResult.status === ValidationStatus.Error}
+                isDisabled={validationResult.status === ValidationStatus.Error}
+              >
+                <CheckIcon />
+              </Button>
+
+              <Button
+                variant="plain"
+                aria-label="close button for editing value"
+                data-testid={props['data-testid'] + '--cancel'}
+                onClick={onCancel}
+              >
+                <TimesIcon />
+              </Button>
+            </InputGroup>
+          </FormGroup>
+        </Form>
+      )}
+    </>
+  );
+};

--- a/src/components/InlineEdit/min-length-validator.test.ts
+++ b/src/components/InlineEdit/min-length-validator.test.ts
@@ -1,0 +1,20 @@
+import { ValidationStatus } from '../../types';
+import { minLengthValidator } from './min-length-validator';
+
+describe('min-length-validator', () => {
+  it('should return error if value is shorter than 5 characters', () => {
+    const result = minLengthValidator('1234');
+    expect(result).toEqual({
+      status: ValidationStatus.Error,
+      errMessages: ['Value must be at least 5 characters long'],
+    });
+  });
+
+  it('should return success if value is at least 5 characters', () => {
+    const result = minLengthValidator('12345');
+    expect(result).toEqual({
+      status: ValidationStatus.Success,
+      errMessages: [],
+    });
+  });
+});

--- a/src/components/InlineEdit/min-length-validator.ts
+++ b/src/components/InlineEdit/min-length-validator.ts
@@ -1,0 +1,15 @@
+import { ValidationResult, ValidationStatus } from '../../types';
+
+export const minLengthValidator = (value: string): ValidationResult => {
+  if (value.length < 5) {
+    return {
+      status: ValidationStatus.Error,
+      errMessages: ['Value must be at least 5 characters long'],
+    };
+  }
+
+  return {
+    status: ValidationStatus.Success,
+    errMessages: [],
+  };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -252,4 +252,5 @@ export type HandleDeleteStepFn = (integrationId: string, UUID: string) => void;
 
 export * from './dsl.model';
 export * from './react-components.model';
+export * from './validation.model';
 export * from './visualization.model';

--- a/src/types/validation.model.ts
+++ b/src/types/validation.model.ts
@@ -1,0 +1,11 @@
+export interface ValidationResult {
+  status: ValidationStatus;
+  errMessages: string[];
+}
+
+export const enum ValidationStatus {
+  Default = 'default',
+  Warning = 'warning',
+  Success = 'success',
+  Error = 'error',
+}


### PR DESCRIPTION
### Context
The InlineEdit component is meant to provide a mechanism to make a text editable in place.

### User flow
1. The user sees a text, signaled with a pencil icon, which means that it can be edited.
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/f8e148f1-e9f1-4832-b2a1-077f582acba4)

2. The user clicks on the pencil and now the text gets transformed into a TextField with save and cancel buttons
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/40e35cd4-92a0-4830-8538-a220c125332b)

3. The user makes the required changes and hits save, now the text is updated. Alternatively, the user could hit cancel and the text will be restored to its original form
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/bbec5e1a-e404-4cd9-af05-748c02be9c9f)

#### Here's a complete user flow
[Screencast from 2023-07-14 13-24-20.webm](https://github.com/KaotoIO/kaoto-ui/assets/16512618/834207a0-12b7-4278-86c8-fd2f0c882d92)

### Validation
The InlineEdit component also supports custom validation, it's just a matter of passing a `validator` and it will be called upon every change.
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/f3967567-d5f0-448d-bb02-0c4edd8ec6e4)
