### PR TITLE
chore: Update packageManager field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
     "cypress-file-upload": {
       "built": true
     }
-  }
+  },
+  "packageManager": "yarn@3.6.1"
 }

--- a/packages/kaoto-ui/package.json
+++ b/packages/kaoto-ui/package.json
@@ -200,6 +200,5 @@
   ],
   "msw": {
     "workerDirectory": "public"
-  },
-  "packageManager": "yarn@3.6.1"
+  }
 }


### PR DESCRIPTION
### Context
Currently, the root `package.json` doesn't contain the `packageManager` field.

This commit adds it to help renovate to identify which package manager is being used.

related comment: https://github.com/renovatebot/renovate/discussions/23662#discussioncomment-6671214