### PR TITLE
feat(about): Show build information in the About modal

### DIFF
--- a/packages/kaoto-ui/package.json
+++ b/packages/kaoto-ui/package.json
@@ -130,6 +130,7 @@
     "eslint-plugin-storybook": "^0.6.12",
     "eslint-plugin-testing-library": "5.11.0",
     "file-selector": "^0.6.0",
+    "git-revision-webpack-plugin": "^5.0.0",
     "html-webpack-plugin": "5.5.3",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",

--- a/packages/kaoto-ui/src/components/About/AboutModal.tsx
+++ b/packages/kaoto-ui/src/components/About/AboutModal.tsx
@@ -1,4 +1,5 @@
-import logo from '../assets/images/logo-kaoto-dark.png';
+import logo from '../../assets/images/logo-kaoto-dark.png';
+import { BuildInfo } from './BuildInfo';
 import { useSettingsStore } from '@kaoto/store';
 import {
   AboutModal as PatternFlyAboutModal,
@@ -33,6 +34,8 @@ export const AboutModal = ({ handleCloseModal, isModalOpen }: IAboutModal) => {
           <TextListItem component="dd" data-testid="about-backend-version">
             {backendVersion}
           </TextListItem>
+
+          <BuildInfo />
         </TextList>
       </TextContent>
     </PatternFlyAboutModal>

--- a/packages/kaoto-ui/src/components/About/BuildInfo.tsx
+++ b/packages/kaoto-ui/src/components/About/BuildInfo.tsx
@@ -1,0 +1,38 @@
+import { TextListItem } from '@patternfly/react-core';
+import { useMemo } from 'react';
+
+export const BuildInfo = () => {
+  const buildInfo = useMemo(() => {
+    try {
+      return BUILD_INFO;
+    } catch (error) {
+      return undefined;
+    }
+  }, []);
+
+  return !buildInfo ? null : (
+    <>
+      <TextListItem component="dt">Build info</TextListItem>
+      <TextListItem component="dt">Package name</TextListItem>
+      <TextListItem component="dd" data-testid="about-package-name">
+        {buildInfo.NAME}
+      </TextListItem>
+      <TextListItem component="dt">Git version</TextListItem>
+      <TextListItem component="dd" data-testid="about-git-version">
+        {buildInfo.VERSION}
+      </TextListItem>
+      <TextListItem component="dt">Git commit hash</TextListItem>
+      <TextListItem component="dd" data-testid="about-git-commit-hash">
+        {buildInfo.COMMITHASH}
+      </TextListItem>
+      <TextListItem component="dt">Git branch</TextListItem>
+      <TextListItem component="dd" data-testid="about-git-brach">
+        {buildInfo.BRANCH}
+      </TextListItem>
+      <TextListItem component="dt">Git last commit date</TextListItem>
+      <TextListItem component="dd" data-testid="about-git-last-commit-date">
+        {buildInfo.LASTCOMMITDATETIME}
+      </TextListItem>
+    </>
+  );
+};

--- a/packages/kaoto-ui/src/components/KaotoToolbar.tsx
+++ b/packages/kaoto-ui/src/components/KaotoToolbar.tsx
@@ -1,5 +1,5 @@
 import logo from '../assets/images/logo-kaoto-dark.png';
-import { AboutModal } from './AboutModal';
+import { AboutModal } from './About/AboutModal';
 import { AppearanceModal } from './AppearanceModal';
 import { ConfirmationModal } from './ConfirmationModal';
 import { NewFlow } from './DSL/NewFlow';

--- a/packages/kaoto-ui/src/global.d.ts
+++ b/packages/kaoto-ui/src/global.d.ts
@@ -3,3 +3,11 @@ declare module '*.svg';
 declare var KAOTO_API: string;
 declare var KAOTO_VERSION: string;
 declare var NODE_ENV: string;
+
+declare var BUILD_INFO: {
+  NAME: string;
+  VERSION: string;
+  COMMITHASH: string;
+  BRANCH: string;
+  LASTCOMMITDATETIME: string;
+};

--- a/packages/kaoto-ui/webpack.common.js
+++ b/packages/kaoto-ui/webpack.common.js
@@ -2,10 +2,12 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-const { dependencies, federatedModuleName, version } = require('./package.json');
+const { name, dependencies, federatedModuleName, version } = require('./package.json');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
+const gitRevisionPlugin = new GitRevisionPlugin();
 
 const isPatternflyStyles = (stylesheet) =>
   stylesheet.includes('@patternfly/react-core/') ||
@@ -89,6 +91,14 @@ const common = (mode) => {
       new webpack.DefinePlugin({
         KAOTO_VERSION: JSON.stringify(version),
         NODE_ENV: JSON.stringify(mode),
+
+        BUILD_INFO: {
+          NAME: JSON.stringify(name),
+          VERSION: JSON.stringify(gitRevisionPlugin.version()),
+          COMMITHASH: JSON.stringify(gitRevisionPlugin.commithash()),
+          BRANCH: JSON.stringify(gitRevisionPlugin.branch()),
+          LASTCOMMITDATETIME: JSON.stringify(gitRevisionPlugin.lastcommitdatetime()),
+        },
       }),
     ],
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,6 +3422,7 @@ __metadata:
     eslint-plugin-storybook: ^0.6.12
     eslint-plugin-testing-library: 5.11.0
     file-selector: ^0.6.0
+    git-revision-webpack-plugin: ^5.0.0
     html-to-image: ^1.11.11
     html-webpack-plugin: 5.5.3
     immer: ^10.0.2
@@ -13456,6 +13457,15 @@ __metadata:
   bin:
     giget: dist/cli.mjs
   checksum: 76ad0f7e792ee95dd6c4e1096697fdcce61a2a3235a6c21761fc3e0d1053342074ce71c80059d6d4363fd34152e5d7b2e58221412f300c852ff7d4a12d0321fe
+  languageName: node
+  linkType: hard
+
+"git-revision-webpack-plugin@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "git-revision-webpack-plugin@npm:5.0.0"
+  peerDependencies:
+    webpack: ^5.0.0
+  checksum: be40634cf0a317f02b6231e77a7f97f5ae85855f87d88ee821500e8ad33a25168b96d47f1be8f2d3e814c22b58b7b9fef732aea5e0ba054b1d181c93d4212de7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Context
At this moment, the `About` modal shows the frontend and backend versions, but in the case of a `dev` version, there's no way to identify which exact build it is.

For this reason, a new `Webpack` git plugin is added to show additional build information to distinguish between versions.

### Changes

#### Before
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/4d0e8eb1-2464-4777-a3f3-4dbba49e3b1b)

#### After
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/ecf3a854-daf0-43cf-9b39-f29230d9314a)
