### PR TITLE
chore(deployment): Disable Deploy button

### DIFF
--- a/packages/kaoto-ui/src/components/KaotoToolbar.tsx
+++ b/packages/kaoto-ui/src/components/KaotoToolbar.tsx
@@ -65,7 +65,7 @@ export const KaotoToolbar = ({
       settings,
       setSettings,
       currentDsl: settings.dsl.name,
-      deployable: settings.dsl.deployable,
+      deployable: false, // Deployment disabled in the meantime: settings.dsl.deployable,
     }),
     shallow,
   );


### PR DESCRIPTION
### Context
Currently, there's limited support for deployment in kaoto.

This button could be misleading, so in the meantime, it will be disabled in favor of VSCode plugins like JBang or Camel K plugins.