### PR TITLE
feat(flows): rename flows

### DIFF
--- a/src/components/Flows/FlowsList.css
+++ b/src/components/Flows/FlowsList.css
@@ -1,0 +1,7 @@
+/* This is to make the last two columns (Edit and Delete) to be the same width */
+/* Select the last two td elements from each tr */
+table.FlowsListTable tr td:last-child,
+table.FlowsListTable tr td:nth-last-child(2) {
+  width: 1%;
+  white-space: nowrap;
+}

--- a/src/components/Flows/FlowsList.test.tsx
+++ b/src/components/Flows/FlowsList.test.tsx
@@ -109,4 +109,21 @@ describe('FlowsList.tsx', () => {
     expect(useFlowsStore.getState().flows).toHaveLength(1);
     expect(useFlowsStore.getState().flows[0].id).toEqual('route-4321');
   });
+
+  test('should allow the user to edit a flow name', async () => {
+    const wrapper = render(<FlowsList />);
+
+    act(() => {
+      const editFlowId = wrapper.getByTestId('goto-btn-route-4321--edit');
+      fireEvent.click(editFlowId);
+    });
+
+    act(() => {
+      const input = wrapper.getByTestId('goto-btn-route-4321--text-input');
+      fireEvent.change(input, { target: { value: 'new-name' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    expect(useFlowsStore.getState().flows[1].id).toEqual('new-name');
+  });
 });

--- a/src/components/Flows/FlowsList.tsx
+++ b/src/components/Flows/FlowsList.tsx
@@ -1,3 +1,6 @@
+import { ValidationService } from '../../services';
+import { InlineEdit } from '../InlineEdit/InlineEdit';
+import './FlowsList.css';
 import { FlowsListEmptyState } from './FlowsListEmptyState';
 import { useFlowsStore, useVisualizationStore } from '@kaoto/store';
 import { Button, Icon } from '@patternfly/react-core';
@@ -11,10 +14,11 @@ interface IFlowsList {
 }
 
 export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
-  const { isListEmpty, flows, deleteFlow } = useFlowsStore(
+  const { isListEmpty, flows, setFlowName, deleteFlow } = useFlowsStore(
     (state) => ({
       isListEmpty: state.flows.length === 0,
       flows: state.flows,
+      setFlowName: state.setFlowName,
       deleteFlow: state.deleteFlow,
     }),
     shallow,
@@ -47,7 +51,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
   return isListEmpty ? (
     <FlowsListEmptyState data-testid="flows-list-empty-state" />
   ) : (
-    <TableComposable variant="compact" data-testid="flows-list-table">
+    <TableComposable className="FlowsListTable" variant="compact" data-testid="flows-list-table">
       <Thead>
         <Tr>
           <Th>{columnNames.current.id}</Th>
@@ -59,17 +63,20 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
         {flows.map((flow) => (
           <Tr key={flow.id} data-testid={`flows-list-row-${flow.id}`} isHoverable>
             <Td dataLabel={columnNames.current.id}>
-              <Button
-                data-testid={`goto-btn-${flow.id}`}
+              <InlineEdit
+                data-testid={`goto-btn-${flow.metadata.name}`}
+                value={flow.metadata.name}
+                validator={ValidationService.validateUniqueName}
                 onClick={() => {
                   onSelectFlow(flow.id);
                 }}
-                variant="plain"
-              >
-                <p>{flow.id}</p>
-                <p>{flow.description}</p>
-              </Button>
+                onChange={(name) => {
+                  setFlowName(flow.id, name);
+                }}
+              />
+              <p>{flow.description}</p>
             </Td>
+
             <Td dataLabel={columnNames.current.isVisible}>
               <Button
                 data-testid={`toggle-btn-${flow.id}`}
@@ -92,6 +99,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                 }}
               />
             </Td>
+
             <Td dataLabel={columnNames.current.delete}>
               <Button
                 data-testid={`delete-btn-${flow.id}`}

--- a/src/components/Flows/FlowsMenu.tsx
+++ b/src/components/Flows/FlowsMenu.tsx
@@ -59,7 +59,7 @@ export const FlowsMenu: FunctionComponent = () => {
         setIsOpen(isOpen);
       }}
       toggle={toggle}
-      minWidth="300px"
+      minWidth="400px"
     >
       <FlowsList
         onClose={() => {

--- a/src/hooks/flows-visibility.hook.ts
+++ b/src/hooks/flows-visibility.hook.ts
@@ -1,5 +1,5 @@
 import { useVisualizationStore } from '../store/visualizationStore';
-import { IVisibleFlowsInformation } from '../types';
+import { IVisibleFlows, IVisibleFlowsInformation } from '../types';
 import { useEffect, useState } from 'react';
 
 /**
@@ -19,9 +19,7 @@ export const useFlowsVisibility = () => {
   return visibleFlowsInformation;
 };
 
-function getVisibleFlowsInformation(
-  visibleFlows: Record<string, boolean>,
-): IVisibleFlowsInformation {
+function getVisibleFlowsInformation(visibleFlows: IVisibleFlows): IVisibleFlowsInformation {
   const flowsArray = Object.entries(visibleFlows);
   const visibleFlowsIdArray = flowsArray.filter((flow) => flow[1]).map((flow) => flow[0]);
 

--- a/src/services/visualizationService.test.ts
+++ b/src/services/visualizationService.test.ts
@@ -141,120 +141,6 @@ describe('visualizationService', () => {
     });
   });
 
-  describe('redrawDiagram', () => {
-    beforeEach(() => {
-      jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-1234');
-      jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-4321');
-    });
-
-    it('should process only visible flows', async () => {
-      useFlowsStore.getState().addNewFlow('Integration');
-      useFlowsStore.getState().addNewFlow('Integration');
-
-      const getLayoutedElementsSpy = jest.spyOn(VisualizationService, 'getLayoutedElements');
-
-      await service.redrawDiagram(jest.fn());
-
-      expect(getLayoutedElementsSpy).toHaveBeenCalledTimes(1);
-      expect(getLayoutedElementsSpy).toHaveBeenCalledWith(
-        [
-          expect.objectContaining({
-            data: {
-              isPlaceholder: true,
-              label: 'ADD A STEP',
-              nextStepUuid: undefined,
-              step: {
-                UUID: expect.stringMatching(/placeholder-\d+/),
-                integrationId: 'route-4321',
-                name: '',
-                type: 'START',
-              },
-            },
-            draggable: false,
-            height: 80,
-            id: expect.stringMatching(/node_0--\d+/),
-            position: {
-              x: 0,
-              y: 0,
-            },
-            sourcePosition: 'right',
-            targetPosition: 'left',
-            type: 'step',
-            width: 80,
-          }),
-        ],
-        [],
-        'LR',
-      );
-    });
-
-    it('should process more than one visible flow', async () => {
-      useFlowsStore.getState().addNewFlow('Integration');
-      useFlowsStore.getState().addNewFlow('Integration');
-      useVisualizationStore.getState().showAllFlows();
-
-      const getLayoutedElementsSpy = jest.spyOn(VisualizationService, 'getLayoutedElements');
-
-      await service.redrawDiagram(jest.fn());
-
-      expect(getLayoutedElementsSpy).toHaveBeenCalledTimes(1);
-      expect(getLayoutedElementsSpy).toHaveBeenCalledWith(
-        [
-          expect.objectContaining({
-            data: {
-              isPlaceholder: true,
-              label: 'ADD A STEP',
-              nextStepUuid: undefined,
-              step: {
-                UUID: expect.stringMatching(/placeholder-\d+/),
-                integrationId: 'route-1234',
-                name: '',
-                type: 'START',
-              },
-            },
-            draggable: false,
-            height: 80,
-            id: expect.stringMatching(/node_0--\d+/),
-            position: {
-              x: 0,
-              y: 0,
-            },
-            sourcePosition: 'right',
-            targetPosition: 'left',
-            type: 'step',
-            width: 80,
-          }),
-          expect.objectContaining({
-            data: {
-              isPlaceholder: true,
-              label: 'ADD A STEP',
-              nextStepUuid: undefined,
-              step: {
-                UUID: expect.stringMatching(/placeholder-\d+/),
-                integrationId: 'route-4321',
-                name: '',
-                type: 'START',
-              },
-            },
-            draggable: false,
-            height: 80,
-            id: expect.stringMatching(/node_0--\d+/),
-            position: {
-              x: 0,
-              y: expect.any(Number),
-            },
-            sourcePosition: 'right',
-            targetPosition: 'left',
-            type: 'step',
-            width: 80,
-          }),
-        ],
-        [],
-        'LR',
-      );
-    });
-  });
-
   it("buildEdgeParams(): should build an edge's default parameters for a single given node", () => {
     const currentStep = nodes[1];
     const previousStep = nodes[0];
@@ -321,20 +207,22 @@ describe('visualizationService', () => {
     });
   });
 
-  it('buildNodesFromSteps(): should build visualization nodes from an array of steps', () => {
-    const stepNodes = VisualizationService.buildNodesFromSteps('Camel Route-1', steps, 'RIGHT');
-    expect(stepNodes[0].data.step.UUID).toBeDefined();
-    expect(stepNodes[0].id).toContain(stepNodes[0].data.step.UUID);
-  });
+  describe('buildNodesFromSteps()', () => {
+    it('should build visualization nodes from an array of steps', () => {
+      const stepNodes = VisualizationService.buildNodesFromSteps('Camel Route-1', steps, 'RIGHT');
+      expect(stepNodes[0].data.step.UUID).toBeDefined();
+      expect(stepNodes[0].id).toContain(stepNodes[0].data.step.UUID);
+    });
 
-  it('buildNodesFromSteps(): should build visualization nodes from an array of steps with branches', () => {
-    const stepNodes = VisualizationService.buildNodesFromSteps(
-      'Camel Route-1',
-      branchSteps,
-      'RIGHT',
-    );
-    expect(stepNodes[0].data.step.UUID).toBeDefined();
-    expect(stepNodes).toHaveLength(11); // 4 Main steps + 7 branch steps
+    it('should build visualization nodes from an array of steps with branches', () => {
+      const stepNodes = VisualizationService.buildNodesFromSteps(
+        'Camel Route-1',
+        branchSteps,
+        'RIGHT',
+      );
+      expect(stepNodes[0].data.step.UUID).toBeDefined();
+      expect(stepNodes).toHaveLength(11); // 4 Main steps + 7 branch steps
+    });
   });
 
   it('containsAddStepPlaceholder(): should determine if there is an ADD STEP placeholder in the steps', () => {
@@ -571,6 +459,120 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
+  describe('redrawDiagram', () => {
+    beforeEach(() => {
+      jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-1234');
+      jest.spyOn(FlowsService, 'getNewFlowId').mockReturnValueOnce('route-4321');
+    });
+
+    it('should process only visible flows', async () => {
+      useFlowsStore.getState().addNewFlow('Integration');
+      useFlowsStore.getState().addNewFlow('Integration');
+
+      const getLayoutedElementsSpy = jest.spyOn(VisualizationService, 'getLayoutedElements');
+
+      await service.redrawDiagram(jest.fn());
+
+      expect(getLayoutedElementsSpy).toHaveBeenCalledTimes(1);
+      expect(getLayoutedElementsSpy).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            data: {
+              isPlaceholder: true,
+              label: 'ADD A STEP',
+              nextStepUuid: undefined,
+              step: {
+                UUID: expect.stringMatching(/placeholder-\d+/),
+                integrationId: 'route-4321',
+                name: '',
+                type: 'START',
+              },
+            },
+            draggable: false,
+            height: 80,
+            id: expect.stringMatching(/node_0--\d+/),
+            position: {
+              x: 0,
+              y: 0,
+            },
+            sourcePosition: 'right',
+            targetPosition: 'left',
+            type: 'step',
+            width: 80,
+          }),
+        ],
+        [],
+        'LR',
+      );
+    });
+
+    it('should process more than one visible flow', async () => {
+      useFlowsStore.getState().addNewFlow('Integration');
+      useFlowsStore.getState().addNewFlow('Integration');
+      useVisualizationStore.getState().showAllFlows();
+
+      const getLayoutedElementsSpy = jest.spyOn(VisualizationService, 'getLayoutedElements');
+
+      await service.redrawDiagram(jest.fn());
+
+      expect(getLayoutedElementsSpy).toHaveBeenCalledTimes(1);
+      expect(getLayoutedElementsSpy).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            data: {
+              isPlaceholder: true,
+              label: 'ADD A STEP',
+              nextStepUuid: undefined,
+              step: {
+                UUID: expect.stringMatching(/placeholder-\d+/),
+                integrationId: 'route-1234',
+                name: '',
+                type: 'START',
+              },
+            },
+            draggable: false,
+            height: 80,
+            id: expect.stringMatching(/node_0--\d+/),
+            position: {
+              x: 0,
+              y: 0,
+            },
+            sourcePosition: 'right',
+            targetPosition: 'left',
+            type: 'step',
+            width: 80,
+          }),
+          expect.objectContaining({
+            data: {
+              isPlaceholder: true,
+              label: 'ADD A STEP',
+              nextStepUuid: undefined,
+              step: {
+                UUID: expect.stringMatching(/placeholder-\d+/),
+                integrationId: 'route-4321',
+                name: '',
+                type: 'START',
+              },
+            },
+            draggable: false,
+            height: 80,
+            id: expect.stringMatching(/node_0--\d+/),
+            position: {
+              x: 0,
+              y: expect.any(Number),
+            },
+            sourcePosition: 'right',
+            targetPosition: 'left',
+            type: 'step',
+            width: 80,
+          }),
+        ],
+        [],
+        'LR',
+      );
+    });
+  });
+
   it('shouldAddEdge(): given a node, should determine whether to add an edge for it', () => {
     const nodeWithoutBranches = {
       id: 'node-without-branches',
@@ -689,38 +691,6 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
-  it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
-    const step = {} as IStepProps;
-
-    expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
-    // has branches but not branch support
-    expect(
-      VisualizationService.showBranchesTab({
-        ...step,
-        branches: [],
-      }),
-    ).toBeFalsy();
-
-    expect(
-      VisualizationService.showBranchesTab({
-        ...step,
-        branches: [],
-        minBranches: 0,
-        maxBranches: -1,
-      }),
-    ).toBeTruthy();
-
-    // if step has maximum number of branches already
-    expect(
-      VisualizationService.showBranchesTab({
-        ...step,
-        branches: [{}, {}] as IStepPropsBranch[],
-        minBranches: 0,
-        maxBranches: 2,
-      }),
-    ).toBeFalsy();
-  });
-
   it('showPrependStepButton(): given a node, should determine whether to show a prepend step button for it', () => {
     const vizStoreState = useVisualizationStore.getState();
     useVisualizationStore.setState({
@@ -791,6 +761,38 @@ describe('visualizationService', () => {
     ).toBeTruthy();
   });
 
+  it('showBranchesTab(): given node data, should determine whether to show the branches tab in mini catalog', () => {
+    const step = {} as IStepProps;
+
+    expect(VisualizationService.showBranchesTab(step)).toBeFalsy();
+    // has branches but not branch support
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        branches: [],
+      }),
+    ).toBeFalsy();
+
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        branches: [],
+        minBranches: 0,
+        maxBranches: -1,
+      }),
+    ).toBeTruthy();
+
+    // if step has maximum number of branches already
+    expect(
+      VisualizationService.showBranchesTab({
+        ...step,
+        branches: [{}, {}] as IStepPropsBranch[],
+        minBranches: 0,
+        maxBranches: 2,
+      }),
+    ).toBeFalsy();
+  });
+
   it('showStepsTab(): given node data, should determine whether to show the steps tab in mini catalog', () => {
     const step: IVizStepNodeData = {
       label: '',
@@ -818,7 +820,7 @@ describe('visualizationService', () => {
     ).toBeFalsy();
   });
 
-  it('should allow consumers to get a static empty step', () => {
+  it('getEmptySelectedStep(): should allow consumers to get a static empty step', () => {
     const result = VisualizationService.getEmptySelectedStep();
 
     expect(result).toEqual({
@@ -829,5 +831,92 @@ describe('visualizationService', () => {
       UUID: '',
       integrationId: '',
     });
+  });
+
+  it('displaySingleFlow(): should display a single flow in the store', () => {
+    useVisualizationStore.setState({
+      visibleFlows: {
+        'route-1': true,
+        'route-2': false,
+      },
+    });
+
+    VisualizationService.displaySingleFlow('route-2');
+
+    expect(useVisualizationStore.getState().visibleFlows).toEqual({
+      'route-1': false,
+      'route-2': true,
+    });
+  });
+
+  it('deleteFlowFromVisibleFlows(): should delete a flow from the visible flows in the store', () => {
+    useVisualizationStore.setState({
+      visibleFlows: {
+        'route-1': true,
+        'route-2': false,
+      },
+    });
+
+    VisualizationService.deleteFlowFromVisibleFlows('route-1');
+
+    expect(useVisualizationStore.getState().visibleFlows).toEqual({
+      'route-2': false,
+    });
+  });
+
+  it('renameVisibleFlow(): should rename a visible flow in the store', () => {
+    useVisualizationStore.setState({
+      visibleFlows: {
+        'route-1': true,
+        'route-2': false,
+      },
+    });
+
+    VisualizationService.renameVisibleFlow('route-1', 'route-1-renamed');
+
+    expect(useVisualizationStore.getState().visibleFlows).toEqual({
+      'route-1-renamed': true,
+      'route-2': false,
+    });
+  });
+
+  describe('setVisibleFlows()', () => {
+    it('should set the visible flows in the store with the first one visible', () => {
+      VisualizationService.setVisibleFlows(['route-1', 'route-2']);
+
+      expect(useVisualizationStore.getState().visibleFlows).toEqual({
+        'route-1': true,
+        'route-2': false,
+      });
+    });
+
+    it('should preserve the previous visible flows status', () => {
+      useVisualizationStore.setState({
+        visibleFlows: {
+          'route-1': true,
+          'route-2': true,
+        },
+      });
+
+      VisualizationService.setVisibleFlows(['route-1', 'route-2']);
+
+      expect(useVisualizationStore.getState().visibleFlows).toEqual({
+        'route-1': true,
+        'route-2': true,
+      });
+    });
+  });
+
+  it('removeAllVisibleFlows(): should remove all visible flows from the store', () => {
+    useVisualizationStore.setState({
+      visibleFlows: {
+        'route-1': true,
+        'route-2': true,
+      },
+    });
+
+    VisualizationService.removeAllVisibleFlows();
+
+    expect(useVisualizationStore.getState().visibleFlows).toEqual({});
   });
 });

--- a/src/services/visualizationService.ts
+++ b/src/services/visualizationService.ts
@@ -5,6 +5,7 @@ import { ValidationService } from './validationService';
 import {
   HandleDeleteStepFn,
   IStepProps,
+  IVisibleFlows,
   IVizStepNode,
   IVizStepNodeData,
   IVizStepNodeDataBranch,
@@ -670,6 +671,15 @@ export class VisualizationService {
     useVisualizationStore.getState().setVisibleFlows({ ...visibleFlows });
   }
 
+  static renameVisibleFlow(oldId: string, newId: string): void {
+    const visibleFlows = useVisualizationStore.getState().visibleFlows;
+    const isFlowVisible = visibleFlows[oldId];
+    delete visibleFlows[oldId];
+    visibleFlows[newId] = isFlowVisible;
+
+    useVisualizationStore.getState().setVisibleFlows(visibleFlows);
+  }
+
   static setVisibleFlows(flowsIds: string[]): void {
     const previousVisibleFlows = useVisualizationStore.getState().visibleFlows;
 
@@ -683,7 +693,7 @@ export class VisualizationService {
          */
         [flow]: previousVisibleFlows[flow] ?? index === 0,
       }),
-      {} as Record<string, boolean>,
+      {} as IVisibleFlows,
     );
     useVisualizationStore.getState().setVisibleFlows(visibleFlows);
   }

--- a/src/store/FlowsStore.test.ts
+++ b/src/store/FlowsStore.test.ts
@@ -580,6 +580,24 @@ describe('FlowsStore', () => {
     expect(useVisualizationStore.getState().visibleFlows).toEqual({});
   });
 
+  describe('setFlowName', () => {
+    it('should allow consumers to set the name of a flow', () => {
+      useFlowsStore.getState().addNewFlow('Integration');
+
+      useFlowsStore.getState().setFlowName(MOCK_FLOW_ID, 'new-name');
+
+      expect(useFlowsStore.getState().flows[0].metadata.name).toEqual('new-name');
+    });
+
+    it('should ignore non existing flows', () => {
+      const initialState = useFlowsStore.getState();
+
+      useFlowsStore.getState().setFlowName('non-existing-flow', 'new-name');
+
+      expect(useFlowsStore.getState()).toEqual(initialState);
+    });
+  });
+
   it('should allow consumers to update the metadata property', () => {
     useFlowsStore.getState().deleteAllFlows();
 

--- a/src/store/FlowsStoreFacade.test.ts
+++ b/src/store/FlowsStoreFacade.test.ts
@@ -41,4 +41,14 @@ describe('FlowsStoreFacade', () => {
 
     expect(facadeFlows).toBe(storeFlows);
   });
+
+  it('should return the flows ids from useFlowsStore', () => {
+    useFlowsStore.setState({
+      flows: [{ id: '1' }, { id: '2' }] as IIntegration[],
+    } as IFlowsStore);
+
+    const facadeFlowsIds = FlowsStoreFacade.getFlowsIds();
+
+    expect(facadeFlowsIds).toEqual(['1', '2']);
+  });
 });

--- a/src/store/FlowsStoreFacade.ts
+++ b/src/store/FlowsStoreFacade.ts
@@ -18,4 +18,8 @@ export class FlowsStoreFacade {
   static getFlows(): IIntegration[] {
     return useFlowsStore.getState().flows;
   }
+
+  static getFlowsIds(): string[] {
+    return FlowsStoreFacade.getFlows().map((flow) => flow.id);
+  }
 }

--- a/src/store/settingsStore.test.tsx
+++ b/src/store/settingsStore.test.tsx
@@ -23,6 +23,20 @@ describe('settingsStore', () => {
     expect(result.current.settings.namespace).toEqual('KameletBinding');
   });
 
+  it('should provide a default value for uiLightMode', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockReturnValueOnce(null);
+
+    const { result } = renderHook(() => useSettingsStore());
+    expect(result.current.settings.uiLightMode).toBeTruthy();
+  });
+
+  it('should disable uiLightMode if the key is "false" in local storae', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockReturnValueOnce('false');
+
+    const { result } = renderHook(() => useSettingsStore());
+    expect(result.current.settings.uiLightMode).toBeTruthy();
+  });
+
   it('setBackendVersion', () => {
     const { result } = renderHook(() => useSettingsStore());
     expect(result.current.settings.backendVersion).toEqual('');

--- a/src/store/visualizationStore.tsx
+++ b/src/store/visualizationStore.tsx
@@ -1,4 +1,4 @@
-import { IVizStepPropsEdge, IVizStepNode } from '@kaoto/types';
+import { IVizStepPropsEdge, IVizStepNode, IVisibleFlows } from '@kaoto/types';
 import {
   Connection,
   EdgeChange,
@@ -34,11 +34,11 @@ export type RFState = {
   updateNode: (nodeToUpdate: IVizStepNode, nodeIndex: number) => void;
 
   /** Visibility related handlers */
-  visibleFlows: Record<string, boolean>;
+  visibleFlows: IVisibleFlows;
   toggleFlowVisible: (flowId: string, isVisible?: boolean) => void;
   showAllFlows: () => void;
   hideAllFlows: () => void;
-  setVisibleFlows: (flows: Record<string, boolean>) => void;
+  setVisibleFlows: (flows: IVisibleFlows) => void;
 };
 
 // this is our useStore hook that we can use in our components to get parts of the store and call actions
@@ -121,11 +121,8 @@ export const useVisualizationStore = create<RFState>((set, get) => ({
  * This will prevent the circular dependency created by
  * importing the Store into the service and the other way around
  */
-const toggleFlowsVisibility = (
-  visibleFlows: Record<string, boolean>,
-  isVisible: boolean,
-): Record<string, boolean> =>
+const toggleFlowsVisibility = (visibleFlows: IVisibleFlows, isVisible: boolean): IVisibleFlows =>
   Object.keys(visibleFlows).reduce((acc, flowId) => {
     acc[flowId] = isVisible;
     return acc;
-  }, {} as Record<string, boolean>);
+  }, {} as IVisibleFlows);

--- a/src/types/visualization.model.ts
+++ b/src/types/visualization.model.ts
@@ -4,3 +4,5 @@ export interface IVisibleFlowsInformation {
   totalFlowsCount: number;
   isCanvasEmpty: boolean;
 }
+
+export type IVisibleFlows = Record<string, boolean>;


### PR DESCRIPTION
### Context
Currently, there only possibility to rename a flow is to leverage the source code editor.

### Changes
This commit makes use of the recently added InlineEdit component to provide a mechanism to rename flows.

### Notes
https://github.com/KaotoIO/kaoto-ui/assets/16512618/a68bee1a-575c-4aba-bfbb-1a01fec0a956

This pull request handles changing the name of a flow, changing the description is still pending.

fixes: https://github.com/KaotoIO/kaoto-ui/issues/1902
fixes: https://github.com/KaotoIO/kaoto-ui/issues/769