### PR TITLE
fix(chromatic): Fix chromatic publishing

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,11 @@
 name: 📖 Storybook (via Chromatic)
 
 # Event for the workflow
-on: push
+on:
+  push:
+    branches-ignore:
+      - "renovate/**"
+      - "dependabot/**"
 
 # List of jobs
 jobs:
@@ -29,3 +33,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: 14f589a59855
           buildScriptName: build:storybook
+          workingDir: packages/kaoto-ui

--- a/packages/kaoto-ui/package.json
+++ b/packages/kaoto-ui/package.json
@@ -15,7 +15,7 @@
     "build:lib": "rimraf dist/lib && yarn copy:css && yarn copy:images && tsc -p tsconfig.lib.json && node ./scripts/fixTsPathsAlias.js",
     "build:lib:watch": "tsc-watch --noClear -p tsconfig.lib.json",
     "build:storybook": "storybook build",
-    "chromatic": "chromatic --build-script-name 'build:storybook' --skip 'dependabot/**' --exit-zero-on-changes",
+    "chromatic": "chromatic --build-script-name 'build:storybook' --skip 'renovate/**' --exit-zero-on-changes",
     "copy:css": "copyfiles -u 1 \"src/**/*.{sass,scss,css}\" dist/lib/",
     "copy:images": "cpr ./src/assets ./dist/lib/assets",
     "clean": "rimraf dist",


### PR DESCRIPTION
### Context
After converting the `kaoto-ui` repository into a mono repo, chromatic needs to know where is the package needs to be published.

### Changes
From the [docs](https://www.chromatic.com/docs/github-actions):

| `workingDir` | Provide the location of Storybook’s package.json if installed in a subdirectory (i.e., monorepos). |
| --- | --- |

fixes: https://github.com/KaotoIO/kaoto-ui/issues/2159