### PR TITLE
fix(build): Publish Windows artifacts

### DIFF
--- a/.github/workflows/add-standalone-jar-to-release.yml
+++ b/.github/workflows/add-standalone-jar-to-release.yml
@@ -94,9 +94,9 @@ jobs:
           - os: ubuntu-latest
             asset_name: kaoto-linux-amd64
             file: -runner
-#          - os: windows-latest
-#            asset_name: kaoto-windows-amd64
-#            file: -runner.exe
+          - os: windows-latest
+            asset_name: kaoto-windows-amd64
+            file: -runner.exe
           - os: macos-latest
             asset_name: kaoto-macos-amd64
             file: -runner
@@ -138,7 +138,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: 🤳 Build Native Quarkus
-        run: mvn install -Pnative -DskipTests -Dquarkus.native.native-image-xmx=5g
+        # Until https://github.com/PowerShell/PowerShell/issues/6291 is done, we cannot use -Dquarkus.native.native-image-xmx=5g
+        run: mvn install -Pnative -DskipTests
+        env:
+          QUARKUS_NATIVE_NATIVE_IMAGE_XMX: "5g"
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
### Context
Currently, there's an [open issue on Powershell](https://github.com/PowerShell/PowerShell/issues/6291) that causes an argument that starts with '-' (dash) and has a '.' (dot) in it, gets parsed as two separate arguments, i.e.:

```bash
> mvn install -Dquarkus.native.native-image-xmx=5g
```

gets parsed as

```bash
mvn install -Dquarkus .native.native-image-xmx=5g
```

This makes the native build fail since that is not a valid command.

### Changes
The workaround is to use the corresponding ENV variable to pass the same property in the meantime

relates to: https://github.com/KaotoIO/kaoto-backend/pull/794