### PR TITLE
fix(e2e): Adjust e2e for aggregate steps property

### DIFF
--- a/packages/kaoto-ui/cypress/e2e/02-editing_properties/editing.cy.js
+++ b/packages/kaoto-ui/cypress/e2e/02-editing_properties/editing.cy.js
@@ -14,7 +14,7 @@ describe('editing properties', () => {
     // Configure timer - source step
     cy.openStepConfigurationTab('timer-source');
     cy.interactWithConfigInputObject('period', '3000');
-    cy.checkCodeSpanLine('period: \'3000\'');
+    cy.checkCodeSpanLine('period: 3000');
     cy.closeStepConfigurationTab();
 
     // Configure kafka-sink step
@@ -37,6 +37,6 @@ describe('editing properties', () => {
     cy.closeStepConfigurationTab();
 
     // CHECK that previous change is still there
-    cy.checkCodeSpanLine('period: \'3000\'');
+    cy.checkCodeSpanLine('period: 3000');
   });
 });

--- a/packages/kaoto-ui/cypress/e2e/09-step_actions_from_canvas/step_actions_from_canvas.cy.js
+++ b/packages/kaoto-ui/cypress/e2e/09-step_actions_from_canvas/step_actions_from_canvas.cy.js
@@ -111,12 +111,13 @@ describe('Test for Step actions from the canvas', () => {
 
         // CHECK that the step is deleted
         cy.isomorphicGet('[data-testid="viz-step-timer"]').should('not.exist');
-        // CHECK that stepNodes contains of the three steps
-        cy.isomorphicGet('.stepNode').should('have.length', 3);
+        // CHECK that stepNodes contains of the four steps after sync, since aggregate brings is a placeholder for its steps property
+        cy.isomorphicGet('.stepNode').should('have.length', 4);
         // CHECK that stepNodes are in the correct order
         cy.isomorphicGet('.stepNode').eq(0).should('have.attr', 'data-testid', 'viz-step-slot');
         cy.isomorphicGet('.stepNode').eq(1).should('have.attr', 'data-testid', 'viz-step-aggregate');
-        cy.isomorphicGet('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-log');
+        cy.isomorphicGet('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-slot'); // aggregate steps placeholder
+        cy.isomorphicGet('.stepNode').eq(3).should('have.attr', 'data-testid', 'viz-step-log');
         // CHECK that YAML not contains the 'timer:null'
         cy.isomorphicGet('.code-editor').should('not.contain.text', 'timer:null');
     });
@@ -140,9 +141,10 @@ describe('Test for Step actions from the canvas', () => {
         // CHECK that stepNodes are in the correct order
         cy.isomorphicGet('.stepNode').eq(0).should('have.attr', 'data-testid', 'viz-step-timer');
         cy.isomorphicGet('.stepNode').eq(1).should('have.attr', 'data-testid', 'viz-step-aggregate');
-        cy.isomorphicGet('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-log');
+        cy.isomorphicGet('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-slot'); // aggregate steps placeholder
+        cy.isomorphicGet('.stepNode').eq(3).should('have.attr', 'data-testid', 'viz-step-log');
         // CHECK that stepNodes contains of the three steps
-        cy.isomorphicGet('.stepNode').should('have.length', 3);
+        cy.isomorphicGet('.stepNode').should('have.length', 4);
         // CHECK YAML contains the  'aggregate: {}'
         cy.checkCodeSpanLine('aggregate: {}');
     });

--- a/packages/kaoto-ui/cypress/e2e/10-branching_actions_from_canvas/branches_from_canvas.cy.js
+++ b/packages/kaoto-ui/cypress/e2e/10-branching_actions_from_canvas/branches_from_canvas.cy.js
@@ -21,12 +21,14 @@ describe('Test for Branching actions from the canvas', () => {
 
         // CHECK that new node with empty slot was created
         cy.isomorphicGet('[data-testid="viz-step-choice"]').should('have.length', 2);
-        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 1);
+        // 1 slot for the aggregate step and another one recently created
+        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 2);
         cy.isomorphicGet('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-slot');
 
         // CHECK after Sync your code button click
         cy.isomorphicGet('[data-testid="viz-step-choice"]').should('have.length', 2);
-        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 1);
+        // 1 slot for the aggregate step and another one recently created
+        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 2);
         cy.isomorphicGet('.stepNode').eq(10).should('have.attr', 'data-testid', 'viz-step-slot');
     });
 
@@ -35,14 +37,14 @@ describe('Test for Branching actions from the canvas', () => {
 
         // CHECK that the branch was deleted and the node with index 11 contains the viz-step-kamelet:sink
         cy.isomorphicGet('[data-testid="viz-step-marshal"]').should('not.exist');
-        cy.isomorphicGet('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-kamelet:sink');
+        cy.isomorphicGet('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-kamelet:sink');
         cy.isomorphicGet('.code-editor').should('not.contain.text', '{{?bar}}')
 
         cy.syncUpCodeChanges()
 
         // CHECK after Sync your code button click
         cy.isomorphicGet('[data-testid="viz-step-marshal"]').should('not.exist');
-        cy.isomorphicGet('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-kamelet:sink');
+        cy.isomorphicGet('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-kamelet:sink');
         cy.isomorphicGet('.code-editor').should('not.contain.text', '{{?bar}}')
     });
 
@@ -57,13 +59,15 @@ describe('Test for Branching actions from the canvas', () => {
 
         // CHECK that new node with empty slot was created
         cy.isomorphicGet('[data-testid="viz-step-choice"]').should('have.length', 3);
-        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 1);
+        // 1 slot for the aggregate step and another one recently created
+        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 2);
         cy.isomorphicGet('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-slot');
 
         cy.syncUpCodeChanges()
 
         // CHECK after Sync your code button click
-        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 1);
+        // 1 slot for the aggregate step and another one recently created
+        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 2);
         cy.isomorphicGet('.stepNode').eq(2).should('have.attr', 'data-testid', 'viz-step-slot');
 
         // CHECK that the choice add button is disabled
@@ -114,8 +118,9 @@ describe('Test for Branching actions from the canvas', () => {
         cy.isomorphicGet('.stepNode').eq(7).should('have.attr', 'data-testid', 'viz-step-marshal');
         cy.isomorphicGet('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-log');
         cy.isomorphicGet('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-aggregate');
-        cy.isomorphicGet('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-activemq');
-        cy.isomorphicGet('.stepNode').eq(13).should('have.attr', 'data-testid', 'viz-step-filter');
+        cy.isomorphicGet('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-slot'); // aggregate slot for steps property
+        cy.isomorphicGet('.stepNode').eq(13).should('have.attr', 'data-testid', 'viz-step-activemq');
+        cy.isomorphicGet('.stepNode').eq(14).should('have.attr', 'data-testid', 'viz-step-filter');
         cy.isomorphicGet('[data-testid="viz-step-activemq"]').should('be.visible');
 
         cy.syncUpCodeChanges()
@@ -125,8 +130,9 @@ describe('Test for Branching actions from the canvas', () => {
         cy.isomorphicGet('.stepNode').eq(7).should('have.attr', 'data-testid', 'viz-step-marshal');
         cy.isomorphicGet('.stepNode').eq(9).should('have.attr', 'data-testid', 'viz-step-log');
         cy.isomorphicGet('.stepNode').eq(11).should('have.attr', 'data-testid', 'viz-step-aggregate');
-        cy.isomorphicGet('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-activemq');
-        cy.isomorphicGet('.stepNode').eq(13).should('have.attr', 'data-testid', 'viz-step-filter');
+        cy.isomorphicGet('.stepNode').eq(12).should('have.attr', 'data-testid', 'viz-step-slot'); // aggregate slot for steps property
+        cy.isomorphicGet('.stepNode').eq(13).should('have.attr', 'data-testid', 'viz-step-activemq');
+        cy.isomorphicGet('.stepNode').eq(14).should('have.attr', 'data-testid', 'viz-step-filter');
         cy.isomorphicGet('[data-testid="viz-step-activemq"]').should('be.visible');
     });
 });

--- a/packages/kaoto-ui/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
+++ b/packages/kaoto-ui/cypress/e2e/10-branching_actions_from_canvas/nested_branches_step_actions_from_canvas.cy.js
@@ -34,11 +34,13 @@ describe('User completes normal actions on steps in a branch', () => {
 
         // CHECK that amqp step is deleted and empty step is added
         cy.isomorphicGet('[data-testid="viz-step-amqp"]').should('not.exist');
-        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 2).and('be.visible');
+        // 1 for the existing empty step, 1 for the aggregate steps property and lastly 1 for the recently deleted step
+        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 3).and('be.visible');
 
         // CHECK that amqp step is deleted and empty step is added
         cy.isomorphicGet('[data-testid="viz-step-amqp"]').should('not.exist');
-        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 2).and('be.visible');
+        // 1 for the existing empty step, 1 for the aggregate steps property and lastly 1 for the recently deleted step
+        cy.isomorphicGet('[data-testid="viz-step-slot"]').should('have.length', 3).and('be.visible');
     });
 
     it('User replaces a step in a branch', () => {


### PR DESCRIPTION
### Context
In the past, Kaoto didn't support the `aggregate`'s steps property. This functionality was recently added and now the e2e tests need to be adjusted to take into account the new empty slot step.

### Before syncing
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/950e3bbe-0987-42dc-bf53-e4a3e86f78b2)

### After syncing
![image](https://github.com/KaotoIO/kaoto-ui/assets/16512618/1356021d-43ec-44fb-8d3e-92ebbe5f23ea)
